### PR TITLE
Add ec-runtest to install script

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,5 @@
-(dirs src theories examples)
+(dirs src theories examples scripts)
+(install
+ (files (scripts/testing/runtest as ec-runtest))
+ (section bin)
+)


### PR DESCRIPTION
This adds the ec-runtest script back to the dune build, for use in `make check`