### PR TITLE
Consistently use `mu1` instead of `mass`. 

### DIFF
--- a/theories/distributions/DBool.ec
+++ b/theories/distributions/DBool.ec
@@ -60,7 +60,7 @@ op dbiased (p : real) = Distr.mk (mbiased p).
 lemma dbiased1E (p : real) (b : bool) :
   mu1 (dbiased p) b =
    if b then clamp p else 1%r - clamp p.
-proof. by rewrite -massE muK  // isdistr_mbiased. qed.
+proof. by rewrite muK  // isdistr_mbiased. qed.
 
 lemma dbiasedE (p : real) (E : bool -> bool) :
   mu (dbiased p) E =
@@ -68,7 +68,7 @@ lemma dbiasedE (p : real) (E : bool -> bool) :
     + (if E false then 1%r - clamp p else 0%r).
 proof.
 rewrite muE (@sumE_fin _ [true; false]) => [|[]|] //.
-by rewrite 2!big_cons big_nil => @/predT /=; rewrite !massE !dbiased1E.
+by rewrite 2!big_cons big_nil => @/predT /=; rewrite !dbiased1E.
 qed.
 
 lemma supp_dbiased (p : real) b :

--- a/theories/distributions/DProd.ec
+++ b/theories/distributions/DProd.ec
@@ -122,7 +122,7 @@ have ->:   Pr[SampleDLet.sample(dt{m1}, du{m1}) @ &m1 : res = x]
 suff ->//:   Pr[SampleDLet.sample2(dt{m1}, du{m1}) @ &m2 : res.`2 = x]
            = mu1 (dlet dt{m1} du{m1}) x.
 byphoare(_ : dt{m1} = dt /\ du{m1} = du ==> _) => //=.
-proc; rnd; skip => /=; rewrite dlet1E dletE_swap /=.
+proc; rnd; skip => /=; rewrite dlet1E dlet_muE_swap /=.
 move=> &hr [-> ->]; apply: eq_sum => y /=; rewrite (@sumD1 _ (y, x)) /=.
 + by apply/summable_cond/summableZ/summable_mu1. 
 rewrite dprod1E dunit1E sum0_eq //=.

--- a/theories/distributions/DProd.ec
+++ b/theories/distributions/DProd.ec
@@ -124,10 +124,10 @@ suff ->//:   Pr[SampleDLet.sample2(dt{m1}, du{m1}) @ &m2 : res.`2 = x]
 byphoare(_ : dt{m1} = dt /\ du{m1} = du ==> _) => //=.
 proc; rnd; skip => /=; rewrite dlet1E dletE_swap /=.
 move=> &hr [-> ->]; apply: eq_sum => y /=; rewrite (@sumD1 _ (y, x)) /=.
-+ by apply/summable_cond/summableZ/summable_mass. 
-rewrite !massE dprod1E dunit1E sum0_eq //=.
++ by apply/summable_cond/summableZ/summable_mu1. 
+rewrite dprod1E dunit1E sum0_eq //=.
 case=> y' x' /=; case: (x' = x) => //= ->>.
-case: (y' = y) => //= ne_y'y; rewrite !massE dprod1E.
+case: (y' = y) => //= ne_y'y; rewrite dprod1E.
 by rewrite dunit1E (@eq_sym y) ne_y'y.
 qed.
 

--- a/theories/distributions/Dfilter.ec
+++ b/theories/distributions/Dfilter.ec
@@ -31,7 +31,7 @@ op dfilter (d : 'a distr) (P : 'a -> bool) = mk (mfilter (mu1 d) P).
 (* -------------------------------------------------------------------- *)
 lemma dfilter1E d (P:'a -> bool) (x:'a):
   mu1 (dfilter d P) x = if P x then 0%r else mu1 d x.
-proof. by rewrite -massE muK 1:isdistr_mfilter 1:isdistr_mu1. qed.
+proof. by rewrite muK 1:isdistr_mfilter 1:isdistr_mu1. qed.
 
 lemma nosmt dfilter1E_notin (d : 'a distr) P x:
   !P x => mu1 (dfilter d P) x = mu1 d x.
@@ -46,7 +46,7 @@ lemma nosmt dfilterE (d : 'a distr) P E:
   mu (dfilter d P) E = mu d (predI E (predC (P))).
 proof.
 rewrite !muE; apply/RealSeries.eq_sum=> x /=.
-by rewrite !massE dfilter1E /predI /predC; case: (P x).
+by rewrite dfilter1E /predI /predC; case: (P x).
 qed.
 
 lemma nosmt dfilterE_subset (d : 'a distr) P E:

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -63,7 +63,7 @@ apply: distrW d2 => m2 isd2 /=; apply: distrW d1 => m1 isd1 /= H.
 have {H} [x Dx] : exists x, m1 x <> m2 x. 
   by apply: contraLR H => ?; rewrite negbK; congr; smt().
 apply (ltr_le_trans `|mu1 (mk m1) x - mu1 (mk m2) x|); last exact sdist_upper_bound.
-by rewrite -!massE !muK // /#.
+by rewrite !muK // /#.
 qed.
 
 lemma sdistC (d1 d2 : 'a distr) : sdist d1 d2 = sdist d2 d1.
@@ -117,19 +117,19 @@ move => tmp; have {tmp} ler_Sn_Sp : Sn <= Sp by done.
 rewrite (sum_split _ pos) // -/Sp -/Sn.
 have <- : `| Sp - Sn | = `|weight d1 - weight d2|.
   rewrite /Sp /Sn -sumB /=; try exact/summable_cond/summable_sdist.
-  rewrite !weightE_mu -sumB /= ?summable_mu1. 
+  rewrite !weightE -sumB /= ?summable_mu1. 
   by congr; apply eq_sum => x /= /#.
 suff : flub F = Sp by rewrite /sdist -/F; smt(ler_def).
 apply ler_anti; split => [|_]; last first. 
 - apply (ler_trans (F pos)); 2: by apply (flub_upper_bound 1%r); smt(mu_bounded).
-  rewrite /Sp /F /f !mu_mu1 -sumB /=; 1,2: exact summable_mu1_cond.
+  rewrite /Sp /F /f !muE -sumB /=; 1,2: exact summable_mu1_cond.
   apply (ler_trans _ _ _ _ (ler_norm _)). 
   apply ler_sum;  [smt()|apply/summable_cond/summable_sdist|].
   by apply/summableD;[|apply/summableN]; apply/summable_mu1_cond.
 apply sdist_le_ub => E.
 rewrite (mu_split d1 E pos) (mu_split d2 E pos). 
 have -> : forall (a b c d : real), a + b - (c + d) = (a - c) + (b - d) by smt().
-rewrite !mu_mu1 -!sumB /=; 1..4: exact: summable_mu1_cond.
+rewrite !muE -!sumB /=; 1..4: exact: summable_mu1_cond.
 rewrite (eq_sum _ 
   (fun x => if predI E pos x then mu1 d1 x - mu1 d2 x else 0%r)); 1: smt().
 rewrite (eq_sum 
@@ -181,7 +181,7 @@ case : (`|Sp| >= `|Sn|) => H.
   rewrite sum_split_dist /= ?summable_mu1.
   have -> : forall x, 2%r * x = x + x by smt().
   rewrite -addrA &(ler_add) // addrC ler_subr_addl.
-  by rewrite -sum_split // sumB ?summable_mu1 -!weightE_mu; smt().
+  by rewrite -sum_split // sumB ?summable_mu1 -!weightE; smt().
 + apply (ler_trans (2%r* -Sn)) => [|{H}]; 1: smt().
   apply (ler_trans (2%r * - sum (fun x => if !p x then mu1 d1 x - mu1 d2 x else 0%r))).
     rewrite ler_pmul2l // &(ler_opp2) &(ler_sum) => [x /=| |]; 2,3: exact summable_cond.
@@ -190,7 +190,7 @@ case : (`|Sp| >= `|Sn|) => H.
   rewrite -[(_ - _)%Real]addrC -addrA. 
   have -> : forall x, 2%r * x = x + x by smt().
   apply ler_add => //. rewrite -ler_subl_addl -opprD -sum_split //. 
-  by rewrite sumB ?summable_mu1 -!weightE_mu /#.
+  by rewrite sumB ?summable_mu1 -!weightE /#.
 qed. 
 
 (*----------------------------------------------------------------------------*)
@@ -205,7 +205,7 @@ rewrite mulrC -sumZ /= sum_pair; 1: exact summable_sdist.
 apply eq_sum => x /=.
 rewrite (eq_sum _ (fun b => `|mu1 d1 x - mu1 d2 x| * mu1 d b)) => [b /=|].
 + rewrite !dprod1E; smt(mu_bounded).
-by rewrite sumZ mulrC -weightE_mu.
+by rewrite sumZ mulrC -weightE.
 qed.
 
 lemma sdist_dprodC_aux (dl1 dl2 : 'a distr) (dr1 dr2 : 'b distr) :
@@ -267,7 +267,7 @@ lemma adv_mu1 (A <: Distinguisher) &m z x' :
   Pr[A.guess(x') @ &m : res = z] = 
   mu1 (mk (fun b => Pr[A.guess(x') @ &m : res = b])) z.
 proof.
-by rewrite -massE muK //; exact (adv_isdistr A).
+by rewrite muK //; exact (adv_isdistr A).
 qed.
 
 module S = {

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -156,7 +156,7 @@ qed.
 lemma sdist_dlet (d1 d2 : 'a distr) (F : 'a -> 'b distr) : 
    sdist (dlet d1 F) (dlet d2 F) <= sdist d1 d2.
 proof. 
-apply sdist_le_ub => E; rewrite !dletE_mu sdist_tvd.
+apply sdist_le_ub => E; rewrite !dletE sdist_tvd.
 rewrite div1r (ler_pdivl_mull 2%r) //.
 rewrite -sumB ?summable_mu1_wght /=; 1,2: smt(mu_bounded).
 rewrite (eq_sum _ (fun x => (mu1 d1 x - mu1 d2 x) * mu (F x) E)).


### PR DESCRIPTION
Once `mass d x = mu1 d x` is proved, `mass` and `mu1` can be used almost interchangeably. As lemmas about `mu` apply to the abbreviation `mu1` as well, this PR aims to replace `mass` by `mu1` wherever possible and remove lemma-duplication between the two.  