### PR TITLE
Deploy smt blacklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ECARGS    ?=
 ECTOUT    ?= 10
 ECJOBS    ?= 1
 ECEXTRA   ?= --report=report.log
-ECPROVERS ?= Alt-Ergo Z3 Eprover
+ECPROVERS ?= Alt-Ergo Z3 CVC4
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/testing/runtest
 CHECK     += --bin-args="$(ECARGS)" --bin-args="$(ECPROVERS:%=-p %)"

--- a/src/ecProvers.ml
+++ b/src/ecProvers.ml
@@ -104,7 +104,7 @@ let test_if_evict_prover tests prover =
 module Evictions = struct
   let alt_ergo_le_0_99_1 = {
     pe_cause = `Inconsistent;
-    pe_test  = `ByVersion ("Alt-Ergo", (`Le, VP.of_tuple (0, 99, 1)));
+    pe_test  = `ByVersion ("Alt-Ergo", (`Lt, VP.of_tuple (2, 2, 0)));
   }
 end
 

--- a/theories/algebra/StdRing.ec
+++ b/theories/algebra/StdRing.ec
@@ -20,7 +20,21 @@ theory RField.
     op   [ - ] <- Real.([-]),
     op   ( * ) <- Real.( * ),
     op   invr  <- Real.inv
-    proof * by smt remove abbrev (-) remove abbrev (/).
+    proof *
+  remove abbrev (-) remove abbrev (/).
+  realize addrA     by smt().
+  realize addrC     by smt().
+  realize add0r     by smt().
+  realize addNr     by smt().
+  realize oner_neq0 by smt().
+  realize mulrA     by smt().
+  realize mulrC     by smt().
+  realize mul1r     by smt().
+  realize mulrDl    by smt().
+  realize mulVr     by rewrite /left_inverse_in /#.
+  realize unitP     by smt().
+  realize unitout   by move=> x /= ->; exact/invr0.
+  realize mulf_eq0  by smt().
 
   lemma nosmt ofintR (i : int): ofint i = i%r.
   proof.
@@ -63,17 +77,17 @@ instance ring with int
   op mul   = Int.( * )
   op expr  = IntExtra.( ^ )
 
-  proof oner_neq0 by smt
-  proof addr0     by smt
-  proof addrA     by smt
-  proof addrC     by smt
-  proof addrN     by smt
-  proof mulr1     by smt
-  proof mulrA     by smt
-  proof mulrC     by smt
-  proof mulrDl    by smt
-  proof expr0     by smt
-  proof exprS     by smt.
+  proof oner_neq0 by smt()
+  proof addr0     by smt()
+  proof addrA     by smt()
+  proof addrC     by smt()
+  proof addrN     by smt()
+  proof mulr1     by smt()
+  proof mulrA     by smt()
+  proof mulrC     by smt()
+  proof mulrDl    by smt()
+  proof expr0     by smt(pow0)
+  proof exprS     by smt(powS).
 
 op bid (b:bool) = b.
 
@@ -84,14 +98,14 @@ instance bring with bool
   op mul   = (/\)
   op opp   = bid
 
-  proof oner_neq0 by smt
-  proof addr0     by smt
-  proof addrA     by smt
-  proof addrC     by smt
-  proof addrK     by smt
-  proof mulr1     by smt
-  proof mulrA     by smt
-  proof mulrC     by smt
-  proof mulrDl    by smt
-  proof mulrK     by smt
-  proof oppr_id   by smt.
+  proof oner_neq0 by smt()
+  proof addr0     by smt()
+  proof addrA     by smt()
+  proof addrC     by smt()
+  proof addrK     by smt()
+  proof mulr1     by smt()
+  proof mulrA     by smt()
+  proof mulrC     by smt()
+  proof mulrDl    by smt()
+  proof mulrK     by smt()
+  proof oppr_id   by smt().

--- a/theories/crypto/rom/PROM.ec
+++ b/theories/crypto/rom/PROM.ec
@@ -580,8 +580,12 @@ abstract theory GenEager.
   eager proc; inline *; wp.
   while (={l,FRO.m} /\ (forall z, mem l z => in_dom_with FRO.m z Unknown){1} /\
          in_dom_with FRO.m{1} x{1} f{1} = result{2}).
-  + auto=> &m1 &m2 [#] 2-> Hz <- ? _ /= ? -> /=.
-    split=> [z /mem_drop Hm|]; rewrite /in_dom_with domE get_setE /#.
+  + auto=> &m1 &m2 [#] 2-> Hz <- _ l_not_nil /= ? -> /=.
+    split=> [z /mem_drop Hm|]; rewrite /in_dom_with domE get_setE.
+    + smt().
+    case: (x{m1} = head witness l{m2})=> //= ->; rewrite oget_some /=.
+    have /Hz @/in_dom_with [] -> -> //: head witness l{m2} \in l{m2}.
+    by move: l_not_nil; case: (l{m2}).    
   by auto=> ? &mr /= [#] 3-> /=; split=> // z; rewrite -FSet.memE mem_fdom dom_restr.
   qed.
 

--- a/theories/distributions/DProd.ec
+++ b/theories/distributions/DProd.ec
@@ -94,7 +94,11 @@ qed.
 (* -------------------------------------------------------------------- *)
 lemma dprod_fu (da : 'a distr) (db : 'b distr):
   is_full (da `*` db) <=> (is_full da /\ is_full db).
-proof. smt (supp_dprod). qed.
+proof.
+split=> [h|[] ha hb].
++ by split=> [a|b]; [move: (h (a,witness))|move: (h (witness,b))]; rewrite supp_dprod.
+by move=> [] a b; rewrite supp_dprod ha hb.
+qed.
 
 (* -------------------------------------------------------------------- *)
 (* TODO : generalize this to parametric distribution *)

--- a/theories/encryption/Means.ec
+++ b/theories/encryption/Means.ec
@@ -93,8 +93,15 @@ elim/fset_ind (oflist (to_seq (support d))).
     rewrite Pr[mu_eq] => // &m1.
     pose f:= (fun (v : input) (r : input * output),
                 ev v (glob A){m1} (snd r) /\ v = fst r).
-    by rewrite imageU image1 cpOrs_add; smt.
-  rewrite Pr[mu_disjoint]; first by smt.
+    by rewrite imageU image1 cpOrs_add /predU /f.
+  rewrite Pr[mu_disjoint].
+  + move=> /> &hr; rewrite negb_and negb_and.
+    case: (x = res{hr}.`1)=> //= ->> {x}.
+    case: (ev res{hr}.`1 (glob A){hr} res{hr}.`2)=> //= hev.
+    move: Hx=> {Hrec}; elim/fset_ind: s.
+    + by rewrite image0 cpOrs0.
+    move=> x s x_notin_s ih; rewrite in_fsetU in_fset1 negb_or eq_sym=> - [] /ih.
+    by rewrite imageU image1 cpOrs_add /= /predU=> -> ->.
   by rewrite Hrec (prCond A &m x ev).
 qed.
 

--- a/theories/looping/FoldProc.eca
+++ b/theories/looping/FoldProc.eca
@@ -77,7 +77,8 @@ section.
   proof.
   transitivity Fold(O).fold_12
     (={glob O,t1,t2} /\ s{2} = O'.s{1} ==> ={glob O} /\ res{2} = O'.s{1})
-    (={glob O,t1,t2} /\ s{1} = O'.s{2} ==> ={glob O} /\ res{1} = O'.s{2})=> [/#|//||].
+    (={glob O,t1,t2} /\ s{1} = O'.s{2} ==> ={glob O} /\ res{1} = O'.s{2})=> //.
+  + by move=> /> &1 &2 <- <-; exists ((glob O){2}) (O'.s{2},t1{1},t2{1}).
   + by proc;inline *;sim.
   transitivity Fold(O).fold_21
     (={glob O,s,t1,t2} ==> ={glob O, res})

--- a/theories/looping/IterProc.eca
+++ b/theories/looping/IterProc.eca
@@ -5,6 +5,7 @@
  *
  * Distributed under the terms of the CeCILL-B-V1 license
  * -------------------------------------------------------------------- *)
+pragma -oldip.
 
 require import Core List.
 
@@ -71,11 +72,15 @@ while (={glob O} /\ l{1} = l0{2}).
 + by auto; call (_: true).
 wp; while (={glob O} /\ l{1} = l{2}++_l2).
 + auto; call (_: true); auto.
-  move=> ? &ml [#] 2!->; case: (l{ml})=> //= x l' ll2_neq_l2.
-  rewrite !drop0 /=; progress=> [/#|/#|].
-  have/contra -> //:= congr1 size (l' ++ _l2) _l2.
-  by rewrite size_cat; smt w=size_ge0.
-by auto; progress=> [/#|/#|]; smt w=(size_cat size_ge0).
+  move=> ? &ml [#] 2!->; case: (l{ml})=> //= x l'.
+  rewrite !drop0=> /= _ Ol Or ->> /= - {Ol Or}; split=> [[] _|].
+  + by apply/contraLR=> /= ->.
+  rewrite -size_eq0=> size_l'.
+  by split; rewrite -negP=> /(congr1 size); rewrite size_cat [smt(size_ge0)].
+auto=> /> &2; split=> [_|].
++ by apply/contraLR=> /= ->.
+rewrite -size_eq0=> size_l1.
+by split; rewrite -negP=> /(congr1 size); rewrite size_cat [smt(size_ge0)].
 qed.
 
 equiv iter_cat_cat (O <: Orcl):
@@ -126,13 +131,15 @@ section.
     (={glob O} /\ l{1} = i::i'::(s1++s2) /\ l1{2} = [i;i'] /\ l2{2} = s1++s2 ==>
      ={glob O})
     (={glob O} /\ l1{1} = [i;i'] /\ l2{1} = s1 ++ s2 /\ l{2} = i'::(s1++i::s2) ==>
-     ={glob O})=> [/#|//||].
+     ={glob O})=> //.
+  + by move=> /> &2; exists ((glob O){2}) ([i;i'],s1++s2).
   + by conseq (iter_cat O)=> ? &ml [#] 4!->.
   transitivity Iter(O).iters
     (={glob O,l2} /\ l1{1} = [i;i'] /\ l1{2} = [i';i] /\ l2{1} = s1++s2 ==>
      ={glob O})
     (={glob O} /\ l1{1} = [i';i] /\ l2{1} = s1 ++ s2 /\ l{2} = i'::(s1++i::s2) ==>
-     ={glob O})=> [/#|//||].
+     ={glob O})=> //.
+  + by move=> /> &1 &2 _ ->; exists ((glob O){2}) ([i'; i],s1++s2).
   + proc; call (_: ={glob O}).
     * by while (={glob O,l}); auto; call (_: true).
     conseq (_: ={glob O} /\ l1{1} = [i;i'] /\ l1{2} = [i';i] ==> ={glob O})=> //.
@@ -149,16 +156,18 @@ section.
     (={glob O} /\ l1{1} = [i';i] /\ l2{1} = s1++s2 /\ l1{2} = [i'] /\ l2{2} = i::(s1++s2) ==>
      ={glob O})
     (={glob O} /\ l1{1} = [i'] /\ l2{1} = i::s1++s2 /\ l{2} = i'::(s1++i::s2) ==>
-     ={glob O})=> [/#|//||].
+     ={glob O})=> //.
+  + by move=> /> &1 &2 _ _; exists ((glob O){2}) ([i'],i::(s1++s2)).
   + by conseq (iter_cat_cat O)=> ? &ml [#] 5!->.
   transitivity Iter(O).iters
     (={glob O,l1} /\ l1{1} = [i'] /\ l2{1} = i::s1++s2 /\ l2{2} = s1++i::s2 ==>
      ={glob O})
     (={glob O} /\ l1{1} = [i'] /\ l2{1} = s1++i::s2 /\ l{2} = i'::s1++i::s2 ==>
-     ={glob O})=> [/#|//||]; last first.
-  + by symmetry; conseq (iter_cat O)=> // ? &ml [#] 4!->.
-  proc; call Hrec; call (_: ={glob O})=> //.
-  by while (={glob O, l}); auto; call (_: true).
+     ={glob O})=> //.
+  + by move=> /> &1 &2 -> _; exists ((glob O){2}) ([i'],s1++i::s2).
+  + proc; call Hrec; call (_: ={glob O})=> //.
+    by while (={glob O, l}); auto; call (_: true).
+  by symmetry; conseq (iter_cat O)=> // ? &ml [#] 4!->.
   qed.
 
   lemma iter_perm :
@@ -181,7 +190,7 @@ section.
     transitivity{1} {Iter(O).iter(l);}
       (={l,glob O} ==> ={glob O})
       (s1 = l{1} /\ l{2} = s3 ++ s4 /\ ={glob O} ==> ={glob O})=> //.
-    + by move=> ? &mr [#] 3!->; exists (glob O){mr} l{1}.
+    + by move=> &1 &mr [#] 3!->; exists (glob O){mr} l{1}.
     + by inline Iter(O).iter; sim.
     transitivity{1} {Iter(O).iter(l);}
       (s1 = l{1} /\ l{2} = s3 ++ s4 /\ ={glob O} ==> ={glob O})
@@ -191,7 +200,7 @@ section.
       rewrite perm_catCA /= perm_cons perm_eq_sym=> Hp.
       by call (ih (s3++s4) Hp).
     by inline Iter(O).iter; sim.
-  by apply (iter_swap s3 i s4). (* FIXME: apply iter_swap fail! *)
+  by apply/(iter_swap s3 i s4). (* FIXME: apply iter_swap fail! *)
   qed.
 
   lemma iters_perm:


### PR DESCRIPTION
We can/should probably delete deploy-pruning-smt as we merge this.