### PR TITLE
[dune+opam] fix git hash versioning widget

### DIFF
--- a/easycrypt.opam
+++ b/easycrypt.opam
@@ -37,5 +37,6 @@ The required steps for configuring the provers are listed on:
   https://github.com/EasyCrypt/easycrypt#configuring-why3"""
 
 build: [
+  ["dune" "subst"]
   ["dune" "build" "-p" name "-j" jobs "@install"]
 ]

--- a/easycrypt.opam.template
+++ b/easycrypt.opam.template
@@ -22,5 +22,6 @@ The required steps for configuring the provers are listed on:
   https://github.com/EasyCrypt/easycrypt#configuring-why3"""
 
 build: [
+  ["dune" "subst"]
   ["dune" "build" "-p" name "-j" jobs "@install"]
 ]


### PR DESCRIPTION
This should fix the reporting of git commit hash on `git config` and on EasyCrypt startup.