### PR TITLE
Recursively exclude examples/incomplete from testing targets

### DIFF
--- a/config/tests.config
+++ b/config/tests.config
@@ -11,7 +11,7 @@ exclude = theories/prelude theories/oldlibs
 
 [test-examples]
 okdirs  = !examples
-exclude = examples/MEE-CBC examples/old examples/old/list-ddh examples/incomplete examples/to-port
+exclude = examples/MEE-CBC examples/old examples/old/list-ddh !examples/incomplete examples/to-port
 
 [test-mee-cbc]
 okdirs = examples/MEE-CBC

--- a/scripts/testing/runtest
+++ b/scripts/testing/runtest
@@ -268,6 +268,15 @@ def _main():
 
         return [config(x) for x in scripts]
 
+    def is_excluded(src,excludes):
+        for path in excludes:
+            if path.startswith('!'):
+                if src.startswith(path[1:]):
+                    return True
+            elif src == path:
+                return True
+        return False
+
     def gather_for_scenario(scenario):
         def expand(dirs):
             def for1(x):
@@ -288,7 +297,7 @@ def _main():
                          for x in expand(scenario.okdirs)])
         dirs.extend([Object(src = x, valid = False, args = scenario.args) \
                          for x in expand(scenario.kodirs)])
-        dirs = [x for x in dirs if x.src not in scenario.exclude]
+        dirs = [x for x in dirs if not is_excluded(x.src,scenario.exclude)]
         dirs = map(lambda x : gather(x, scenario), dirs)
         return list(itertools.chain.from_iterable(dirs))
 


### PR DESCRIPTION
This extends the runtest script with recursive exclusions, and makes the examples/incomplete exclusion recursive.

Submitted as a pull request for code review/refactoring and checking that it does not break things downstream.