### PR TITLE
match with duplicate constructors can result in exception

### DIFF
--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -1132,12 +1132,16 @@ let trans_branch ~loc env ue gindty ((pb, body) : ppattern * _) =
 (* -------------------------------------------------------------------- *)
 let trans_match ~loc env ue (gindty, gind) pbs =
   let pbs = List.map (trans_branch ~loc env ue gindty) pbs in
+  (* the left-hand-sides of pbs are a subset of the left hand sides
+     of gind.tydt_ctors (with the order perhaps different) *)
 
   if List.length pbs < List.length gind.tydt_ctors then
     tyerror loc env (InvalidMatch FXE_MatchPartial);
 
-  if List.length pbs > List.length gind.tydt_ctors then
+  if List.has_dup ~cmp:(fun x y -> compare (fst x) (fst y)) pbs then
     tyerror loc env (InvalidMatch FXE_MatchDupBranches);
+  (* the left-hand-sides of pbs are exactly the left-hand sides
+     of gind.tydt_ctors (with the order perhaps different) *)
 
   let pbs = Msym.of_list pbs in
 

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -566,6 +566,16 @@ module List = struct
   (* ------------------------------------------------------------------ *)
   let reduce1 (f : 'a list -> 'a) : 'a list -> 'a =
     function [x] -> x | xs  -> f xs
+
+  (* ------------------------------------------------------------------ *)
+  let rec find_dup ?(cmp = Pervasives.compare) (xs : 'a list ) =
+    match xs with
+    | []      -> None
+    | x :: xs ->
+        if BatList.mem_cmp cmp x xs then Some x else find_dup ~cmp xs
+
+  let has_dup ?(cmp = Pervasives.compare) (xs : 'a list) =
+    Option.is_some (find_dup ~cmp xs)
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecUtils.mli
+++ b/src/ecUtils.mli
@@ -288,6 +288,8 @@ module List : sig
   val rev_pmap   : ('a -> 'b option) -> 'a list -> 'b list
   val rotate     : [`Left|`Right] -> int -> 'a list -> int * 'a list
   val reduce1    : ('a list -> 'a) -> 'a list -> 'a
+  val find_dup   : ?cmp:('a -> 'a -> int) -> 'a list -> 'a option
+  val has_dup    : ?cmp:('a -> 'a -> int) -> 'a list -> bool
 
   (* ------------------------------------------------------------------ *)
   val ksort:


### PR DESCRIPTION
When a match has duplicate constructors but the same number of
branches as the number of constructors in the datatype being matched,
an exception was raised instead of the expected error message being
issued. Example:

```
type t = [A | B].
module M = {
  proc f(x : t) = {
    match x with
    | A => { }
    | A => { }
    end;
  }
}.
```