### PR TITLE
[docker] Build box base is now an opam image

### DIFF
--- a/scripts/docker/build-box/Dockerfile
+++ b/scripts/docker/build-box/Dockerfile
@@ -1,22 +1,19 @@
-FROM debian:sid
+FROM ocaml/opam:debian-ocaml-4.12
 
 MAINTAINER Pierre-Yves Strub <pierre-yves@strub.nu>
 
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN \
-	apt-get -q -y update && \
-	apt-get -q -y upgrade && \
-	apt-get -q -y install m4 rsync git curl wget && \
-	apt-get -q -y install python3 python3-pip && \
+	sudo apt-get -q -y update && \
+	sudo apt-get -q -y upgrade && \
+	sudo apt-get -q -y install wget curl python3 python3-pip && \
 	pip3 install --no-cache-dir pyyaml && \
-	apt-get -q -y --no-install-recommends install mccs ocaml-nox opam aspcud && \
-	apt-get -q -y clean
+	sudo apt-get -q -y clean
 
-ENV OPAMROOT=/home/root/.opam OPAMROOTISOK=1 OPAMYES=true OPAMVERBOSE=0 OPAMJOBS=4 OPAMEXTERNALSOLVER=mccs
+ENV OPAMYES=true OPAMVERBOSE=0 OPAMJOBS=4
 
 RUN \
-	opam init --disable-sandboxing -a && \
 	opam switch create -v easycrypt ocaml-base-compiler.4.12.0 && \
 	opam pin add -n easycrypt https://github.com/EasyCrypt/easycrypt.git && \
 	opam install depext && opam depext easycrypt && \
@@ -33,12 +30,12 @@ RUN \
 
 RUN \
         wget -O cvc4 https://github.com/cvc5/cvc5/releases/download/${CVC4V}/cvc4-${CVC4V}-x86_64-linux-opt && \
-        mv cvc4 /usr/local/bin/ && chmod 755 /usr/local/bin/cvc4
+        sudo mv cvc4 /usr/local/bin/ && sudo chmod 755 /usr/local/bin/cvc4
 
 RUN \
         wget https://github.com/Z3Prover/z3/releases/download/z3-${Z3V}/z3-${Z3V}${Z3SV}-x64-${Z3A}.zip && \
         unzip -j z3-${Z3V}${Z3SV}-x64-${Z3A}.zip z3-${Z3V}${Z3SV}-x64-${Z3A}/bin/z3 && \
-        cp z3 /usr/local/bin/ && chmod 755 /usr/local/bin/z3 && \
+        sudo cp z3 /usr/local/bin/ && sudo chmod 755 /usr/local/bin/z3 && \
 	rm -rf z3-${Z3V}${Z3SV}-x64-${Z3A}.zip
 
 RUN \


### PR DESCRIPTION
The original base was 5 months out of date. An issue in the build was due to opam running as root.

The replacement base image is setup for opam to not run as root while allowing passwordless sudo.
This has been tested on some CI loops by building easycrypt with `make install`, but not yet using dune dev and `opam install easycrypt`.