### PR TITLE
Add a -no-eco option to disable .eco generation

### DIFF
--- a/src/ec.ml
+++ b/src/ec.ml
@@ -195,7 +195,7 @@ let main () =
   begin let open EcUserMessages in register () end;
 
   (* Initialize I/O + interaction module *)
-  let (prvopts, input, terminal, interactive) =
+  let (prvopts, input, terminal, interactive, eco) =
     match options.o_command with
     | `Config ->
         let config = {
@@ -231,7 +231,7 @@ let main () =
           then lazy (EcTerminal.from_emacs ())
           else lazy (EcTerminal.from_tty ())
 
-        in (cliopts.clio_provers, None, terminal, true)
+        in (cliopts.clio_provers, None, terminal, true, false)
     end
 
     | `Compile cmpopts -> begin
@@ -251,7 +251,7 @@ let main () =
           lazy (EcTerminal.from_channel ~name ~gcstats (open_in name))
         in
           ({cmpopts.cmpo_provers with prvo_iterate = true},
-           Some name, terminal, false)
+           Some name, terminal, false, cmpopts.cmpo_noeco)
 
     end
   in
@@ -408,7 +408,8 @@ let main () =
         EcTerminal.finish `ST_Ok terminal;
         if !terminate then begin
             EcTerminal.finalize terminal;
-            finalize_input input (EcCommands.current ());
+            if not eco then
+              finalize_input input (EcCommands.current ());
             exit 0
           end;
       with

--- a/src/ecOptions.ml
+++ b/src/ecOptions.ml
@@ -28,6 +28,7 @@ and cmp_option = {
   cmpo_provers : prv_options;
   cmpo_gcstats : bool;
   cmpo_tstats  : string option;
+  cmpo_noeco   : bool;
 }
 
 and cli_option = {
@@ -234,7 +235,8 @@ let specs = {
       `Group "loader";
       `Group "provers";
       `Spec  ("gcstats", `Flag, "Display GC statistics");
-      `Spec  ("tstats", `String, "Save timing statistics to <file>")]);
+      `Spec  ("tstats", `String, "Save timing statistics to <file>");
+      `Spec  ("no-eco", `Flag, "Do not cache verification results")]);
 
     ("cli", "Run EasyCrypt top-level", [
       `Group "loader";
@@ -370,7 +372,8 @@ let cmp_options_of_values ?ini values input =
   { cmpo_input   = input;
     cmpo_provers = prv_options_of_values ?ini values;
     cmpo_gcstats = get_flag "gcstats" values;
-    cmpo_tstats  = get_string "tstats" values; }
+    cmpo_tstats  = get_string "tstats" values;
+    cmpo_noeco   = get_flag "no-eco" values; }
 
 (* -------------------------------------------------------------------- *)
 let parse ?ini argv =

--- a/src/ecOptions.mli
+++ b/src/ecOptions.mli
@@ -24,6 +24,7 @@ and cmp_option = {
   cmpo_provers : prv_options;
   cmpo_gcstats : bool;
   cmpo_tstats  : string option;
+  cmpo_noeco   : bool;
 }
 
 and cli_option = {


### PR DESCRIPTION
Existing .eco cached results are used, but new ones are not generated.

@strub  Please review. Retrofitting the CLI processing to output an additional and mostly useless flag feels like a dirty hack I should have put more effort into.