### PR TITLE
Fixed bug in SMT option matching

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3267,7 +3267,7 @@ smt_info:
 
 smt_info1:
 | t=word
-    { `MAXLEMMAS (Some t)      }
+    { `MAXLEMMAS (Some t) }
 
 | TIMEOUT EQ t=word
     { `TIMEOUT t }

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -291,7 +291,9 @@
       List.iter do1 os;
 
       oiter
-        (fun r -> pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm })
+        (fun r ->
+           pnames := Some { pp_use_only = List.rev r.pp_use_only;
+                            pp_add_rm   = List.rev r.pp_add_rm })
         !pnames;
 
       { pprov_max       = !mprovers;

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -287,7 +287,7 @@
         pnames := Some
           (match k with
            | `Only    ->
-	     (ok_use_only r p; { r with pp_use_only = p  :: r.pp_use_only })
+	     (ok_use_only r p; { r with pp_use_only = p :: r.pp_use_only })
            | `Include -> { r with pp_add_rm = (`Include, p) :: r.pp_add_rm }
            | `Exclude -> { r with pp_add_rm = (`Exclude, p) :: r.pp_add_rm }) in
 

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -308,9 +308,9 @@
 
       List.iter do1 os;
 
-      let _ =
-        let r = odfl empty_pprover_list !pnames in
-          pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm } in
+      oiter
+        (fun r -> pnames := Some { r with pp_add_rm = List.rev r.pp_add_rm })
+        !pnames;
 
       { pprov_max       = !mprovers;
         pprov_timeout   = !timeout;

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -567,12 +567,16 @@ module Prover = struct
       match ppr.pprov_names with
       | None -> None, []
       | Some pl ->
-        let do_uo s =
-          if s.pl_desc = "ALL" then all_provers ()
-          else [check_prover_name s] in
+        let do_uo uo s =
+          match s.pl_desc with
+          | "ALL" -> all_provers ()
+          | "CLEAR" -> []
+          | _ ->
+            let x = check_prover_name s in
+            if List.exists ((=) x) uo then uo else x :: uo in
         let uo =
           if pl.pp_use_only = [] then None
-          else Some (List.flatten (List.map do_uo pl.pp_use_only)) in
+          else Some (List.fold_left do_uo [] pl.pp_use_only) in
         let do_ar (k,s) = k, check_prover_name s in
         uo, List.map do_ar pl.pp_add_rm in
     let verbose = omap (odfl 1) ppr.pprov_verbose in

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -569,8 +569,8 @@ module Prover = struct
       | Some pl ->
         let do_uo uo s =
           match s.pl_desc with
-          | "ALL" -> all_provers ()
-          | "CLEAR" -> []
+          | "" -> all_provers ()
+          | "!" -> []
           | _ ->
             let x = check_prover_name s in
             if List.exists ((=) x) uo then uo else x :: uo in

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -642,18 +642,16 @@ module String = struct
             then List.map fst matched
             else aux matched (i+1)
           end
-
       in aux matched 0
 
     let last_matching tomatch s =
-      first_matching (List.map rev tomatch) (rev s)
+      List.map rev (first_matching (List.map rev tomatch) (rev s))
   end
 
   let option_matching tomatch s =
     match OptionMatching.all_matching tomatch s with
-    | [s] -> [s] | matched ->
-    match OptionMatching.first_matching matched s with
-    | [s] -> [s] | matched -> OptionMatching.last_matching matched s
+    | [s] -> [s]
+    | matched -> OptionMatching.first_matching matched s
 end
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
The third stage of filtering in the definition of option_matching had
 a bug, meaning that attempts to rely on it resulted in assertion failures.
 But that last stage - disambiguating from right to left - was arguably
 hard for users to predict, anyway. So, fixed the third stage, but
 left it out of algorithm.
    
 (If it's really desired, easy to put it back in, as now it'll
 work. But do we really think users will understand why, e.g., [prover
 x=1] means [prover maxlemmas=1] - because the x in maxlemmas comes
 earlier when working backward as opposed to the x in maxprovers?)
    
 This is how option disambiguation works: First filter-in those option
 names having the letters of the abbreviation abv in the correct
 order. Then work through the letters of abv in order, keeping
 only those option names in which each successive letter appears
 as early as possible