### PR TITLE
lift LRO oracle out of FullEager

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -2163,10 +2163,10 @@ section PROOFS.
   have->:Pr[UFCMA(ROIN.RO).distinguish() @ &m : res \/ UFCMA.bad2] = 
          Pr[UFCMA3(ROIN.RO).distinguish() @ &m : res] by byequiv equiv_step4.
   have->:Pr[UFCMA3(ROIN.RO).distinguish() @ &m : res] =
-         Pr[UFCMA3(ROIN.FullEager.LRO).distinguish() @ &m : res].
+         Pr[UFCMA3(ROIN.LRO).distinguish() @ &m : res].
   + byequiv (ROIN.FullEager.RO_LRO_D UFCMA3 _)=> //=; exact: dpoly_in_ll.
-  have->:Pr[UFCMA3(ROIN.FullEager.LRO).distinguish() @ &m : res] = 
-         Pr[UFCMA4(ROIN.FullEager.LRO).distinguish() @ &m : UF.forged \/ UFCMA.bad2].
+  have->:Pr[UFCMA3(ROIN.LRO).distinguish() @ &m : res] = 
+         Pr[UFCMA4(ROIN.LRO).distinguish() @ &m : UF.forged \/ UFCMA.bad2].
   + byequiv=> //=; proc; inline*; sim; sp.
     seq 5 5 : (={glob UFCMA3, RO.m} /\ (UF.forged,UFCMA.bad2,UFCMA.cbad2, RO.m){2} = (false,false,0, empty)).
     + by wp; conseq/>; sim.
@@ -2224,7 +2224,7 @@ section PROOFS.
                                         (* the probability of bad occuring during ith query *)
         (size l1)                       (* the bound on the counter (after which we stop caring) *)
         UF.forged                       (* the bad event *)
-        [UFCMA4(FullEager.LRO).set_forged : (UFCMA4.cforged < size l1) ]
+        [UFCMA4(LRO).set_forged : (UFCMA4.cforged < size l1) ]
                                         (* condition(s) under which the oracle(s) do not respond *)
         (ROout.m = roout /\ Mem.lc = l /\ UFCMA4.cforged <= size l1)
                                         (* general unconditional invariants *);
@@ -2256,7 +2256,7 @@ section PROOFS.
                                         (* the probability of bad occuring during ith query *)
         (size l2)                       (* the bound on the counter (after which we stop caring) *)
         UFCMA.bad2                      (* the bad event *)
-        [UFCMA4(FullEager.LRO).set_bad2 : (UFCMA.cbad2 < size l2) ]
+        [UFCMA4(LRO).set_bad2 : (UFCMA.cbad2 < size l2) ]
                                         (* condition(s) under which the oracle(s) do not respond *)
         (ROout.m = roout /\ Mem.lc = l /\ UFCMA.cbad2 <= size l2)
                                         (* general unconditional invariants *);

--- a/theories/crypto/PROM.ec
+++ b/theories/crypto/PROM.ec
@@ -108,6 +108,19 @@ module RO : RO, ROmap = {
     return m;
   }
 }.
+
+module LRO : RO = {
+  proc init = RO.init
+
+  proc get = RO.get
+
+  proc set = RO.set 
+
+  proc rem = RO.rem
+
+  proc sample(x : in_t) = { }
+}.
+
 end MkRO.
 
 clone include MkRO.
@@ -244,18 +257,6 @@ end section LL.
 theory FullEager.
 require import List FSet.
 require (*--*) IterProc.
-
-module LRO : RO = {
-  proc init = RO.init
-
-  proc get = RO.get
-
-  proc set = RO.set 
-
-  proc rem = RO.rem
-
-  proc sample(x : in_t) = { }
-}.
 
 (* -------------------------------------------------------------------- *)
 (** Hides internals in normal usage while allowing use where needed    **)

--- a/theories/crypto/ROM.eca
+++ b/theories/crypto/ROM.eca
@@ -220,12 +220,14 @@ local module Exp' (O : RO) = {
   }
 }.
 
+
+
 local equiv eq_LRO_RO:
-  Exp(LRO, D).main ~ Exp'(FullEager.LRO).main:
+  Exp(Lazy.LRO, D).main ~ Exp'(H.LRO).main:
     ={glob D, arg} ==> ={res}.
 proof.
 proc; inline *; wp.
-call (: LRO.m{1} = RO.m{2})=> />; first by sim.
+call (: Lazy.LRO.m{1} = RO.m{2})=> />; first by sim.
 while{2} true (size w{2}).
 + by auto=> &m />; case: (w{m})=> //#.
 by auto=> /> w; rewrite -size_eq0 Int.eqz_leq size_ge0.
@@ -264,9 +266,9 @@ by call eq_ERO_RO_init; inline *; auto.
 qed.
 
 equiv eq_eager_sampling:
-  Exp(LRO, D).main ~ Exp(ERO, D).main: ={glob D, arg} ==> ={res}.
+  Exp(Lazy.LRO, D).main ~ Exp(ERO, D).main: ={glob D, arg} ==> ={res}.
 proof.
-transitivity Exp'(FullEager.LRO).main
+transitivity Exp'(H.LRO).main
              (={glob D, arg} ==> ={res})
              (={glob D, arg} ==> ={res})=> />.
 + by move=> &2; exists (glob D){2} (x{2}).

--- a/theories/modules/RndProd.eca
+++ b/theories/modules/RndProd.eca
@@ -208,7 +208,7 @@ smt(mem_empty fdom0).
 qed.
 
 local equiv eq_2 :
-  D(O3(ROa.FullEager.LRO,ROb.FullEager.LRO)).distinguish ~ D(O2(ROa.RO,ROb.RO)).distinguish :
+  D(O3(ROa.LRO,ROb.LRO)).distinguish ~ D(O2(ROa.RO,ROb.RO)).distinguish :
   ={arg, glob D, ROa.RO.m, ROb.RO.m} ==>
   ={res, glob D, ROa.RO.m, ROb.RO.m}.
 proof.
@@ -230,16 +230,16 @@ transitivity Game(D, O3(ROa.RO, ROb.RO)).main
   (={arg, glob D} ==> ={res, glob D})
   (={arg, glob D} ==> ={res, glob D})=> //=; 1: smt().
 + by conseq eq_1=> />.
-transitivity Game(D, O3(ROa.FullEager.LRO, ROb.RO)).main
+transitivity Game(D, O3(ROa.LRO, ROb.RO)).main
   (={arg, glob D} ==> ={res, glob D})
   (={arg, glob D} ==> ={res, glob D})=> //=; 1: smt().
 + proc; inline*. 
   by call(ROa.FullEager.RO_LRO_D (D1(ROb.RO)) _); auto=> /=; apply: da_ll.
-transitivity Game(D, O3(ROa.FullEager.LRO, ROb.FullEager.LRO)).main
+transitivity Game(D, O3(ROa.LRO, ROb.LRO)).main
   (={arg, glob D} ==> ={res, glob D})
   (={arg, glob D} ==> ={res, glob D})=> //=; 1: smt().
 + proc; inline*. 
-  by call(ROb.FullEager.RO_LRO_D (D2(ROa.FullEager.LRO)) _);
+  by call(ROb.FullEager.RO_LRO_D (D2(ROa.LRO)) _);
     auto=> /=; apply: db_ll.
 by proc; inline*; call eq_2; auto.
 qed.


### PR DESCRIPTION
This pulls the LRO Oracle from the `FullEager` theory into the surrounding `FullRO` theory. Also, `LRO` is now part of `MkRO` as both share the same state. So cloning MkRO now also yields a fresh `LRO`. 