### PR TITLE
Allows nosmt with all operators other than pure, abstract ones

### DIFF
--- a/src/ecDecl.ml
+++ b/src/ecDecl.ml
@@ -80,7 +80,7 @@ type operator_kind =
   | OB_nott of notation
 
 and opbody =
-  | OP_Plain  of EcTypes.expr
+  | OP_Plain  of EcTypes.expr * bool  (* nosmt? *)
   | OP_Constr of EcPath.path * int
   | OP_Record of EcPath.path
   | OP_Proj   of EcPath.path * int * int
@@ -96,6 +96,7 @@ and opfix = {
   opf_resty    : EcTypes.ty;
   opf_struct   : int list * int;
   opf_branches : opbranches;
+  opf_nosmt    : bool;
 }
 
 and opbranches =

--- a/src/ecDecl.mli
+++ b/src/ecDecl.mli
@@ -55,7 +55,7 @@ type operator_kind =
   | OB_nott of notation
 
 and opbody =
-  | OP_Plain  of EcTypes.expr
+  | OP_Plain  of EcTypes.expr * bool (* nosmt? *)
   | OP_Constr of EcPath.path * int
   | OP_Record of EcPath.path
   | OP_Proj   of EcPath.path * int * int
@@ -71,6 +71,7 @@ and opfix = {
   opf_resty    : EcTypes.ty;
   opf_struct   : int list * int;
   opf_branches : opbranches;
+  opf_nosmt    : bool;
 }
 
 and opbranches =

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -2618,7 +2618,7 @@ module Op = struct
     let op = oget (by_path_opt p env) in
     let f  =
       match op.op_kind with
-      | OB_oper (Some (OP_Plain e)) ->
+      | OB_oper (Some (OP_Plain (e, _))) ->
           form_of_expr EcCoreFol.mhr e
       | OB_pred (Some (PR_Plain f)) ->
           f

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -530,7 +530,7 @@ let process_delta ?target (s, o, p) tc =
         let op = EcEnv.Op.by_path (fst p) env in
 
         match op.EcDecl.op_kind with
-        | EcDecl.OB_oper (Some (EcDecl.OP_Plain e)) ->
+        | EcDecl.OB_oper (Some (EcDecl.OP_Plain (e, _))) ->
             (snd p, op.EcDecl.op_tparams, form_of_expr EcFol.mhr e, args)
         | EcDecl.OB_pred (Some (EcDecl.PR_Plain f)) ->
             (snd p, op.EcDecl.op_tparams, f, args)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3417,8 +3417,9 @@ clone_override:
 | TYPE ps=cltyparams x=qident LARROW t=loc(type_exp)
    { (x, PTHO_Type (ps, t, `Inline)) }
 
-| OP x=qoident tyvars=bracket(tident*)? COLON sty=loc(type_exp) mode=opclmode e=expr
+| OP st=nosmt x=qoident tyvars=bracket(tident*)? COLON sty=loc(type_exp) mode=opclmode e=expr
    { let ov = {
+       opov_nosmt  = st;
        opov_tyvars = tyvars;
        opov_args   = [];
        opov_retty  = sty;
@@ -3426,8 +3427,9 @@ clone_override:
      } in
        (x, PTHO_Op (ov, mode)) }
 
-| OP x=qoident tyvars=bracket(tident*)? mode=loc(opclmode) e=expr
+| OP st=nosmt x=qoident tyvars=bracket(tident*)? mode=loc(opclmode) e=expr
    { let ov = {
+       opov_nosmt  = st;
        opov_tyvars = tyvars;
        opov_args   = [];
        opov_retty  = mk_loc mode.pl_loc PTunivar;
@@ -3435,8 +3437,9 @@ clone_override:
      } in
        (x, PTHO_Op (ov, unloc mode)) }
 
-| OP x=qoident tyvars=bracket(tident*)? p=ptybindings mode=loc(opclmode) e=expr
+| OP st=nosmt x=qoident tyvars=bracket(tident*)? p=ptybindings mode=loc(opclmode) e=expr
    { let ov = {
+       opov_nosmt  = st;
        opov_tyvars = tyvars;
        opov_args   = p;
        opov_retty  = mk_loc mode.pl_loc PTunivar;

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1030,6 +1030,7 @@ and pr_override = pr_override_def * [`Alias | `Inline]
 and th_override = pqsymbol
 
 and op_override_def = {
+  opov_nosmt  : bool;
   opov_tyvars : psymbol list option;
   opov_args   : ptybinding list;
   opov_retty  : pty;

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -348,7 +348,7 @@ let opdecl_use_local_or_abs opdecl lc =
          | OP_Record _ -> ()
          | OP_Proj   _ -> ()
          | OP_TC       -> ()
-         | OP_Plain  e -> on_mpath_expr cb e
+         | OP_Plain  (e, _) -> on_mpath_expr cb e
          | OP_Fix    f ->
            let rec on_mpath_branches br =
              match br with

--- a/src/ecSmt.ml
+++ b/src/ecSmt.ml
@@ -990,12 +990,12 @@ and create_op ?(body = false) (genv : tenv) p =
   if not known then begin
     let decl =
       match body, op.op_kind with
-      | true, OB_oper (Some (OP_Plain body)) ->
+      | true, OB_oper (Some (OP_Plain (body, false))) ->
           let body = EcFol.form_of_expr EcFol.mhr body in
           let wparams, wbody = trans_body (genv, lenv) wdom wcodom body in
           WDecl.create_logic_decl [WDecl.make_ls_defn ls wparams wbody]
 
-      | true, OB_oper (Some (OP_Fix body)) ->
+      | true, OB_oper (Some (OP_Fix ({ opf_nosmt = false } as body ))) ->
         OneShot.now register;
         let wparams, wbody = trans_fix (genv, lenv) (wdom, body) in
         let wbody = Cast.arg wbody ls.WTerm.ls_value in
@@ -1326,9 +1326,9 @@ module Frequency = struct
     match EcEnv.Op.by_path_opt p env with
     | Some {op_kind = OB_pred (Some (PR_Plain f)) } ->
       r_union rs (f_ops unwanted_op f)
-    | Some {op_kind = OB_oper (Some (OP_Plain e)) } ->
+    | Some {op_kind = OB_oper (Some (OP_Plain (e, false))) } ->
       r_union rs (f_ops unwanted_op (form_of_expr mhr e))
-    | Some {op_kind = OB_oper (Some (OP_Fix e)) } ->
+    | Some {op_kind = OB_oper (Some (OP_Fix ({ opf_nosmt = false } as e))) } ->
       let rec aux rs = function
         | OPB_Leaf (_, e) -> r_union rs (f_ops unwanted_op (form_of_expr mhr e))
         | OPB_Branch bs -> Parray.fold_left (fun rs b -> aux rs b.opb_sub) rs bs

--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -350,9 +350,9 @@ and subst_notation (s : _subst) (nott : notation) =
 
 and subst_op_body (s : _subst) (bd : opbody) =
   match bd with
-  | OP_Plain body ->
+  | OP_Plain (body, nosmt) ->
       let s = e_subst_of_subst s in
-        OP_Plain (EcTypes.e_subst s body)
+        OP_Plain (EcTypes.e_subst s body, nosmt)
 
   | OP_Constr (p, i)  -> OP_Constr (s.s_p p, i)
   | OP_Record p       -> OP_Record (s.s_p p)
@@ -365,7 +365,8 @@ and subst_op_body (s : _subst) (bd : opbody) =
         OP_Fix { opf_args     = args;
                  opf_resty    = s.s_ty opfix.opf_resty;
                  opf_struct   = opfix.opf_struct;
-                 opf_branches = subst_branches es opfix.opf_branches; }
+                 opf_branches = subst_branches es opfix.opf_branches;
+                 opf_nosmt    = opfix.opf_nosmt; }
 
   | OP_TC -> OP_TC
 

--- a/src/ecThCloning.ml
+++ b/src/ecThCloning.ml
@@ -342,6 +342,7 @@ end = struct
          let params = List.map (EcIdent.name |- fst) oopd.op_tparams in
          let params = List.map (mk_loc lc) params in
          let ovrd   = {
+             opov_nosmt = false;  (* because inline mode *)
              opov_tyvars = Some params;
              opov_args   = [];
              opov_retty  = loced PTunivar;

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -203,6 +203,12 @@ and replay_opd (ove : _ ovrenv) (subst, ops, proofs, scope) (x, oopd) =
       (subst, ops, proofs, ove.ovre_hooks.hop scope (x, oopd))
 
   | Some { pl_desc = (opov, opmode); pl_loc = loc; } ->
+      let nosmt = opov.opov_nosmt in
+
+      if nosmt && opmode = `Inline then
+          ove.ovre_hooks.herr ~loc
+          ("operator overriding with nosmt only makes sense with alias mode");
+
       let (reftyvars, refty) =
         let refop = EcSubst.subst_op subst oopd in
         (refop.op_tparams, refop.op_ty)
@@ -218,10 +224,8 @@ and replay_opd (ove : _ ovrenv) (subst, ops, proofs, scope) (x, oopd) =
           let env, xs = EcTyping.trans_binding env ue opov.opov_args in
           let body    = EcTyping.transexpcast env `InOp ue codom opov.opov_body in
           let lam     = EcTypes.e_lam xs body in
-
           (lam.EcTypes.e_ty, lam)
         in
-
         begin
           try ty_compatible scenv ue
               (List.map fst reftyvars, refty)
@@ -238,7 +242,7 @@ and replay_opd (ove : _ ovrenv) (subst, ops, proofs, scope) (x, oopd) =
         let body    = body |> EcTypes.e_mapty uni in
         let ty      = uni ty in
         let tparams = EcUnify.UniEnv.tparams ue in
-        let newop   = mk_op tparams ty (Some (OP_Plain body)) in
+        let newop   = mk_op tparams ty (Some (OP_Plain (body, nosmt))) in
           match opmode with
           | `Alias ->
               let subst, x = rename ove subst (`Op, x) in
@@ -488,7 +492,7 @@ and replay_instance
                 | OB_oper (Some (OP_Fix    _))
                 | OB_oper (Some (OP_TC      )) ->
                     Some (EcPath.pappend npath q)
-                | OB_oper (Some (OP_Plain e)) ->
+                | OB_oper (Some (OP_Plain (e, _))) ->
                     match e.EcTypes.e_node with
                     | EcTypes.Eop (r, _) -> Some r
                     | _ -> raise E.InvInstPath


### PR DESCRIPTION
I.e., with plain, axiomatized (including : {t | phi} as ax) and cases operators.
When cloning, [op nosmt x = ...] is allowed, but nosmt can't be used
with inlining mode.

Below are some examples:

```
(* example uses of nosmt on plain, axiomatized and cases operators *)

require import AllCore.

theory T.

op nosmt x : {int | 0 <= x} as ge0_x.

op nosmt x' : int = 3 axiomatized by x'_eq.

op z : int.  (* nosmt is not legal *)

op q : int.

axiom nosmt foo : z + q = 10.

op nosmt u = z + q.

lemma nosmt goo : u = 10.
proof.
(* smt fails *)
by rewrite /u foo.
qed.

end T.

print T.
(*
theory T.
  op x : int.
  
  axiom nosmt ge0_x: 0 <= T.x.
  
  op x' : int.
  
  axiom nosmt x'_eq: T.x' = 3.
  
  op z : int.
  
  op q : int.
  
  axiom nosmt foo: T.z + T.q = 10.
  
  op nosmt u : int = T.z + T.q.
  
  lemma nosmt goo: T.u = 10.
end T.
*)

op nosmt z' : int = 6.
op nosmt q' : int = 4.

clone T as T' with
  op nosmt x = z', (* can't do with inline mode *)
  op nosmt x' = 3,
  op nosmt z = z',
  op q <- q'
proof *.
realize ge0_x. by rewrite /x /z'. qed.
realize x'_eq. by rewrite /x'. qed.
realize foo. by rewrite /z /z' /q'. qed.

print T'.
(*
theory T'.
  op nosmt x : int = z'.
  
  lemma nosmt ge0_x: 0 <= T'.x.
  
  op nosmt x' : int = 3.
  
  lemma nosmt x'_eq: T'.x' = 3.
  
  op nosmt z : int = z'.
  
  lemma nosmt foo: T'.z + q' = 10.
  
  op nosmt u : int = T'.z + q'.
  
  lemma nosmt goo: T'.u = 10.
end T'.
*)
```
