### PR TITLE
allow zero queries in Hybrid 

### DIFF
--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -572,7 +572,7 @@ abstract theory N1.
 (* We need operators, because we need to define modules that use them *)
 op [lossless] d1 : a distr.
 op [lossless] d2 : a distr.
-op N : { int | 0 < N } as N_pos.
+op N : { int | 0 <= N } as N_ge0.
 
 section. 
 
@@ -591,7 +591,7 @@ local clone Hybrid as Hyb with
   type outleaks <- unit,
   type outputA <- bool,
   op q <- N,
-  lemma q_pos <- N_pos
+  lemma q_ge0 <- N_ge0
   proof*.
 
 local module Ob : Hyb.Orclb = {
@@ -663,7 +663,7 @@ lemma sdist_oracleN &m :
   `| Pr[Game(A,Os).main(d1) @ &m : res] - Pr[Game(A,Os).main(d2) @ &m : res] | 
   <= N%r * sdist d1 d2.
 proof.
-rewrite -ler_pdivr_mull -?normrZ; 1,2: smt(N_pos). 
+(* rewrite -ler_pdivr_mull -?normrZ; 1,2: smt(N_ge0).  *)
 rewrite Osd1_Hyb Osd2_Hyb. 
 have /= <- := Hyb.Hybrid_restr (<: Ob) (<: B) _ _ _ _ _ &m (fun _ _ _ r => r).
 - move => O; proc; inline *; sp; wp. 
@@ -691,8 +691,9 @@ have -> : Pr[Hyb.HybGame(B, Ob, Hyb.R(Ob)).main() @ &m : res] =
   proc; inline *; sp.
   if; [smt() | by auto |].
   if; [smt()| by auto | by auto].
+rewrite normrZ /= 2:ler_wpmul2l; 1,2: smt(N_ge0).
 apply (sdist_oracle1 C);[|exact d1_ll|exact d2_ll|].
-- move => O O_ll; islossless; 2: by rewrite DInterval.weight_dinter; smt(N_pos).
+- move => O O_ll; islossless; 2: by rewrite DInterval.weight_dinter; smt(N_ge0).
   by apply (A_ll (<: B'(Ob, Hyb.HybOrcl(Ob, C(O).O')).O')); islossless. 
 move => O; proc.
 call(: if Hyb.HybOrcl.l <= Hyb.HybOrcl.l0 then Count.n = 0 else Count.n = 1).
@@ -712,7 +713,7 @@ import SmtMap.
 type in_t.
 op [lossless] d1 : a distr.
 op [lossless] d2 : a distr.
-op N : { int | 0 < N } as N_pos.
+op N : { int | 0 <= N } as N_ge0.
 
 clone PROM.FullRO as R1 with 
   type in_t <- in_t, 
@@ -823,7 +824,7 @@ local clone N1 as N1 with
   axiom d1_ll <- d1_ll,
   axiom d2_ll <- d2_ll,
   op N <- N,
-  axiom N_pos <- N_pos
+  axiom N_ge0 <- N_ge0
   proof*.
 
 lemma sdist_ROM  &m : 

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -665,7 +665,7 @@ lemma sdist_oracleN &m :
 proof.
 (* rewrite -ler_pdivr_mull -?normrZ; 1,2: smt(N_ge0).  *)
 rewrite Osd1_Hyb Osd2_Hyb. 
-have /= <- := Hyb.Hybrid_restr (<: Ob) (<: B) _ _ _ _ _ &m (fun _ _ _ r => r).
+have /= -> := Hyb.Hybrid_restr (<: Ob) (<: B) _ _ _ _ _ &m (fun _ _ _ r => r).
 - move => O; proc; inline *; sp; wp. 
   inline *.
   conseq (: Hyb.Count.c = Count.n) (: Count.n = 0 ==> Count.n <= N) => //. 

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -663,7 +663,6 @@ lemma sdist_oracleN &m :
   `| Pr[Game(A,Os).main(d1) @ &m : res] - Pr[Game(A,Os).main(d2) @ &m : res] | 
   <= N%r * sdist d1 d2.
 proof.
-(* rewrite -ler_pdivr_mull -?normrZ; 1,2: smt(N_ge0).  *)
 rewrite Osd1_Hyb Osd2_Hyb. 
 have /= -> := Hyb.Hybrid_restr (<: Ob) (<: B) _ _ _ _ _ &m (fun _ _ _ r => r).
 - move => O; proc; inline *; sp; wp. 

--- a/theories/encryption/DDH_hybrid.ec
+++ b/theories/encryption/DDH_hybrid.ec
@@ -13,15 +13,15 @@ require import Cyclic_group_prime.
 
 require Hybrid.
 
-op n : int.
-clone Hybrid as H with
+op n : { int | 0 < n } as n_pos.
+clone import Hybrid as H with
   type input <- unit,
   type output <- group * group * group,
   type inleaks <- unit,
   type outleaks <- unit,
   type outputA <- bool,
-  op q <- n.
-import H.
+  op q <- n 
+  proof* by smt(n_pos).
 
 module DDHl = {
   proc orcl () : group * group * group = {
@@ -76,9 +76,10 @@ section.
         Pr[Rn(DDHb, A).main() @ &m : (res /\ Count.c <= n) ]).
   proof.
    move=> &m.
-   apply (H.Hybrid (<:DDHb) (<:A) _ _ _ _ &m
+   apply (H.Hybrid_div (<:DDHb) (<:A) _ _ _ _ &m
        (fun (ga:glob A) (gb:glob DDHb) (c:int) (r:bool), r)).
    apply islossless_leaks. apply islossless_orcl1. apply islossless_orcl2. apply losslessA.
+   smt(n_pos).
   qed.
 
 end section.

--- a/theories/encryption/Indist.ec
+++ b/theories/encryption/Indist.ec
@@ -109,7 +109,7 @@ module HybGame2(A:Adv) (O:Orcl) (LR:LR) = {
   proc main():bool = {
     var b':bool;
 
-    HybOrcl.l0 <$ [0..q-1];
+    HybOrcl.l0 <$ [0..max 0 (q-1)];
     HybOrcl.l  <- 0;
     b'         <@ A(O,HybOrcl2(O,LR)).main();
     return b';
@@ -248,13 +248,14 @@ have ->:   Pr[INDR(O, A).main() @ &m : res /\ p (glob A) (glob O) Count.c /\ Cou
     proc; inline OrclCount(R(Orcl2(O))).orcl R(Orcl2(O)).orcl Orcl2(O).orclR Count.incr.
     by wp; call(: true); wp.
   by inline *; auto.
-apply: (Hybrid (Orcl2(O)) A' losslessL _ _ _ &m (fun ga go c b, b /\ p ga go c)).
+apply: (Hybrid_div (Orcl2(O)) A' losslessL _ _ _ &m (fun ga go c b, b /\ p ga go c)).
 + by proc; call losslessO.
 + by proc; call losslessO.
 move=> Ob LR Hlr Hl Ho1 Ho2; proc.
 call (losslessA (<: A'(Ob,LR).O) (<: A'(Ob,LR).LR') _ _ _)=> //.
 + by proc; call Hlr.
-by proc; call Ho1.
++ by proc; call Ho1.
++ smt(q_pos).
 qed.
 end section.
 

--- a/theories/encryption/PKE_hybrid.ec
+++ b/theories/encryption/PKE_hybrid.ec
@@ -214,7 +214,7 @@ move=> <-; congr.
       by inline ToOrcl(S).orcl H.Count.incr; wp; call (: true); wp.
     by call (: ={glob S, K.pk}); first sim.
   swap{1} [4..5] -2; inline ToOrcl(S).leaks; wp.
-  by call (: true); auto.
+  call(: true); auto; smt().
 congr.
 byequiv (: ={glob S,glob A} ==> ={res,glob H.HybOrcl} /\ K.c{1} = H.Count.c{2})=> //.
 proc.
@@ -229,6 +229,6 @@ wp; call (: ={glob S,glob H.HybOrcl, K.pk} /\ K.c{1} = H.Count.c{2}).
     by inline ToOrcl(S).orcl H.Count.incr; wp; call (: true); wp.
   by call (: ={glob S, K.pk}); first sim.
 swap {1} [4..5] -2; inline ToOrcl(S).leaks; wp.
-by call (: true); auto.
+by call (: true); auto; smt().
 qed.
 end section.


### PR DESCRIPTION
This PR extends `Hybrid` as follows:
- now statements using multiplication rather than division that also apply in the case where `q = 0`.
- documentation for the games that appear in the statements

In order to ensure that `HybGame` terminates even in the case where `q = 0`, the sampling is now done in `[0..max 0 (q-1)]` rather than [0..q-1]. 