### PR TITLE
[ci] an attempt at external CI

### DIFF
--- a/.github/workflows/check-contribs.yml
+++ b/.github/workflows/check-contribs.yml
@@ -1,0 +1,94 @@
+name: check-contributions
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Container setup
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Cachix setup (push)
+        uses: cachix/cachix-action@v10
+        with:
+          name: formosa-crypto
+          authToken: '${{ secrets.CACHIX_WRITE_TOKEN }}'
+      - name: Fetch EC source
+        if: github.event_name == 'push'
+        uses: actions/checkout@v3
+      - name: Build binaries
+        if: github.event_name == 'push'
+        run: |
+          export NIXPKGS_ALLOW_UNFREE=1
+          cd "${{ github.workspace }}/scripts/nix"
+          nix-build z3.nix \
+            --arg    lib                 "(import <nixpkgs> {}).lib" \
+            --arg    stdenv              "(import <nixpkgs> {}).stdenv" \
+            --arg    fetchFromGitHub     "(import <nixpkgs> {}).fetchFromGitHub" \
+            --arg    python              "(import <nixpkgs> {}).python3" \
+            --arg    fixDarwinDylibNames "(import <nixpkgs> {}).fixDarwinDylibNames" \
+            --arg    writeScript         "(import <nixpkgs> {}).writeScript" \
+            --argstr version             "4.8.10"
+          nix-build easycrypt.nix --argstr ecRev "$GITHUB_SHA"
+  check:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: actions
+    strategy:
+      matrix:
+        contribs:
+          - name: "jasmin-eclib-release"
+            url: "https://github.com/jasmin-lang/jasmin.git"
+            branch: "release-21"
+            workdir: "eclib"
+            config: "tests.config"
+            checks: [ "jasmin" ]
+          - name: "jasmin-eclib-main"
+            url: "https://github.com/jasmin-lang/jasmin.git"
+            branch: "main"
+            workdir: "eclib"
+            config: "tests.config"
+            checks: [ "jasmin" ]
+          - name: "sha3"
+            url: "https://gitlab.com/easycrypt/sha3.git"
+            branch: "master"
+            workdir: "."
+            config: "config/tests.config"
+            checks: [ "sponge" ]
+    steps:
+      - name: Container setup
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Cachix setup
+        uses: cachix/cachix-action@v10
+        with:
+          name: formosa-crypto
+      - name: Fetch EC source
+        uses: actions/checkout@v3
+      - name: Install binaries
+        run: |
+          export NIXPKGS_ALLOW_UNFREE=1
+          cd ${{ github.workspace }}/scripts/nix
+          nix-env --install --file z3.nix \
+            --arg    lib                 "(import <nixpkgs> {}).lib" \
+            --arg    stdenv              "(import <nixpkgs> {}).stdenv" \
+            --arg    fetchFromGitHub     "(import <nixpkgs> {}).fetchFromGitHub" \
+            --arg    python              "(import <nixpkgs> {}).python3" \
+            --arg    fixDarwinDylibNames "(import <nixpkgs> {}).fixDarwinDylibNames" \
+            --arg    writeScript         "(import <nixpkgs> {}).writeScript" \
+            --argstr version             "4.8.10"
+          nix-env --install --file easycrypt.nix --argstr ecRev "$GITHUB_SHA"
+          nix-env --install gnumake why3 alt-ergo cvc4 --file '<nixpkgs>'
+      - name: Configure EasyCrypt
+        run: |
+          mkdir -p ~/.config/easycrypt
+          easycrypt why3config
+          easycrypt config
+      - name: Checkout contrib
+        run: |
+          git clone --branch ${{ matrix.contribs.branch }} ${{ matrix.contribs.url }} ${{ github.workspace }}/${{ matrix.contribs.name }}
+      - name: Check contrib
+        run: |
+          cd ${{ github.workspace }}/${{ matrix.contribs.name }}/${{ matrix.contribs.workdir }}
+          ec-runtest ${{ matrix.contribs.config }} ${{ matrix.config.checks }} --report=${{ matrix.contribs.name }}.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: EasyCrypt compilation & check
 on: [push,pull_request]
 
 jobs:
-  compile:
-    name: EasyCrypt compilation
+  compile-opam:
+    name: EasyCrypt compilation (opam)
     runs-on: ubuntu-20.04
     container:
       image: easycryptpa/ec-build-box
@@ -23,9 +23,28 @@ jobs:
     - name: Compile EasyCrypt
       run: sudo -u opam opam config exec -- make
 
+  compile-nix:
+    name: EasyCrypt compilation (nix)
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Fetch EC source
+      uses: actions/checkout@v3
+    - name: Setup Nix
+      uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Cachix setup
+      uses: cachix/cachix-action@v10
+      with:
+        name: formosa-crypto
+        authToken: '${{ secrets.CACHIX_WRITE_TOKEN }}'
+    - name: Build and cache EasyCrypt and dependencies
+      run: |
+        nix-build ./scripts/nix/easycrypt.nix --argstr ecRev ${{ github.sha }}
+
   check:
     name: Check EasyCrypt Libraries
-    needs: compile
+    needs: compile-opam
     runs-on: ubuntu-20.04
     container:
       image: easycryptpa/ec-build-box
@@ -65,7 +84,7 @@ jobs:
 
   notification:
     name: Notification
-    needs: [compile, check]
+    needs: [compile-opam, compile-nix, check]
     if: |
       (github.event_name == 'push') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,12 @@ if !lib.versionAtLeast why3.version "1.4" then
   throw "please update your nixpkgs channel: nix-channel --update"
 else
   stdenv.mkDerivation {
-    name = "easycrypt-1.0";
+    pname = "easycrypt";
+    version = "local";
+
     src = ./.;
-    buildInputs = [ why3 ] ++ (with ocamlPackages; [
+
+    buildInputs = [ git why3 ] ++ (with ocamlPackages; [
       ocaml
       findlib
       batteries
@@ -20,5 +23,6 @@ else
       yojson
       zarith
     ]);
+
     installFlags = [ "PREFIX=$(out)" ];
   }

--- a/scripts/nix/easycrypt.nix
+++ b/scripts/nix/easycrypt.nix
@@ -1,0 +1,94 @@
+{ ecRev
+, pkgs    ? import <nixpkgs> {}
+, python  ? (import <nixpkgs> {}).python3
+
+, bJobs   ? 4
+, cJobs   ? 4
+}:
+
+with pkgs;
+let
+  pname   = "easycrypt";
+  version = "ci-" + builtins.substring 0 8 ecRev;
+
+  minimalOcamlVersion = "4.09";
+  maximalOcamlVersion = "4.13.1";
+
+  minimalWhy3Version  = "1.4";
+in
+
+if      !lib.versionAtLeast why3.version minimalWhy3Version
+then    throw "why3 >= ${minimalWhy3Version} is required"
+else if !lib.versionAtLeast ocaml.version minimalOcamlVersion
+then    throw  "ocaml >= ${minimalOcamlVersion} is required"
+else if !lib.versionAtLeast maximalOcamlVersion ocaml.version
+then    throw  "ocaml <= ${maximalOcamlVersion} is required"
+else
+
+let
+  pythonEnv = with pkgs; python.withPackages (p: with p; [ pyyaml ]);
+in
+
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src     = ../..;
+
+  propagatedBuildInputs =
+    with pkgs; [
+      why3
+      pythonEnv
+    ];
+
+  buildInputs =
+       (with pkgs; [ git ])
+    ++ (with ocamlPackages; [
+          ocaml
+          findlib
+          batteries
+          dune_2
+          dune-build-info
+          inifiles
+          menhir
+          menhirLib
+          yojson
+          zarith
+        ]);
+
+  # Playing dirty tricks
+  patchPhase = ''
+    runHook prePatch
+    echo ":100644 100644 15f0b785 00000000 M	dune-project
+
+diff --git a/dune-project b/dune-project
+index 15f0b785..c41ae20c 100644
+--- a/dune-project
++++ b/dune-project
+@@ -3,6 +3,7 @@
+ (using dune_site 0.1)
+
+ (name easycrypt)
++(version nix-${builtins.substring 0 8 ecRev})
+
+ (generate_opam_files true)" | patch -p1
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname} -j${toString bJobs}
+    runHook postBuild
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    dune runtest -p ${pname} -j${toString cJobs}
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    dune install --prefix $out -p ${pname} -j${toString bJobs}
+    runHook postInstall
+  '';
+}

--- a/scripts/nix/z3.nix
+++ b/scripts/nix/z3.nix
@@ -1,0 +1,97 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python
+, fixDarwinDylibNames
+, javaBindings ? false
+, ocamlBindings ? false
+, pythonBindings ? true
+, jdk ? null
+, ocaml ? null
+, findlib ? null
+, zarith ? null
+, writeScript
+, version ? "4.8.14"
+}:
+
+assert javaBindings -> jdk != null;
+assert ocamlBindings -> ocaml != null && findlib != null && zarith != null;
+
+with lib;
+
+stdenv.mkDerivation rec {
+  pname = "z3";
+  inherit version;
+
+  src = fetchFromGitHub {
+    name  = "${pname}_${version}";
+    owner = "Z3Prover";
+    repo = pname;
+    rev = "z3-${version}";
+    sha256 = "jvn1RtSqmhRTA9I+VDDVGW3KID38WiFGl/vGB6ioPvA=";
+  };
+
+  nativeBuildInputs = optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+  buildInputs = [ python ]
+    ++ optional javaBindings jdk
+    ++ optionals ocamlBindings [ ocaml findlib zarith ]
+  ;
+  propagatedBuildInputs = [ python.pkgs.setuptools ];
+  enableParallelBuilding = true;
+
+  postPatch = optionalString ocamlBindings ''
+    export OCAMLFIND_DESTDIR=$ocaml/lib/ocaml/${ocaml.version}/site-lib
+    mkdir -p $OCAMLFIND_DESTDIR/stublibs
+  '';
+
+  configurePhase = concatStringsSep " "
+    (
+      [ "${python.interpreter} scripts/mk_make.py --prefix=$out" ]
+        ++ optional javaBindings "--java"
+        ++ optional ocamlBindings "--ml"
+        ++ optional pythonBindings "--python --pypkgdir=$out/${python.sitePackages}"
+    ) + "\n" + "cd build";
+
+  postInstall = ''
+    mkdir -p $dev $lib
+    mv $out/lib $lib/lib
+    mv $out/include $dev/include
+  '' + optionalString pythonBindings ''
+    mkdir -p $python/lib
+    mv $lib/lib/python* $python/lib/
+    ln -sf $lib/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary} $python/${python.sitePackages}/z3/lib/libz3${stdenv.hostPlatform.extensions.sharedLibrary}
+  '' + optionalString javaBindings ''
+    mkdir -p $java/share/java
+    mv com.microsoft.z3.jar $java/share/java
+    moveToOutput "lib/libz3java.${stdenv.hostPlatform.extensions.sharedLibrary}" "$java"
+  '';
+
+  outputs = [ "out" "lib" "dev" "python" ]
+    ++ optional javaBindings "java"
+    ++ optional ocamlBindings "ocaml";
+
+   passthru = {
+    updateScript = writeScript "update-z3" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts curl jq
+
+      set -eu -o pipefail
+
+      # Expect tags in format
+      #    [{name: "Nightly", ..., {name: "z3-vv.vv.vv", ...].
+      # Below we extract frst "z3-vv.vv" and drop "z3-" prefix.
+      newVersion="$(curl -s https://api.github.com/repos/Z3Prover/z3/releases |
+          jq 'first(.[].name|select(startswith("z3-"))|ltrimstr("z3-"))' --raw-output
+      )"
+      update-source-version ${pname} "$newVersion"
+    '';
+   };
+
+  meta = with lib; {
+    description = "A high-performance theorem prover and SMT solver";
+    homepage = "https://github.com/Z3Prover/z3";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thoughtpolice ttuegel ];
+  };
+}


### PR DESCRIPTION
This works to:
- check that a `nix`-based build goes through (and cache dependencies and outputs); and
- check some external projects specified in a job matrix.

Management of external projects is still pretty manual, but they *can* add themselves with a simple PR.
This PR would need careful review, because we pull their code in, and execute a command they provide. Without additional hardening, this would also preclude running any command like `make` where the code being run could be modified downstream without approval from us. So in general, we should check that the check tasks are run without access to sensitive environments and tokens.

We should consolidate the nix dependencies to:
- clean the actions script up; and
- ensure that the same derivations (for coqword, Jasmin, EasyCrypt) are used across in Jasmin and libjade CI (so caching is even more effective).