### PR TITLE
Reject `x <- RHS` when `RHS` is a procedure call

### DIFF
--- a/examples/ChaChaPoly/ske.ec
+++ b/examples/ChaChaPoly/ske.ec
@@ -145,7 +145,7 @@ module StLSke (StL:StLOrcls) : SKE = {
   var gs : globS
 
   proc init () = { 
-    gs <- StL.init();
+    gs <@ StL.init();
   }
  
   proc kg = StL.kg

--- a/examples/MEE-CBC/CBC.eca
+++ b/examples/MEE-CBC/CBC.eca
@@ -83,7 +83,7 @@ module CBC(P : PseudoRP) = {
     i <- 0;
     while (i < size p) {
       pi <- nth witness p i;
-      s  <- P.f(key,(s + pi));
+      s  <@ P.f(key,(s + pi));
       c  <- c ++ [s];
       i  <- i + 1;
     }
@@ -98,9 +98,9 @@ module CBC(P : PseudoRP) = {
     s <- iv;
     while (i < size c) {
       ci <- nth witness c i;
-      pi <- P.fi(key,ci);
+      pi <@ P.fi(key,ci);
       p  <- p ++ [s + pi];
-      s <- ci;
+      s  <- ci;
       i  <- i + 1;
     }
     return Some p;
@@ -221,7 +221,7 @@ module CBC_Oracle (P:PRF) = {
     i <- 0;
     while (i < size p) {
       pi <- nth witness p i;
-      s  <- P.f(s + pi);
+      s  <@ P.f(s + pi);
       c  <- c ++ [s];
       i  <- i + 1;
     }
@@ -368,7 +368,7 @@ module PRPF_Adv(A:RCPA_Adversary, F:PRF_Oracles) = {
       i <- 0;
       while (i < size p) {
         pi <- nth witness p i;
-        s  <- F.f(s + pi);
+        s  <@ F.f(s + pi);
         c  <- c ++ [s];
         i  <- i + 1;
       }

--- a/examples/br93.ec
+++ b/examples/br93.ec
@@ -114,7 +114,7 @@ module BR93 (H:Oracle) = {
 
     (r,m) <- c;
     r     <- fi sk r;
-    h     <- H.o(r);
+    h     <@ H.o(r);
     return h +^ m;
   }
 }.

--- a/examples/cramer-shoup/TCR.eca
+++ b/examples/cramer-shoup/TCR.eca
@@ -16,9 +16,9 @@ module type ADV_TCR = {
 module TCR (A:ADV_TCR) = {
   proc main() = {
     var x,y,k;
-    x <- A.c1();
+    x <@ A.c1();
     k <$ dk;
-    y <- A.c2(k);
+    y <@ A.c2(k);
     return (H k x = H k y /\ x <> y);
   }
 }.

--- a/examples/cramer-shoup/cramer_shoup.ec
+++ b/examples/cramer-shoup/cramer_shoup.ec
@@ -204,14 +204,14 @@ module B_DDH (A:CCA_ADV) = {
     CCA.cstar <- None;
     pk <- (k, g, g_, g^x1 * g_^x2, g^y1 * g_^y2, g^z1 * g_^z2);
     CCA.sk <- (k, g, g_, x1, x2, y1, y2, z1, z2);
-    (m0,m1) <- CCA.A.choose(pk);
+    (m0,m1) <@ CCA.A.choose(pk);
     b <$ {0,1};
     c <- a^z1 * a_^z2 * (b ? m1 : m0);
     v <- H k (a,a_,c);
     d <- a^(x1 + v*y1) * a_^(x2+v*y2);
     c' <- (a,a_,c,d);
     CCA.cstar <- Some c';
-    b' <- CCA.A.guess(c');
+    b' <@ CCA.A.guess(c');
     return (b = b');
   }
     

--- a/examples/elgamal.ec
+++ b/examples/elgamal.ec
@@ -51,7 +51,7 @@ module ElGamal : Scheme = {
 module DDHAdv (A:Adversary) = {
   proc guess (gx, gy, gz) : bool = {
     var m0, m1, b, b';
-    (m0, m1) <- A.choose(gx);
+    (m0, m1) <@ A.choose(gx);
     b        <$ {0,1};
     b'       <@ A.guess(gy, gz * (b?m1:m0));
     return b' = b;

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -167,6 +167,7 @@ type tyerror =
 | ProcedureUnbounded     of symbol * symbol
 | LvMapOnNonAssign
 | NoDefaultMemRestr
+| ProcAssign             of qsymbol
 
 exception TymodCnvFailure of tymod_cnv_failure
 exception TyError of EcLocation.t * env * tyerror

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -566,6 +566,9 @@ end = struct
            set the %s pragma to retrieve the old behaviour"
         EcGState.old_mem_restr
 
+    | ProcAssign f ->
+        msg "`%a' is a procedure name. Assign its result to a variable using `<@` instead" pp_qsymbol f
+
   let pp_restr_error env fmt (w, e) =
     let ppe = EcPrinting.PPEnv.ofenv env in
 

--- a/theories/crypto/ROM.eca
+++ b/theories/crypto/ROM.eca
@@ -295,7 +295,7 @@ module Bound (O : Oracle) = {
     var r <- witness;
 
     if (c < qH) {
-      r <- O.o(x);
+      r <@ O.o(x);
       c <- c + 1;
     }
     return r;

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -180,7 +180,7 @@ theory DHIES.
   lemma nosmt mencDHIES_eq : equiv [MEnc.mencDHIES1 ~ MEnc.mencDHIES2: ={tag,ptxt,kks} ==> ={res}].
   proof.
   proc.
-  transitivity{1} { mcph <- MEncDHIES_loop.S.loop(encDHIES tag ptxt, kks); }
+  transitivity{1} { mcph <@ MEncDHIES_loop.S.loop(encDHIES tag ptxt, kks); }
                   ( ={tag, ptxt, kks} ==> ={mcph} )
                   ( ={tag, ptxt, kks} ==> mcph{1}=cphl{2} ).
   + by move=> *; exists kks{2} ptxt{2} tag{2}.
@@ -193,7 +193,7 @@ theory DHIES.
     - by inline*; wp; rnd; wp.
     - by call MEncDHIES_loop.Sample_Loop_eq.
   transitivity{2} { skeys <- map (snd \o snd) kks;
-                    cs <- MEnc_loop.S.loop(fun k=> enc k tag ptxt, skeys); 
+                    cs <@ MEnc_loop.S.loop(fun k=> enc k tag ptxt, skeys); 
                     cphl <- map (fun x:(_*(_*_))*_ => (x.`1.`1, (x.`1.`2.`1, x.`2)))
                                 (zip kks cs); }
                   ( ={tag, ptxt, kks} ==> mcph{1}=cphl{2} )
@@ -519,7 +519,7 @@ module Adv1(A : MRPKE_Adv, O : ODH_OrclT) = {
       var b,b' : bool;
       b <$ {0,1};
       Adv1_Procs(O).init(b);
-      b' <- A.guess();
+      b' <@ A.guess();
       return (MRPKE_lor.b = b');
    }    
 }.
@@ -952,7 +952,7 @@ module Adv2(A : MRPKE_Adv, O : AEADmul_OraclesT) = {
    proc guess() : bool = {
       var b' : bool;
       Adv2_Procs(O).init();
-      b' <- A.guess();
+      b' <@ A.guess();
       return b';
    }    
 }.

--- a/theories/crypto/ske/CPA.eca
+++ b/theories/crypto/ske/CPA.eca
@@ -23,8 +23,8 @@ module IND_CPA ( S : SKE, A : Adv_CPA) = {
     (p0,p1) <@ A.choose();
     b       <$ {0,1};
     p       <- b ? p1 : p0; (* FIXME: need to check whether plaintexts are both valid or both invalid *)
-    c       <- O.enc(p);
-    b'      <- A.guess(oget c);
+    c       <@ O.enc(p);
+    b'      <@ A.guess(oget c);
     return b = b';
   }
 }.


### PR DESCRIPTION
This has to be done in the semantic analysis pass, since local procedures cannot be distinguished from operators in parsing.

We could reject some more bad things in parsing, but doing it here gives us an easy and nice error message which will help users transition. (At least that's my excuse.)