### PR TITLE
including mee-cbc in examples target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ uninstall-purge:
 tests: check
 
 examples: build
-	$(CHECK) examples
+	$(CHECK) examples mee-cbc
 
 check: build
 	$(CHECK) $(CHECKCATS)


### PR DESCRIPTION
Only doubles the time taken by `examples` CI job (from 2.5 to 5 minutes). This is still less than the time it takes to check the standard theories, and could be reduced by some minor (but time-consuming) work on the mee-cbc proofs.

I chose this solution over the alternative of modifying the test specs in order to still allow separate checks locally.

We could also easily add a separate make target and job. I am not sure which would be preferred.