### PR TITLE
New smt option: quorum

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -160,6 +160,7 @@
   type smt = [
     | `ALL
     | `ITERATE
+    | `QUORUM         of int
     | `MAXLEMMAS      of int option
     | `MAXPROVERS     of int
     | `PROVER         of prover list
@@ -190,9 +191,19 @@
 
     let option_matching =
        option_matching
-         [ "all"; "timeout"; "maxprovers"; "maxlemmas";
-           "wantedlemmas"; "unwantedlemmas";
-           "prover"; "verbose"; "lazy"; "full"; "iterate"; "selected" ]
+         [ "all"           ;
+           "quorum"        ;
+           "timeout"       ;
+           "maxprovers"    ;
+           "maxlemmas"     ;
+           "wantedlemmas"  ;
+           "unwantedlemmas";
+           "prover"        ;
+           "verbose"       ;
+           "lazy"          ;
+           "full"          ;
+           "iterate"       ;
+           "selected"      ]
 
     let as_int = function
       | None          -> `None
@@ -239,6 +250,7 @@
 
       match unloc s with
       | "timeout"        -> `TIMEOUT        (get_as     ("int"   , as_int) s o)
+      | "quorum"         -> `QUORUM         (get_as     ("int"   , as_int) s o)
       | "maxprovers"     -> `MAXPROVERS     (get_as     ("int"   , as_int) s o)
       | "maxlemmas"      -> `MAXLEMMAS      (get_opt_as ("int"   , as_int) s o)
       | "wantedlemmas"   -> `WANTEDLEMMAS   (get_as     ("dbhint", as_dbhint) s o)
@@ -256,6 +268,7 @@
       let mprovers = ref None in
       let timeout  = ref None in
       let pnames   = ref None in
+      let quorum   = ref None in
       let all      = ref None in
       let mlemmas  = ref None in
       let wanted   = ref None in
@@ -268,32 +281,35 @@
       let is_universal p = unloc p = "" || unloc p = "!" in
 
       let ok_use_only pp p =
-        if pp.pp_add_rm <> []
-        then let msg = "use-only elements must come at beginning"
-	     in parse_error (loc p) (Some msg)
-	else if pp.pp_use_only <> [] && is_universal p
-             then let msg = "cannot add universal to non-empty use-only"
-                  in parse_error (loc p) (Some msg)
-        else match pp.pp_use_only with
-             | [q] ->
-	       if is_universal q
-	       then let msg = "use-only part is already universal"
-		    in parse_error (loc p) (Some msg)
-	       else ()
-             | _ -> () in
+        if pp.pp_add_rm <> [] then
+          let msg = "use-only elements must come at beginning" in
+          parse_error (loc p) (Some msg)
+        else if pp.pp_use_only <> [] && is_universal p then
+          let msg = "cannot add universal to non-empty use-only" in
+          parse_error (loc p) (Some msg)
+        else
+          match pp.pp_use_only with
+          | [q] ->
+              if is_universal q then
+                let msg = "use-only part is already universal" in
+                parse_error (loc p) (Some msg)
+          | _ -> () in
 
       let add_prover (k, p) =
-        let r = odfl empty_pprover_list !pnames in
-        pnames := Some
-          (match k with
-           | `Only    ->
-	     (ok_use_only r p; { r with pp_use_only = p :: r.pp_use_only })
-           | `Include -> { r with pp_add_rm = (`Include, p) :: r.pp_add_rm }
-           | `Exclude -> { r with pp_add_rm = (`Exclude, p) :: r.pp_add_rm }) in
+        let r  = odfl empty_pprover_list !pnames in
+        let pr =
+          match k with
+          | `Only ->
+	            ok_use_only r p; { r with pp_use_only = p :: r.pp_use_only }
+          | `Include -> { r with pp_add_rm = (`Include, p) :: r.pp_add_rm }
+          | `Exclude -> { r with pp_add_rm = (`Exclude, p) :: r.pp_add_rm }
+
+        in pnames := Some pr in
 
       let do1 o  =
         match o with
         | `ALL              -> all      := Some true
+        | `QUORUM         n -> quorum   := Some n
         | `TIMEOUT        n -> timeout  := Some n
         | `MAXPROVERS     n -> mprovers := Some n
         | `MAXLEMMAS      n -> mlemmas  := Some n
@@ -316,6 +332,7 @@
         pprov_timeout   = !timeout;
         pprov_cpufactor =  None;
         pprov_names     = !pnames;
+        pprov_quorum    = !quorum;
         pprov_verbose   = !verbose;
         pprov_version   = !version;
         plem_all        = !all;

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -619,6 +619,7 @@ type pprover_infos = {
   pprov_timeout   : int option;
   pprov_cpufactor : int option;
   pprov_names     : pprover_list option;
+  pprov_quorum    : int option;
   pprov_verbose   : int option option;
   pprov_version   : [`Lazy | `Full] option;
   plem_all        : bool option;
@@ -634,6 +635,7 @@ let empty_pprover = {
   pprov_timeout   = None;
   pprov_cpufactor = None;
   pprov_names     = None;
+  pprov_quorum    = None;
   pprov_verbose   = None;
   pprov_version   = None;
   plem_all        = None;

--- a/src/ecProvers.mli
+++ b/src/ecProvers.mli
@@ -39,6 +39,7 @@ type prover_infos = {
   pr_provers   : string list;
   pr_timelimit : int;
   pr_cpufactor : int;
+  pr_quorum    : int;
   pr_wrapper   : string option;
   pr_verbose   : int;
   pr_all       : bool;

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -537,6 +537,7 @@ module Prover = struct
     po_cpufactor  : int option;
     po_nprovers   : int option;
     po_provers    : string list option * (include_exclude * string) list;
+    po_quorum     : int option;
     po_verbose    : int option;
     pl_all        : bool option;
     pl_max        : int option;
@@ -552,6 +553,7 @@ module Prover = struct
     po_cpufactor = None;
     po_nprovers  = None;
     po_provers   = (None, []);
+    po_quorum    = None;
     po_verbose   = None;
     pl_all       = None;
     pl_max       = None;
@@ -585,6 +587,7 @@ module Prover = struct
       po_cpufactor = ppr.pprov_cpufactor;
       po_nprovers  = ppr.pprov_max;
       po_provers   = provers;
+      po_quorum    = ppr.pprov_quorum;
       po_verbose   = verbose;
       pl_all       = ppr.plem_all;
       pl_max       =
@@ -615,6 +618,7 @@ module Prover = struct
     let pr_wanted    = odfl dft.pr_wanted options.pl_wanted in
     let pr_unwanted  = odfl dft.pr_unwanted options.pl_unwanted in
     let pr_selected  = odfl dft.pr_selected options.pl_selected in
+    let pr_quorum    = max 1 (odfl dft.pr_quorum options.po_quorum) in
     let pr_provers   =
       let l = odfl dft.pr_provers (fst options.po_provers) in
       let do_ar l (k, p) =
@@ -625,7 +629,8 @@ module Prover = struct
 
     { pr_maxprocs; pr_provers; pr_timelimit; pr_cpufactor;
       pr_wrapper ; pr_verbose; pr_all      ; pr_max      ;
-      pr_iterate ; pr_wanted ; pr_unwanted ; pr_selected}
+      pr_iterate ; pr_wanted ; pr_unwanted ; pr_selected ;
+      pr_quorum  ; }
 
   (* -------------------------------------------------------------------- *)
   let set_wrapper scope wrapper =

--- a/src/ecScope.mli
+++ b/src/ecScope.mli
@@ -187,6 +187,7 @@ module Prover : sig
     po_cpufactor  : int option;
     po_nprovers   : int option;
     po_provers    : string list option * (include_exclude * string) list;
+    po_quorum     : int option;
     po_verbose    : int option;
     pl_all        : bool option;
     pl_max        : int option;


### PR DESCRIPTION
This option expects an integer argument. It indicates the number
of smt provers that must solve a goal before being accepted.

A value of 0 set the quorum to its default value (1).

Note that if provers do not agree while waiting to reach a
quorum, the goal is rejected.

[closes #17371]