### PR TITLE
Added clean way to clear the list of current provers.

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -291,7 +291,9 @@
       List.iter do1 os;
 
       oiter
-        (fun r -> pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm })
+        (fun r ->
+           pnames := Some { pp_use_only = List.rev r.pp_use_only;
+                            pp_add_rm   = List.rev r.pp_add_rm })
         !pnames;
 
       { pprov_max       = !mprovers;

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -287,7 +287,7 @@
         pnames := Some
           (match k with
            | `Only    ->
-	     (ok_use_only r p; { r with pp_use_only = p  :: r.pp_use_only })
+	     (ok_use_only r p; { r with pp_use_only = p :: r.pp_use_only })
            | `Include -> { r with pp_add_rm = (`Include, p) :: r.pp_add_rm }
            | `Exclude -> { r with pp_add_rm = (`Exclude, p) :: r.pp_add_rm }) in
 

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -308,9 +308,9 @@
 
       List.iter do1 os;
 
-      let _ =
-        let r = odfl empty_pprover_list !pnames in
-          pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm } in
+      oiter
+        (fun r -> pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm })
+        !pnames;
 
       { pprov_max       = !mprovers;
         pprov_timeout   = !timeout;

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -567,12 +567,16 @@ module Prover = struct
       match ppr.pprov_names with
       | None -> None, []
       | Some pl ->
-        let do_uo s =
-          if s.pl_desc = "ALL" then all_provers ()
-          else [check_prover_name s] in
+        let do_uo uo s =
+          match s.pl_desc with
+          | "ALL" -> all_provers ()
+          | "CLEAR" -> []
+          | _ ->
+            let x = check_prover_name s in
+            if List.exists ((=) x) uo then uo else x :: uo in
         let uo =
           if pl.pp_use_only = [] then None
-          else Some (List.flatten (List.map do_uo pl.pp_use_only)) in
+          else Some (List.fold_left do_uo [] pl.pp_use_only) in
         let do_ar (k,s) = k, check_prover_name s in
         uo, List.map do_ar pl.pp_add_rm in
     let verbose = omap (odfl 1) ppr.pprov_verbose in

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -569,8 +569,8 @@ module Prover = struct
       | Some pl ->
         let do_uo uo s =
           match s.pl_desc with
-          | "ALL" -> all_provers ()
-          | "CLEAR" -> []
+          | "" -> all_provers ()
+          | "!" -> []
           | _ ->
             let x = check_prover_name s in
             if List.exists ((=) x) uo then uo else x :: uo in


### PR DESCRIPTION
The elements of prover [...] have one of the following forms, where s
is a string:

s (add s to the use-only list)
+s (add include s to the include/exclude list)
-s (add exclude s to the include/exclude list)

The include/exclude list is ordered, so that later instructions can
supersede earlier ones. The use-only list was not ordered, but now
is. The relative order of the use-only and include/exclude lists
is irrelevant, so that, e.g., prover ["Z3" +"Alt-Ergo"] and prover
[+"Alt-Ergo" "Z3"] are equivalent.

The semantics is that the use-only list is first interpreted (if it's
empty, one starts with the current provers as the base), and only then
are the instructions of the include/exclude list applied to it, in
order.

There was already the special use-only instruction "ALL". Now, there is
also the use-only instruction "CLEAR", which clears the use-only list,
but may be superseded by the use-only instructions that follow.

Examples (assuming "Z3" and "Alt-Ergo" are only known provers):
prover []. (* a no-op *)
prover [+"Z3"]  (* adds just "Z3" to whatever current provers are *)
prover [-"Z3"]  (* removes just "Z3" from whatever current provers are *)
prover ["ALL"]  (* results in "Z3", "Alt-Ergo" *)
prover ["CLEAR"]  (* results in nothing *)
prover ["CLEAR" +"Z3"]  (* results in just "Z3" *)
prover [+"Z3" "CLEAR"]  (* results in just "Z3" *)
prover ["CLEAR" "Z3"]  (* result in just "Z3" *)
prover ["Z3" "CLEAR"]  (* results in nothing *)
prover [-"Z3" "ALL"]  (* results in "Alt-Ergo" *)
prover [+"Z3" "ALL" -"Z3"]  (* results in "Alt-Ergo" *)
prover [-"Z3" "ALL" +"Z3"]  (* results in "Z3", "Alt-Ergo" *)