### PR TITLE
Tighter Birthday bound + coarse lemmas

### DIFF
--- a/examples/MEE-CBC/CBC.eca
+++ b/examples/MEE-CBC/CBC.eca
@@ -845,7 +845,7 @@ section Probability_Collision.
             by auto=> /> &1 &2; smt (in_fsetU in_fset1).
           by auto=> />; smt (size_ge0).
         by auto; smt (in_fset0 gt0_q).
-      have:= BBound.pr_collision_bounded_oracles (Wrap(A)) _ &m.
+      have:= BBound.pr_collision_bounded_oracles_coarser (Wrap(A)) _ &m.
         move=> S S_s_ll; proc.
         call (A_run_ll (<: Wrap(A,S).O) _).
           proc; sp; if=> //=.

--- a/theories/crypto/prp_prf/RP_RF.eca
+++ b/theories/crypto/prp_prf/RP_RF.eca
@@ -396,7 +396,7 @@ section CollisionProbability.
     Pr[IND(PRFi,DBounder(D)).main() @ &m: collision PRFi.m]
     <= (q^2)%r * mu1 uD witness.
   proof.
-  rewrite (pr_PRFi_Exp_collision &m) (pr_collision A A_ll A_bounded &m).
+  by rewrite (pr_PRFi_Exp_collision &m) (pr_collision_coarser A A_ll A_bounded &m).
   qed.
 end section CollisionProbability.
 


### PR DESCRIPTION
This is a new version of #38 where only the Birthday bound is changed in a meaningful way.

It makes the default Birthday lemmas precise, but also offers two alternatives ("coarse" and "coarser") where "q(q-1)/2" becomes "q^2/2" and the original "q^2", respectively.