### PR TITLE
stronger version of dmap1E_can

### DIFF
--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -1049,6 +1049,17 @@ move=> a ad @/(\o) @/pred1; apply/eq_iff; split; last exact: canLR.
 by move=> faE; move/can_gf: ad; rewrite faE.
 qed.
 
+lemma nosmt dmap1E_can_local (d: 'a distr) (f: 'a -> 'b) (g: 'b -> 'a) (x: 'b):
+  f (g x) = x =>
+  (forall (y: 'a), y \in d => f y = x => y = g x) => 
+  mu1 (dmap d f) x = mu1 d (g x). 
+proof.
+rewrite dmap1E /= => can_fg local_can_gf.
+apply mu_eq_support => y y_in_d @/(\o) @/pred1; apply/eq_iff.
+split => [|->//].
+by apply local_can_gf.
+qed.
+
 lemma dmapE (d : 'a distr) (f : 'a -> 'b) (P : 'b -> bool):
   mu (dmap d f) P = mu d (P \o f).
 proof.

--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -1049,7 +1049,7 @@ move=> a ad @/(\o) @/pred1; apply/eq_iff; split; last exact: canLR.
 by move=> faE; move/can_gf: ad; rewrite faE.
 qed.
 
-lemma nosmt dmap1E_can_local (d: 'a distr) (f: 'a -> 'b) (g: 'b -> 'a) (x: 'b):
+lemma nosmt in_dmap1E_can (d: 'a distr) (f: 'a -> 'b) (g: 'b -> 'a) (x: 'b):
   f (g x) = x =>
   (forall (y: 'a), y \in d => f y = x => y = g x) => 
   mu1 (dmap d f) x = mu1 d (g x). 


### PR DESCRIPTION
When dealing with applications of dmap to list distributions I've had cases where the original ```dmap1E_can``` is too weak because it cares about the global properties of f and g instead of just what happens with values relating to x. Usually I'll know something about x to begin with (e.g. size is bounded by the length of the list).

If there's no stability reasons to keep the old version around I'd want to replace it instead since they are fairly similar.