### PR TITLE
New logic to upper-bound the worst-case complexity of programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,3 +270,11 @@ Proof General Front-End
 
 EasyCrypt mode has been integrated upstream. Please, go
 to <https://github.com/ProofGeneral/PG> and follow the instructions.
+
+Examples
+====================================================================
+
+Examples of how to use EasyCrypt are in the `examples` directory. You
+will find basic examples at the root of this directory, as well as a
+more advanced example in the `MEE-CBC` sub-directory and a tutorial on
+how to use the complexity system in `cost` sub-directory.

--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -551,8 +551,8 @@ abstract theory OpCC.
 
   section PROOFS.
   
-    declare module I <: Init { OCC }.
-    declare module A <: Adv { OCC, I}.
+    declare module I <: Init { -OCC }.
+    declare module A <: Adv { -OCC, -I}.
    
     phoare chacha_spec k0 n0 p0 gs0 : 
       [ChaCha(OCC(I)).enc : 
@@ -1016,11 +1016,11 @@ module G9 (A:CCA_Adv, RO1:SplitC1.I1.RO) = {
 
 section PROOFS.
 
-  declare module A <: CCA_Adv { RO, FRO, OpCCinit.OCC, OpCCRO.OCC, IndBlock, Mem, StLSke,
-                               Split0.IdealAll.RO, ROT.RO, ROF.RO, SplitC1.I1.RO, SplitC1.I2.RO,
-                               Split1.IdealAll.RO, SplitC2.I1.RO, SplitC2.I2.RO }.
+  declare module A <: CCA_Adv { -RO, -FRO, -OpCCinit.OCC, -OpCCRO.OCC, -IndBlock, -Mem, -StLSke,
+                               -Split0.IdealAll.RO, -ROT.RO, -ROF.RO, -SplitC1.I1.RO, -SplitC1.I2.RO,
+                               -Split1.IdealAll.RO, -SplitC2.I1.RO, -SplitC2.I2.RO }.
 
-  declare axiom A_ll : forall (O <: CCA_Oracles{A}), islossless O.enc => islossless O.dec => islossless A(O).main.
+  declare axiom A_ll : forall (O <: CCA_Oracles{-A}), islossless O.enc => islossless O.dec => islossless A(O).main.
 
   local module G1 (S:SKE) = CCA_game(A, RealOrcls(S)).
 
@@ -1355,9 +1355,9 @@ module EncRnd = {
 }.
 
 section PROOFS.
-  declare module A <: CCA_Adv { BNR, Mem, IndBlock, RO, FRO}.
+  declare module A <: CCA_Adv { -BNR, -Mem, -IndBlock, -RO, -FRO}.
 
-  declare axiom A_ll : forall (O <: CCA_Oracles{A}), islossless O.enc => islossless O.dec => islossless A(O).main.
+  declare axiom A_ll : forall (O <: CCA_Oracles{-A}), islossless O.enc => islossless O.dec => islossless A(O).main.
 
   local clone import Step1_2 as Step1_2'.
 
@@ -1676,13 +1676,15 @@ section PROOFS.
       + move=> &2 _; islossless.
         while true (size p).
         + move=> z; wp; conseq (_: true) => />; 2: by islossless.
+          move => &hr; elim (p{hr}) => //.
           smt (size_drop size_eq0 gt0_block_size).
         by auto; smt (size_ge0 size_eq0).         
       + move=> _; proc; inline *; sp; if => //.
         swap 13 9; wp; conseq (_: true) => />; 1: smt(); islossless.
         while true (size p2).
         + move=> z; wp; conseq (_: true) => //=; 2: by islossless.
-          move=> &h.
+          move => &hr; elim (p2{hr}) => //. 
+          clear &hr.
           smt (size_drop size_eq0 gt0_block_size).
         by auto; smt (size_ge0 size_eq0 dpoly_out_ll). 
       + by proc; inline *; sp 1 1; if; auto => /> *; smt(get_setE mem_set).
@@ -2463,8 +2465,10 @@ section PROOFS.
     - by conseq(:_==> true)=> />; while(true); auto.
     rcondf{2} 5; 1: auto=> />.
     - by conseq(:_==> true)=> />; while(true); auto.
-    wp -7 -7=> />; 1: smt(get_setE).
+    wp -7 -7=> />.
+    move => />; smt (get_setE).
     conseq(:_==> ={c1, t, RO.m, Mem.log, t, c1}); 2:(sim=> /#).
+    move => />.
     smt(get_setE leq_make_lbad1 make_lbad1_size_cons3 size_ge0).
   inline*; sp.
   rcondt{1} 5; 1: auto=> />.

--- a/examples/ChaChaPoly/ske.ec
+++ b/examples/ChaChaPoly/ske.ec
@@ -166,13 +166,13 @@ module UFCMA(A:CCA_Adv, StL:StLOrcls) =
 
 section PROOFS.
 
-  declare module St <: StLOrcls { StLSke, Mem }.
+  declare module St <: StLOrcls { -StLSke, -Mem }.
 
   declare axiom valid_kg : hoare [St.kg : true ==> valid_key res].
 
-  declare module A <: CCA_Adv { StLSke, Mem, St }.
+  declare module A <: CCA_Adv { -StLSke, -Mem, -St }.
 
-  declare axiom A_ll : forall (O <: CCA_Oracles{A}), islossless O.enc => islossless O.dec => islossless A(O).main.
+  declare axiom A_ll : forall (O <: CCA_Oracles{-A}), islossless O.enc => islossless O.dec => islossless A(O).main.
 
   equiv eqv_CCA_UFCMA : CCA_game(A, RealOrcls(StLSke(St))).main ~ UFCMA(A, St).main :
      ={glob A} ==> !(exists c, c \in Mem.lc /\ dec StLSke.gs Mem.k c <> None){2} => ={res}.

--- a/examples/MEE-CBC/CBC.eca
+++ b/examples/MEE-CBC/CBC.eca
@@ -282,7 +282,7 @@ lemma CPA_direct_eq (P  <: PRF)
   equiv [P.init ~ P'.init: true ==> I (glob P){1} (glob P'){2}] =>
   equiv [P.f ~ P'.f: ={arg} /\ I (glob P){1} (glob P'){2}
                  ==> ={res} /\ I (glob P){1} (glob P'){2}] =>
-  forall &m (A <: RCPA_Adversary {P, P'}),
+  forall &m (A <: RCPA_Adversary {-P, -P'}),
     Pr[INDR_CPA_direct(CBC_Oracle(P),A).main() @ &m: res]
     = Pr[INDR_CPA_direct(CBC_Oracle(P'),A).main() @ &m: res].
 proof.
@@ -294,7 +294,7 @@ proof.
 qed.
 
 section Cleanup.
-  declare module A <: RCPA_Adversary { RCPA_Wrap, PRP }.
+  declare module A <: RCPA_Adversary { -RCPA_Wrap, -PRP }.
 
   local module M : Enc_Scheme = {
     proc keygen = IV_Wrap(CBC(PseudoRP)).keygen
@@ -380,9 +380,9 @@ module PRPF_Adv(A:RCPA_Adversary, F:PRF_Oracles) = {
 }.
 
 section Decomposition.
-  declare module A <: RCPA_Adversary { RCPA_Wrap, PRP, PRPi, PRFi }.
+  declare module A <: RCPA_Adversary { -RCPA_Wrap, -PRP, -PRPi, -PRFi }.
 
-  local lemma refactor_abstract (O <: PRP {A}) &m:
+  local lemma refactor_abstract (O <: PRP {-A}) &m:
     Pr[INDR_CPA_direct(CBC_Oracle(O),A).main() @ &m: res]
     = Pr[IND(O,PRPF_Adv(A)).main() @ &m: res].
   proof. by byequiv=> //=; proc; inline *; sim. qed.
@@ -442,8 +442,8 @@ module Compute = {
 }.
 
 section Reduce.
-  declare module A <: RCPA_Adversary { RCPA_Wrap, PRFi, Compute }.
-  declare axiom A_distinguish_ll (O <: RCPA_Oracles {A}): islossless O.enc => islossless A(O).distinguish.
+  declare module A <: RCPA_Adversary { -RCPA_Wrap, -PRFi, -Compute }.
+  declare axiom A_distinguish_ll (O <: RCPA_Oracles {-A}): islossless O.enc => islossless A(O).distinguish.
 
   local module DoubleQuery (F : PRF) = {
     var qs : block fset
@@ -465,7 +465,7 @@ section Reduce.
     }
   }.
 
-  local lemma doublequery_eq (F <: PRF {A, DoubleQuery}) &m:
+  local lemma doublequery_eq (F <: PRF {-A, -DoubleQuery}) &m:
     Pr[INDR_CPA_direct(CBC_Oracle(F),A).main() @ &m: res]
     = Pr[INDR_CPA_direct(CBC_Oracle(DoubleQuery(F)),A).main() @ &m: res].
   proof.
@@ -594,8 +594,8 @@ end section Reduce.
  **          - Pr[IND(PRFa.PRFi,PRPF_Adv(A)).main() @ &m: res]|
  **      + Pr[INDR_CPA_direct(Compute,A).main() @ &m: Compute.bad]
  **)
-lemma reduction (A <: RCPA_Adversary { RCPA_Wrap, PRP, PRPi, PRFi, Compute }) &m:
-  (forall (O <: RCPA_Oracles {A}), islossless O.enc => islossless A(O).distinguish) =>
+lemma reduction (A <: RCPA_Adversary { -RCPA_Wrap, -PRP, -PRPi, -PRFi, -Compute }) &m:
+  (forall (O <: RCPA_Oracles {-A}), islossless O.enc => islossless A(O).distinguish) =>
      `|Pr[INDR_CPA(IV_Wrap(CBC(PseudoRP)),A).main() @ &m: res]
        - Pr[INDR_CPA(Random,A).main() @ &m: res]|
   <=    `|Pr[IND(PRP,PRPF_Adv(A)).main() @ &m: res]
@@ -684,8 +684,8 @@ module QueryBounder(A:RCPA_Adversary, O:RCPA_Oracles) = {
 }.
 
 section Probability_RP_RF.
-  declare module A <: RCPA_Adversary { PRPi, PRFi, QueryBounder }.
-  declare axiom A_run_ll (O <: RCPA_Oracles { A }): islossless O.enc => islossless A(O).distinguish.
+  declare module A <: RCPA_Adversary { -PRPi, -PRFi, -QueryBounder }.
+  declare axiom A_run_ll (O <: RCPA_Oracles { -A }): islossless O.enc => islossless A(O).distinguish.
 
   local clone PRPi_RF as RP_RFc with
     op   q    <- q * ell
@@ -745,8 +745,8 @@ section Probability_RP_RF.
 end section Probability_RP_RF.
 
 section Probability_Collision.
-  declare module A <: RCPA_Adversary { PRPi, PRFi, Compute, QueryBounder }.
-  declare axiom A_run_ll (O <: RCPA_Oracles { A }): islossless O.enc => islossless A(O).distinguish.
+  declare module A <: RCPA_Adversary { -PRPi, -PRFi, -Compute, -QueryBounder }.
+  declare axiom A_run_ll (O <: RCPA_Oracles { -A }): islossless O.enc => islossless A(O).distinguish.
 
   local clone import Birthday as BBound with
     type T  <- block,
@@ -839,8 +839,8 @@ section Probability_Collision.
   qed.
 end section Probability_Collision.
 
-lemma Conclusion (A <: RCPA_Adversary { RCPA_Wrap, PRP, PRPi, QueryBounder, PRFi (* pollution *), Compute (* pollution *) }) &m:
-  (forall (O <: RCPA_Oracles {A}), islossless O.enc => islossless A(O).distinguish) =>
+lemma Conclusion (A <: RCPA_Adversary { -RCPA_Wrap, -PRP, -PRPi, -QueryBounder, -PRFi (* pollution *), -Compute (* pollution *) }) &m:
+  (forall (O <: RCPA_Oracles {-A}), islossless O.enc => islossless A(O).distinguish) =>
      `|Pr[INDR_CPA(IV_Wrap(CBC(PseudoRP)),QueryBounder(A)).main() @ &m: res]
        - Pr[INDR_CPA(Random,QueryBounder(A)).main() @ &m: res]|
   <=    `|Pr[IND(PRP,PRPF_Adv(QueryBounder(A))).main() @ &m: res]
@@ -848,7 +848,7 @@ lemma Conclusion (A <: RCPA_Adversary { RCPA_Wrap, PRP, PRPi, QueryBounder, PRFi
       + 2%r * ((q*ell)^2)%r * mu dBlock (pred1 witness).
 proof.
 move=> A_distinguish_ll.
-have BA_distinguish_ll: (forall (O <: RCPA_Oracles { QueryBounder(A) }), islossless O.enc => islossless QueryBounder(A,O).distinguish).
+have BA_distinguish_ll: (forall (O <: RCPA_Oracles { -QueryBounder(A) }), islossless O.enc => islossless QueryBounder(A,O).distinguish).
 + move=> O O_enc_ll; proc.
   call (A_distinguish_ll (<: QueryBounder(A,O).O') _).
   + proc; sp; if.

--- a/examples/MEE-CBC/MAC_then_Pad_then_CBC.eca
+++ b/examples/MEE-CBC/MAC_then_Pad_then_CBC.eca
@@ -256,8 +256,8 @@ module Weak_PRPa (M : MAC_Scheme, A : RCPA_Adversary, P : PRP_Oracles) = {
 }.
 
 section RCPA.
-  declare module A <: RCPA_Adversary { PRPi, PRP, RCPA_Wrap, RCPA_QueryBounder, Weak_PRPa }.
-  declare axiom A_distinguish_ll (O <: RCPA_Oracles { A }):
+  declare module A <: RCPA_Adversary { -PRPi, -PRP, -RCPA_Wrap, -RCPA_QueryBounder, -Weak_PRPa }.
+  declare axiom A_distinguish_ll (O <: RCPA_Oracles { -A }):
     islossless O.enc => islossless A(O).distinguish.
 
   local clone import CBC as CBCa with
@@ -367,7 +367,7 @@ section RCPA.
        defines its own QueryCounter and QueryBounder and to make sure that
        abstract security results come in both bounded and unbounded (when
        possible) flavours. This is TODO when we rework the crypto libraries    *)
-    have PushQueryBounder: forall (O <: CBCa.SKEa.RCPA.RCPA_Oracles { A, RCPA_QueryBounder, OracleBounder, RCPA_WUF_RCPA.RCPAa }),
+    have PushQueryBounder: forall (O <: CBCa.SKEa.RCPA.RCPA_Oracles { -A, -RCPA_QueryBounder, -OracleBounder, -RCPA_WUF_RCPA.RCPAa }),
       equiv [QueryBounder(RCPAa(RCPA_WUF_RCPA.RCPAa(MAC,A)),O).distinguish
              ~ RCPAa(RCPA_WUF_RCPA.RCPAa(MAC,RCPA_QueryBounder(A)),O).distinguish
              : ={arg, glob A, glob O} ==> ={res}].
@@ -449,7 +449,7 @@ section RCPA.
     done.
   qed.
 
-  local lemma CleanupAdversary (P <: PRP { A, Weak_PRPa, OracleBounder, RCPA_WUF_RCPA.RCPAa }) &m:
+  local lemma CleanupAdversary (P <: PRP { -A, -Weak_PRPa, -OracleBounder, -RCPA_WUF_RCPA.RCPAa }) &m:
     Pr[IND(P,Weak_PRPa(MAC,A)).main() @ &m: res]
     = Pr[IND(P, PRPF_Adv(QueryBounder(RCPAa(RCPA_WUF_RCPA.RCPAa(MAC,A))))).main() @ &m : res].
   proof.
@@ -536,8 +536,8 @@ module CMAa (P : PseudoRP) (A : PTXT_Adversary) (M : CMA_Oracles) = {
 }.
 
 section PTXT.
-  declare module A <: PTXT_Adversary { WUF_Wrap, PTXT_Wrap, CMAa }.
-  declare axiom A_forge_ll (O <: PTXT_Oracles { A }):
+  declare module A <: PTXT_Adversary { -WUF_Wrap, -PTXT_Wrap, -CMAa }.
+  declare axiom A_forge_ll (O <: PTXT_Oracles { -A }):
     islossless O.enc => islossless O.verify => islossless A(O).forge.
 
   (** TODO: this is not useful apart from avoiding having to define

--- a/examples/MEE-CBC/RCPA_CMA.ec
+++ b/examples/MEE-CBC/RCPA_CMA.ec
@@ -140,9 +140,9 @@ theory MtE.
     }.
 
     section RCPA.
-      declare module E <: SKEa.Enc_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa }.
-      declare module M <: MACa.MAC_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E }.
-      declare module A <: RCPA_Adversary  { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E, M }.
+      declare module E <: SKEa.Enc_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa }.
+      declare module M <: MACa.MAC_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E }.
+      declare module A <: RCPA_Adversary  { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E, -M }.
 
       lemma RCPA_prob &m:
         Pr[INDR_CPA(MacThenEncrypt(E,M),A).main() @ &m: res]
@@ -162,9 +162,9 @@ theory MtE.
     end section RCPA.
 
     (* Adv^{IND$-CPA}_{MacThenEncrypt(E,M)}(A) = Adv^{IND$-CPA}_{E}(RCPAa(A)) *)
-    lemma RCPA_preservation (E <: SKEa.Enc_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa })
-                            (M <: MACa.MAC_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E })
-                            (A <: RCPA_Adversary  { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E, M })
+    lemma RCPA_preservation (E <: SKEa.Enc_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa })
+                            (M <: MACa.MAC_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E })
+                            (A <: RCPA_Adversary  { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E, -M })
                             &m:
       islossless M.keygen =>
       islossless M.tag    =>
@@ -221,9 +221,9 @@ theory MtE.
     }.
 
     section PTXT.
-      declare module E <: SKEa.Enc_Scheme { PTXT_Wrap, MACa.WUF_CMA.WUF_Wrap, CMAa }.
-      declare module M <: MACa.MAC_Scheme { PTXT_Wrap, MACa.WUF_CMA.WUF_Wrap, CMAa, E }.
-      declare module A <: PTXT_Adversary  { PTXT_Wrap, MACa.WUF_CMA.WUF_Wrap, CMAa, E, M }.
+      declare module E <: SKEa.Enc_Scheme { -PTXT_Wrap, -MACa.WUF_CMA.WUF_Wrap, -CMAa }.
+      declare module M <: MACa.MAC_Scheme { -PTXT_Wrap, -MACa.WUF_CMA.WUF_Wrap, -CMAa, -E }.
+      declare module A <: PTXT_Adversary  { -PTXT_Wrap, -MACa.WUF_CMA.WUF_Wrap, -CMAa, -E, -M }.
 
       (* Equivalence up to failure requires termination of oracles and adversaries *)
       declare axiom E_keygen_ll: islossless E.keygen.
@@ -234,7 +234,7 @@ theory MtE.
       declare axiom M_tag_ll   : islossless M.tag.
       declare axiom M_verify_ll: islossless M.verify.
 
-      declare axiom A_forge_ll (O <: PTXT_Oracles { A }):
+      declare axiom A_forge_ll (O <: PTXT_Oracles { -A }):
         islossless O.enc => islossless O.verify => islossless A(O).forge.
 
       (* Adv^{INT-PTXT}_{MacThenEncrypt(E,M)}(A) <= Adv^{WUF-CMA}_{M}(CMAa(E,A)) *)
@@ -434,9 +434,9 @@ theory EtM.
     }.
 
     section RCPA.
-      declare module E <: SKEa.Enc_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa }.
-      declare module M <: MACa.MAC_Scheme { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E }.
-      declare module A <: RCPA_Adversary  { RCPA_Wrap, SKEa.RCPA.RCPA_Wrap, RCPAa, E, M }.
+      declare module E <: SKEa.Enc_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa }.
+      declare module M <: MACa.MAC_Scheme { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E }.
+      declare module A <: RCPA_Adversary  { -RCPA_Wrap, -SKEa.RCPA.RCPA_Wrap, -RCPAa, -E, -M }.
 
       local lemma RCPA_prob &m:
         Pr[INDR_CPA(EtM(E,M),A).main() @ &m: res]
@@ -496,9 +496,9 @@ theory EtM.
     }.
 
     section CTXT.
-      declare module E <: SKEa.Enc_Scheme { CTXT_Wrap, MACa.SUF_CMA.SUF_Wrap, CMAa }.
-      declare module M <: MACa.MAC_Scheme { CTXT_Wrap, MACa.SUF_CMA.SUF_Wrap, CMAa, E }.
-      declare module A <: CTXT_Adversary  { CTXT_Wrap, MACa.SUF_CMA.SUF_Wrap, CMAa, E, M }.
+      declare module E <: SKEa.Enc_Scheme { -CTXT_Wrap, -MACa.SUF_CMA.SUF_Wrap, -CMAa }.
+      declare module M <:MACa.MAC_Scheme { -CTXT_Wrap, -MACa.SUF_CMA.SUF_Wrap, -CMAa, -E }.
+      declare module A <: CTXT_Adversary  { -CTXT_Wrap, -MACa.SUF_CMA.SUF_Wrap, -CMAa, -E, -M }.
 
       (* Equivalence up to failure requires termination of oracles and adversaries *)
       declare axiom E_keygen_ll: islossless E.keygen.
@@ -509,7 +509,7 @@ theory EtM.
       declare axiom M_tag_ll   : islossless M.tag.
       declare axiom M_verify_ll: islossless M.verify.
 
-      declare axiom A_forge_ll (O <: CTXT_Oracles { A }):
+      declare axiom A_forge_ll (O <: CTXT_Oracles { -A }):
         islossless O.enc => islossless O.verify => islossless A(O).forge.
 
       (* In addition, this result requires that the encryption scheme is correct,

--- a/examples/MEE-CBC/RCPA_pad.eca
+++ b/examples/MEE-CBC/RCPA_pad.eca
@@ -76,8 +76,8 @@ module RCPAa (A:RCPA_Adversary,O:CoreDefs.RCPA.RCPA_Oracles) = {
 }.
 
 section RCPA.
-  declare module S <: CoreDefs.Enc_Scheme { RCPA_Wrap, CoreDefs.RCPA.RCPA_Wrap }.
-  declare module A <: RCPA_Adversary  { RCPA_Wrap, CoreDefs.RCPA.RCPA_Wrap, S }.
+  declare module S <: CoreDefs.Enc_Scheme { -RCPA_Wrap, -CoreDefs.RCPA.RCPA_Wrap }.
+  declare module A <: RCPA_Adversary  { -RCPA_Wrap, -CoreDefs.RCPA.RCPA_Wrap, -S }.
 
   local lemma PtE_Ideal &m:
     Pr[INDR_CPA(Ideal,A).main() @ &m: res]

--- a/examples/PRG.ec
+++ b/examples/PRG.ec
@@ -184,10 +184,10 @@ module Exp'(A:Adv) = {
 
 section.
   (* Forall Adversary A that does not share memory with P or F... *)
-  declare module A <: Adv {P,F}.
+  declare module A <: Adv {-P,-F}.
 
   (* ... and whose a procedure is lossless whenever F.f and P.prg are *)
-  declare axiom AaL (F <: ARF {A}) (P <: APRG {A}):
+  declare axiom AaL (F <: ARF {-A}) (P <: APRG {-A}):
     islossless P.prg =>
     islossless F.f =>
     islossless A(F,P).a.
@@ -422,8 +422,8 @@ lemma CPprgL (A <: Adv) (F <: ARF) (P <: APRG):
   islossless C(A,F,P).CP.prg.
 proof. by move=> PprgL; proc; sp; if=> //; call PprgL; wp. qed.
 
-lemma CaL (A <: Adv {C}) (F <: ARF {A}) (P <: APRG {A}):
-  (forall (F <: ARF {A}) (P <: APRG {A}),
+lemma CaL (A <: Adv {-C}) (F <: ARF {-A}) (P <: APRG {-A}):
+  (forall (F <: ARF {-A}) (P <: APRG {-A}),
     islossless P.prg => islossless F.f => islossless A(F,P).a) =>
      islossless F.f
   => islossless P.prg
@@ -437,8 +437,8 @@ by wp.
 qed.
 
 section.
-  declare module A <: Adv {C,P,F}.
-  declare axiom AaL (F <: ARF {A}) (P <: APRG {A}):
+  declare module A <: Adv {-C,-P,-F}.
+  declare axiom AaL (F <: ARF {-A}) (P <: APRG {-A}):
     islossless P.prg =>
     islossless F.f =>
     islossless A(F,P).a.

--- a/examples/UC/MapAux.ec
+++ b/examples/UC/MapAux.ec
@@ -1,0 +1,146 @@
+(*---------------------- Auxiliary Lemmas on Maps ----------------------*)
+
+prover [""].
+
+require import AllCore SmtMap FSet StdOrder.
+import IntOrder.
+
+lemma get_none (m : ('a, 'b) fmap, x : 'a) :
+  x \notin m => m.[x] = None.
+proof. by rewrite domE. qed.
+
+lemma get_some (m : ('a, 'b) fmap, x : 'a) :
+  x \in m => m.[x] = Some (oget m.[x]).
+proof. move=> /domE; by case m.[x]. qed.
+
+lemma set_same (m : ('a, 'b) fmap, x : 'a) :
+  x \in m => m.[x <- oget m.[x]] = m.
+proof.
+move=> x_in_m.
+apply fmap_eqP => y.
+case (y = x) => [->> | ne_y_x].
+by rewrite get_set_sameE get_some.
+by rewrite get_setE ne_y_x.
+qed.
+
+lemma set_eq (m : ('a, 'b) fmap, x : 'a, y : 'b) :
+  m.[x] = Some y => m.[x <- y] = m.
+proof.
+move=> m_get_x_eq_y.
+have x_in_m : x \in m by rewrite domE m_get_x_eq_y.
+have -> : y = oget m.[x] by rewrite m_get_x_eq_y oget_some.
+by rewrite set_same.
+qed.
+
+lemma frng_set (m : ('a, 'b) fmap, x : 'a, y : 'b) :
+  frng m.[x <- y] = frng (rem m x) `|` fset1 y.
+proof.
+apply fsetP => z; rewrite in_fsetU in_fset1 2!mem_frng 2!rngE /=.
+split => [[x'] | [[x'] | ->]].
+case (x' = x) => [-> | ne_x'_x].
+by rewrite get_set_sameE /= => ->.
+rewrite get_setE ne_x'_x /= => get_x'_some_z.
+left; exists x'; by rewrite remE ne_x'_x.
+rewrite remE.
+case (x' = x) => // ne_x'_x get_x'_some_z.
+exists x'; by rewrite get_setE ne_x'_x.
+exists x; by rewrite get_set_sameE.
+qed.
+
+lemma eq_except_ne_in (x y : 'a, m1 m2 : ('a, 'b) fmap) :
+  eq_except (pred1 x) m1 m2 => y <> x =>
+  y \in m1 => y \in m2.
+proof.
+move=> /eq_exceptP @/pred1 eq_exc ne_y_x.
+by rewrite 2!domE eq_exc.
+qed.
+
+lemma eq_except_setr_as_l (m1 m2 : ('a, 'b) fmap) x:
+  x \in m1 => eq_except (pred1 x) m1 m2 =>
+  m1 = m2.[x <- oget m1.[x]].
+proof.
+rewrite eq_exceptP -fmap_eqP=> x_in_m1 eqe x'.
+rewrite get_setE /oget; case (x' = x)=> [->> |].
+by move: x_in_m1; rewrite domE; case (m1.[x]).
+by move=> ne_x'_x; rewrite eqe.
+qed.
+
+lemma eq_except_set_both x b b' (m : ('a, 'b) fmap):
+  eq_except (pred1 x) m.[x <- b] m.[x <- b'].
+proof. by rewrite eq_exceptP=> x'; rewrite /pred1 !get_setE=> ->. qed.
+
+lemma eq_except_rem (m1 m2 : ('a,'b) fmap) (X : 'a -> bool) x:
+   X x => eq_except X m1 m2 => eq_except X m1 (rem m2 x).
+proof.
+move=> X_x /eq_exceptP eq_exc; rewrite eq_exceptP=> y X_y; rewrite remE.
+case (y = x)=> [->> // | ne_y_x]; by apply eq_exc.
+qed.
+
+lemma rem_id (m : ('a, 'b) fmap, x : 'a) :
+  x \notin m => rem m x = m.
+proof.
+move=> x_notin_m; apply fmap_eqP => y; rewrite remE.
+case (y = x) => // ->.
+case (None = m.[x]) => // get_not_none.
+rewrite eq_sym -domE // in get_not_none.
+qed.
+
+lemma map_empty (f : 'a -> 'b -> 'c) :
+  map f empty = empty.
+proof. by rewrite -fmap_eqP=> x; rewrite mapE 2!emptyE. qed.
+
+lemma map_rem (f:'a -> 'b -> 'c) m x :
+  map f (rem m x) = rem (map f m) x.
+proof.
+rewrite -fmap_eqP=> z; by rewrite !(mapE,remE); case (z = x).
+qed.
+
+lemma map_id (m:('a,'b)fmap): map (fun _ b => b) m = m.
+proof. by rewrite -fmap_eqP=>x; rewrite mapE; case (m.[x]). qed.
+
+lemma le_card_frng_fdom (m : ('a, 'b) fmap) :
+  card (frng m) <= card (fdom m).
+proof.
+move: m.
+elim /fmapW=> [| m k v k_notin_m IH].
+by rewrite frng0 fdom0 2!fcards0.
+rewrite mem_fdom in k_notin_m.
+rewrite frng_set rem_id // fdom_set (fcardUI_indep _ (fset1 k))
+        1:fsetI1 1:mem_fdom 1:k_notin_m // fcard1 fcardU fcard1
+        -addzA ler_add // -{2}(addz0 1) ler_add // oppz_le0 fcard_ge0.
+qed.
+
+lemma fdom_frng_prop (X : 'a fset, m : ('a, 'a) fmap) :
+  fdom m \proper X => frng m \subset X => frng m \proper X.
+proof.
+rewrite /(\proper); move=> |>.
+case (frng m = X)=> // ^ eq_frng_m_X -> fdom_m_sub_X fdom_m_ne_X _.
+have card_fdom_m_lt_card_X : card (fdom m) < card X.
+  rewrite ltz_def; split.
+  case (card X = card (fdom m))=> // /eq_sym /subset_cardP.
+  by rewrite fdom_m_sub_X fdom_m_ne_X.
+  by rewrite subset_leq_fcard.
+have card_X_le_card_fdom_m : card X <= card (fdom m)
+  by rewrite -eq_frng_m_X le_card_frng_fdom.
+by rewrite /= -(ltzz (card X)) (ler_lt_trans (card (fdom m))).
+qed.
+
+lemma fdom_frng_prop_type (m : ('a, 'a) fmap) :
+  (exists (x : 'a), ! x \in m) =>
+  (exists (y : 'a), ! rng m y).
+proof.
+move=> [x x_notin_m].
+have : fdom m \proper fdom m `|` frng m `|` fset1 x.
+  rewrite /(\proper); split.
+  move=> z; rewrite 2!in_fsetU; move=> />.
+  case (fdom m = fdom m `|` frng m `|` fset1 x)=> // contra_eq.
+  rewrite -mem_fdom in x_notin_m.
+  have // : x \in fdom m by rewrite contra_eq 2!in_fsetU in_fset1.
+pose univ := fdom m `|` frng m `|` fset1 x.
+have fdom_prop_univ frng_sub_univ : frng m \subset univ
+  by move=> z @/univ; rewrite 2!in_fsetU; move=> />.
+have : frng m \proper univ by apply fdom_frng_prop.
+move=> /properP [_ [y [_ y_notin_frng_m]]].
+rewrite mem_frng in y_notin_frng_m.
+by exists y.
+qed.

--- a/examples/UC/RndO.ec
+++ b/examples/UC/RndO.ec
@@ -1,0 +1,824 @@
+(* -------------------------- Eager Sampling -------------------------- *)
+
+prover [""].
+
+require import Core List MapAux SmtMap FSet Distr.
+require IterProc.
+
+type flag = [ Unknown | Known ].  (* map setting known by distinguisher? *)
+
+lemma neqK_eqU f : f <> Known <=> f = Unknown.
+proof. by case: f. qed.
+
+op noflags (m : ('from, 'to * 'flag) fmap) : ('from, 'to) fmap =
+  map (fun _ (p : 'to * 'flag) => p.`1) m.
+
+op in_dom_with (m : ('from, 'to * 'flag) fmap) (x : 'from) (f : 'flag) = 
+   dom m x /\ (oget (m.[x])).`2 = f.
+
+op restr f (m : ('from, 'to * 'flag) fmap) = 
+  let m = filter (fun _ (p : 'to * 'flag) => p.`2 = f) m in
+  map (fun _ (p : 'to * 'flag) => p.`1) m.
+
+lemma restrP (m : ('from, 'to * 'flag) fmap) f x :
+  (restr f m).[x] = 
+  obind (fun (p : 'to * 'flag) => if p.`2 = f then Some p.`1 else None) m.[x].
+proof.
+  rewrite /restr /= mapE filterE /=.
+  by case (m.[x])=> //= -[x1 f'] /=; case (f' = f).
+qed.
+
+lemma dom_restr (m : ('from, 'to * 'flag) fmap) f x :
+  dom (restr f m) x <=> in_dom_with m x f. 
+proof. 
+  rewrite /in_dom_with !domE; case: (m.[x]) (restrP m f x)=> //= -[t f'] /=.
+  by rewrite /=; case (f' = f)=> [_ -> |].
+qed.
+
+lemma restr_set (m : ('from, 'to * 'flag) fmap) f1 f2 x y :
+  restr f1 m.[x <- (y, f2)] =
+  if f1 = f2 then (restr f1 m).[x <- y] else rem (restr f1 m) x.
+proof.
+  rewrite -fmap_eqP.
+  case (f1 = f2)=> [-> | Hneq] x0; rewrite !(restrP, get_setE);
+    1: by case (x = x0)=> [-> // |]; 1: rewrite (eq_sym x0);
+    1: move=> ->//.
+  case (x0 = x)=> [-> /= /= | Hnx]; 1: by rewrite (eq_sym f2) Hneq remE.
+  by rewrite remE Hnx restrP.
+qed.
+
+lemma restr_set_eq (m : ('from, 'to * 'flag) fmap) f x y :
+  restr f m.[x <- (y, f)] = (restr f m).[x <- y].
+proof. by rewrite restr_set. qed.
+
+lemma restr0 f : restr f empty<:'from, 'to * 'flag> = empty.
+proof. by apply fmap_eqP=> x; rewrite restrP !emptyE. qed.
+
+lemma restr_set_neq f2 f1 (m : ('from, 'to * 'flag) fmap) x y :
+  ! dom m x =>
+  f2 <> f1 => restr f1 m.[x <- (y, f2)] = restr f1 m.
+proof.
+  by move=> Hm Hneq;
+    rewrite restr_set (eq_sym f1) Hneq rem_id // dom_restr /in_dom_with Hm.
+qed.
+
+lemma restr_rem (m : ('from, 'to * 'flag) fmap) (x:'from) f :
+  restr f (rem m x) =
+  (if in_dom_with m x f then rem (restr f m) x else restr f m).
+proof.
+  rewrite -fmap_eqP=>z; rewrite restrP; case (in_dom_with m x f);
+  rewrite !(restrP, remE); rewrite /in_dom_with.
+  case (z = x)=> //.
+  case (z = x)=> // ->.
+  rewrite negb_and; elim=> [x_not_in_m | ne_get_m_x_2_f].
+  by rewrite (get_none m x).
+  case (m.[x] = None)=> [get_x_none | get_x_some];
+    [by rewrite get_x_none |
+     rewrite -domE in get_x_some; by rewrite get_some //= ne_get_m_x_2_f].
+qed.
+
+(* ------------------Random Oracles and Flag Random Oracles------------------ *)
+
+abstract theory Ideal.
+
+type from, to.
+
+op sampleto : from -> to distr.
+
+module type RO = {
+  proc init  ()                  : unit
+  proc get   (x : from)          : to
+  proc set   (x : from, y : to)  : unit
+  proc rem   (x : from)          : unit
+  proc sample(x : from)          : unit
+}.
+
+module type RO_Distinguisher(G : RO) = {
+  proc distinguish(): bool 
+}.
+
+module type FRO = {
+  proc init  ()                   : unit
+  proc get   (x : from)           : to
+  proc set   (x : from, y : to)   : unit
+  proc rem   (x : from)           : unit 
+  proc sample(x : from)           : unit
+  (****)
+  proc in_dom(x : from, f : flag) : bool
+  proc restrK()                   : (from, to) fmap
+}.
+
+module type FRO_Distinguisher(G : FRO) = {
+  proc distinguish(): bool 
+}.
+
+module RO : RO = {
+  var m : (from, to) fmap
+
+  proc init () = { m <- empty; }
+
+  proc get(x : from) = {
+    var r;
+    r <$ sampleto x;
+    if (! dom m x) m.[x] <- r;
+    return (oget m.[x]);
+  }
+
+  proc set(x : from, y : to) = {
+    m.[x] <- y;
+  }
+
+  proc rem(x : from) = {
+    m <- rem m x;
+  }
+
+  proc sample(x : from) = {
+    get(x);
+  }
+
+  proc restrK() = {
+    return m;
+  }
+}.
+
+module FRO : FRO = {
+  var m : (from, to * flag) fmap
+
+  proc init() = { m <- empty; }
+
+  proc get(x : from) = {
+    var r;
+    r <$ sampleto x;
+    if (dom m x) r <- (oget m.[x]).`1;
+    m.[x] <- (r, Known);
+    return r;
+  }
+
+  proc set(x : from, y : to) = {
+    m.[x] <- (y, Known);
+  }
+
+  proc rem(x : from) = {
+    m <- rem m x;
+  }
+
+  proc sample(x : from) = {
+    var c;
+    c <$ sampleto x;
+    if (! dom m x) m.[x] <- (c, Unknown);
+  }
+
+  proc in_dom(x : from, f : flag) = {
+    return in_dom_with m x f;
+  }
+
+  proc restrK() = {
+    return restr Known m;
+  }
+}.
+
+equiv RO_FRO_init : RO.init ~ FRO.init : true ==> RO.m{1} = noflags FRO.m{2}.
+proof. by proc; auto=> /=; rewrite /noflags map_empty. qed.
+
+equiv RO_FRO_get : RO.get ~ FRO.get :
+   ={x} /\ RO.m{1} = noflags FRO.m{2} ==> ={res} /\ RO.m{1} = noflags FRO.m{2}.
+proof.
+  proc; auto=> &1 &2 [] 2!-> /= ? -> /=.
+  rewrite /noflags mem_map !map_set /fst /= get_set_sameE oget_some => |>; progress.
+  + by rewrite mapE oget_omap_some 1:-domE.
+  + by rewrite eq_sym set_eq 1:mapE /= 1:get_some.
+qed.
+
+equiv RO_FRO_set : RO.set ~ FRO.set :
+   ={x, y} /\ RO.m{1} = noflags FRO.m{2} ==> RO.m{1} = noflags FRO.m{2}.
+proof. by proc; auto=> &1 &2 [#] 3->; rewrite /noflags map_set. qed.
+
+equiv RO_FRO_rem : RO.rem ~ FRO.rem :
+   ={x} /\ RO.m{1} = noflags FRO.m{2} ==> RO.m{1} = noflags FRO.m{2}.
+proof. by proc; auto=> ? ?; rewrite /noflags map_rem. qed.
+
+equiv RO_FRO_sample : RO.sample ~ FRO.sample :
+   ={x} /\ RO.m{1} = noflags FRO.m{2} ==> RO.m{1} = noflags FRO.m{2}.
+proof. 
+  by proc; inline *; auto=> &1 &2 [] 2!-> /= ? ->; rewrite /noflags mem_map map_set.
+qed.
+
+lemma RO_FRO_D (D <: RO_Distinguisher{-RO, -FRO}) :
+  equiv [D(RO).distinguish ~ D(FRO).distinguish : 
+         ={glob D} /\ RO.m{1} = noflags FRO.m{2} ==>
+         ={res, glob D} /\ RO.m{1} = noflags FRO.m{2}].
+proof.
+  proc (RO.m{1} = noflags FRO.m{2})=> //.
+  + by conseq RO_FRO_init. + by conseq RO_FRO_get. + by conseq RO_FRO_set. 
+  + by conseq RO_FRO_rem. + by conseq RO_FRO_sample.
+qed.
+
+section LL. 
+
+lemma RO_init_ll : islossless RO.init.
+proof. by proc; auto. qed.
+
+lemma FRO_init_ll : islossless FRO.init.
+proof. by proc; auto. qed.
+
+lemma FRO_in_dom_ll : islossless FRO.in_dom.
+proof. by proc. qed.
+
+lemma FRO_restrK_ll : islossless FRO.restrK.
+proof. by proc. qed.
+
+lemma RO_set_ll : islossless RO.set.
+proof. by proc; auto. qed.
+
+lemma FRO_set_ll : islossless FRO.set.
+proof. by proc; auto. qed.
+
+axiom sampleto_ll : forall x, Distr.weight (sampleto x) = 1%r.
+
+lemma RO_get_ll : islossless RO.get.
+proof. by proc; auto; progress; apply sampleto_ll. qed.
+
+lemma FRO_get_ll : islossless FRO.get.
+proof. by proc; auto; progress; apply sampleto_ll. qed.
+
+lemma RO_sample_ll : islossless RO.sample.
+proof. by proc; call RO_get_ll. qed.
+
+lemma FRO_sample_ll : islossless FRO.sample.
+proof. by proc; auto; progress; apply sampleto_ll. qed.
+
+end section LL.
+ 
+end Ideal.
+
+(* -------------------------------------------------------------------------- *)
+
+abstract theory GenEager.
+
+clone include Ideal. 
+
+clone include IterProc with type t <- from.
+
+(* RRO is an FRO that resamples a query if the associated value is
+   unknown; it also has a resample procedure that resamples all
+   queries whose results are unknown
+
+   uses the map of FRO *)
+
+module RRO : FRO = {
+  proc init = FRO.init
+
+  proc get(x : from) = {
+    var r;
+    r <$ sampleto x;
+    if (! dom FRO.m x || (oget FRO.m.[x]).`2 = Unknown) {
+      FRO.m.[x] <- (r, Known);
+    }
+    return (oget FRO.m.[x]).`1;
+  }
+
+  proc set = FRO.set 
+
+  proc rem = FRO.rem
+
+  proc sample = FRO.sample
+
+  proc in_dom = FRO.in_dom
+
+  proc restrK = FRO.restrK
+
+  module I = {
+    proc f(x : from) = {
+      var c;
+      c <$ sampleto x;
+      FRO.m.[x] <- (c, Unknown);
+    }
+  }
+
+  proc resample () = {
+    Iter(I).iter (elems (fdom (restr Unknown FRO.m)));
+  }
+}.
+
+(* LRO is an RO whose sample procedure is lazy, i.e., does nothing
+
+   uses the map of RO *)
+
+module LRO : RO = {
+  proc init = RO.init
+
+  proc get = RO.get
+
+  proc set = RO.set 
+
+  proc rem = RO.rem
+
+  proc sample(x : from) = {}
+}.
+
+lemma RRO_resample_ll : islossless RRO.resample.
+proof. 
+  proc; call (iter_ll RRO.I _)=> //; proc; auto=> /= ?;
+    by split; first apply sampleto_ll. 
+qed.
+
+(* now we use the eager tactics to show a series of lemmas
+   of the form
+
+    eager [RRO.resample();, FRO.<proc> ~ RRO.<proc>, RRO.resample(); :
+           ={?<arg>, FRO.m} ==> ={?res, FRO.m}].
+
+   where <proc> ranges over init, get, set, rem, sample, in_dom and
+   restrK *)
+
+lemma eager_init :
+  eager [RRO.resample();, FRO.init ~ RRO.init, RRO.resample(); :
+         ={FRO.m} ==> ={FRO.m}].
+proof.
+  eager proc. inline{2} *; rcondf{2} 3; auto=> /=.
+  + by move=> ? _; rewrite restr0 fdom0 elems_fset0.
+  + by conseq _ (_ : true ==> true: = 1%r) _ => //; call RRO_resample_ll.
+qed.
+
+lemma iter_perm2 :
+  equiv [Iter(RRO.I).iter_12 ~ Iter(RRO.I).iter_21 :
+         ={glob RRO.I, t1, t2} ==> ={glob RRO.I}].
+proof.
+  proc; inline *; case ((t1 = t2){1}); 1:by auto.
+  * by swap{2} [4..5] -3; auto=> &ml &mr [#] 3-> neq /= ? -> ? ->;
+    rewrite set_setE (eq_sym t2{mr}) neq.
+qed.
+
+equiv I_f_neq x1 mx1 : RRO.I.f ~ RRO.I.f :
+    ={x, FRO.m} /\ x1 <> x{1} /\ FRO.m{1}.[x1] = mx1 ==>
+    ={FRO.m} /\ FRO.m{1}.[x1] = mx1.
+proof.
+  by proc; auto=> ? &mr [#] 2-> Hneq Heq /= ? ->; rewrite get_setE Hneq.
+qed.
+
+equiv I_f_eqex x1 mx1 mx2 : RRO.I.f ~ RRO.I.f :
+    ={x} /\ x1 <> x{1} /\ eq_except (pred1 x1) FRO.m{1} FRO.m{2} /\
+    FRO.m{1}.[x1] = mx1 /\ FRO.m{2}.[x1] = mx2 ==>
+    eq_except (pred1 x1) FRO.m{1} FRO.m{2} /\
+    FRO.m{1}.[x1] = mx1 /\ FRO.m{2}.[x1] = mx2.
+proof.
+  by proc; auto=> ? &mr [#] -> Hneq Heq /= Heq1 Heq2 ? -> /=;
+    rewrite !get_setE Hneq eq_except_set_eq.
+qed.
+
+equiv I_f_set x1 r1 : RRO.I.f ~ RRO.I.f :
+  ={x} /\ x1 <> x{1} /\ FRO.m{1}.[x1] = None /\
+  FRO.m{2} = FRO.m{1}.[x1 <- (r1, Known)] ==>
+  FRO.m{1}.[x1] = None /\ FRO.m{2} = FRO.m{1}.[x1 <- (r1, Known)].
+proof.
+  by proc; auto=> ? &mr [#] -> Hneq H1 -> /= ? ->;
+    rewrite get_setE Hneq/= set_setE (eq_sym _ x1) Hneq.
+qed.
+
+lemma eager_get :
+  eager [RRO.resample();, FRO.get ~ RRO.get, RRO.resample(); :
+         ={x, FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc.
+  wp; case ((dom FRO.m x /\ (oget FRO.m.[x]).`2=Known){1}).
+  + rnd{1}; rcondf{2} 2; 1: by auto => /> _ ->.
+    exists* x{1}, ((oget FRO.m.[x{2}]){1}); elim*=> x1 mx; inline RRO.resample.
+    call (iter_inv RRO.I (fun z=> x1<>z)
+                   (fun o1 o2 => o1 = o2 /\ o1.[x1]= Some mx) _)=> /=.
+    + by conseq (I_f_neq x1 (Some mx))=> //.
+    auto=> ? &mr [#] 4-> Hd Hget; split; first apply sampleto_ll.
+    move=> /= _ ? _; split.
+    + rewrite get_some // oget_some /= => z; rewrite -memE mem_fdom dom_restr
+              /in_dom_with;
+        case (x{mr} = z)=> [<- | //]; by rewrite Hget.
+    move=> [#] _ Heq ? mr [#] -> Heq'.
+    split=> [| _ r _]; first apply sampleto_ll.
+    by rewrite domE Heq' oget_some /= set_eq 1:Heq'
+               1:{1}(pairS (oget FRO.m{mr}.[x{mr}])) 1:Hget.
+  case ((dom FRO.m x){1}).
+  + inline{1} RRO.resample=> /=; rnd{1}.
+    transitivity{1} 
+      { Iter(RRO.I).iter_1s(x, elems ((fdom (restr Unknown FRO.m)) `\` fset1 x)); }
+      (={x, FRO.m} /\ dom FRO.m{1} x{1} /\ (oget FRO.m{1}.[x{1}]).`2 = Unknown ==>
+       ={x, FRO.m})
+      (={x, FRO.m} /\ dom FRO.m{1} x{1} /\ (oget FRO.m{1}.[x{1}]).`2 = Unknown ==>
+       ={x} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+       FRO.m{1}.[x{2}] = Some (result{2}, Unknown) /\
+       FRO.m{2}.[x{2}] = Some (result{2}, Known)).
+    + move=> ? &mr [#] -> -> /negb_and [] // H1 H2; exists FRO.m{mr} x{mr};
+      move=> />; by rewrite -neqK_eqU.
+    + move=> ? ? ?; rewrite domE=> [#] <*> [#] -> /eq_except_sym H Hxm Hx2.
+      split=> [| _ r _]; first apply sampleto_ll.
+      rewrite /= Hxm oget_some /= ; apply /eq_sym.
+      have /(congr1 oget) /= <- := Hx2; apply eq_except_setr_as_l=> //.
+      by rewrite domE Hx2.
+    + symmetry; call (iter1_perm RRO.I iter_perm2).
+      skip=> &1 &2 [[->> ->>]] [Hdom Hm]; split=> //=.
+      by apply /perm_eq_sym/perm_to_rem/mem_fdom/dom_restr;
+        rewrite /in_dom_with Hdom Hm.      
+    inline Iter(RRO.I).iter_1s RRO.I.f RRO.resample.
+    seq 5 3 : (={x} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+               (l = elems(fdom (restr Unknown FRO.m) `\` fset1 x)){1} /\
+               FRO.m{1}.[x{2}] = Some (result{2}, Unknown) /\
+               FRO.m{2}.[x{2}] = Some (result{2}, Known)).
+    + auto=> ? &mr [#] 2-> /= ^Hdom -> ^Hget -> ? -> /=.
+      by rewrite !get_setE /= !restr_set /= fdom_set
+                 eq_except_set_both fsetDK.
+    exists* x{1}, FRO.m{1}.[x{2}], FRO.m{2}.[x{2}]; elim*=> x1 mx1 mx2.
+    call (iter_inv RRO.I (fun z => x1 <> z) 
+           (fun o1 o2 =>
+              eq_except (pred1 x1) o1 o2 /\ o1.[x1] = mx1 /\ o2.[x1] = mx2) 
+           (I_f_eqex x1 mx1 mx2)); auto=> /> &1 &2 eq_exc get1_x2 get2_x2.
+      split. split=> [| x2].
+      congr; rewrite fsetP=> y; rewrite in_fsetD1 2!mem_fdom.
+      case (y = x1)=> [->/= | ne_y_x2 /=].
+      by rewrite dom_restr /in_dom_with get2_x2.
+      rewrite 2!dom_restr /in_dom_with; rewrite eq_exceptP in eq_exc.
+      have ^ get_y_eq -> := eq_exc y _. by rewrite /pred1.
+      split=> />; by rewrite !domE get_y_eq.
+      by rewrite -memE in_fsetD1 eq_sym.
+      by rewrite get1_x2 get2_x2.
+  swap{1} -1; seq 1 1 : (={r, x, FRO.m} /\ ! dom FRO.m{1} x{1}); 1:by auto. 
+  inline RRO.resample; exists* x{1},r{1}; elim*=> x1 r1.
+  call (iter_inv RRO.I (fun z=> x1<>z) 
+           (fun o1 o2 => o1.[x1] = None /\ o2 = o1.[x1 <- (r1, Known)])
+           (I_f_set x1 r1)); auto.
+    move=> ? &mr [#] 5-> ^ Hnin ^ + -> /=; rewrite domE=> /= -> /=;
+    rewrite get_setE /=; split=> [| _]. split=> [| y].
+    congr; rewrite fsetP=> y;
+      rewrite 2!mem_fdom 2!dom_restr /in_dom_with mem_set get_setE.
+    case (y = x{mr})=> // ->;
+      rewrite Hnin // -memE mem_fdom dom_restr /in_dom_with.
+    rewrite -memE mem_fdom dom_restr /in_dom_with;
+      case (x{mr} = y)=> [<- [#] // | //].
+    move=> /> m_L; by rewrite domE.
+qed.
+
+lemma eager_set :
+  eager [RRO.resample();, FRO.set ~ RRO.set, RRO.resample(); :
+         ={x, y} /\ ={FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc.
+  inline RRO.resample=> /=; wp.
+  case ((dom FRO.m x /\ (oget FRO.m.[x]).`2 = Unknown){1}).
+  + transitivity{1}
+      { Iter(RRO.I).iter_1s(x, elems (fdom (restr Unknown FRO.m) `\` fset1 x)); }
+      (={x, y, FRO.m} /\ dom FRO.m{1} x{1} /\
+       (oget FRO.m{1}.[x{1}]).`2 = Unknown ==>
+       ={x, y, FRO.m})
+      (={x, y, FRO.m} /\ dom FRO.m{1} x{1} /\
+       (oget FRO.m{1}.[x{1}]).`2 = Unknown ==>
+       ={x, y} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+       FRO.m{2}.[x{2}] = Some (y{2},Known)).
+    + by move=> &ml &mr [#] 3-> x_in_m get_m_x_2_unk;
+        exists FRO.m{mr} x{mr} y{mr}.
+    + move=> ? &m &mr [#] <*> [#] 2-> Hex Hm2.
+      by rewrite (eq_except_setr_as_l FRO.m{mr} FRO.m{m} x{mr}) ?in_dom ?Hm2 //
+         1:domE 1:Hm2 // eq_except_sym.
+    + symmetry; call (iter1_perm RRO.I iter_perm2); auto=> ? &mr [#] 3 -> Hdom Hm;
+      split=> //=.
+      by apply /perm_eq_sym/perm_to_rem/mem_fdom/dom_restr; rewrite /in_dom_with Hdom.
+    inline{1} Iter(RRO.I).iter_1s. 
+    seq 3 1 :
+      (={x, y} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+       l{1} = (elems (fdom (restr Unknown FRO.m))){2} /\ !mem l{1} x{1} /\
+       (FRO.m.[x] = Some (y, Known)){2}).
+    + inline *; auto=> ? &mr [#] 3-> /= Hmem Hget.
+      split=> [|_ c _]; first apply sampleto_ll.
+      by rewrite (eq_except_set_both _ (c, Unknown)) get_set_sameE restr_set /=
+                 fdom_rem /= -memE in_fsetD1.
+    exists* x{1}, y{1}, (FRO.m.[x]{1}); elim*=> x1 y1 mx1;
+      pose mx2 := Some (y1, Known).
+    call (iter_inv RRO.I (fun z=> x1<>z) 
+           (fun o1 o2 => eq_except (pred1 x1) o1 o2 /\ o1.[x1] = mx1 /\
+                         o2.[x1] = mx2) 
+           (I_f_eqex x1 mx1 mx2));
+        auto=> &1 &2 /> eq_exc not_x2_in_unkn_m2 get_m2_x2_eq.
+      by move=> x0; rewrite -memE mem_fdom dom_restr /in_dom_with;
+        case (x{2} = x0)=> // <-; rewrite get_m2_x2_eq.
+  exists* x{1}, y{1}, (FRO.m.[x]{1}); elim*=> x1 y1 mx1;
+    pose mx2 := Some (y1, Known).
+  call (iter_inv RRO.I (fun z=> x1<>z) 
+         (fun o1 o2 => eq_except (pred1 x1) o1 o2 /\ o1.[x1] = mx1 /\
+                       o2.[x1] = mx2) 
+         (I_f_eqex x1 mx1 mx2))=> /=; auto=> &1 &2 /> /negb_and x2_disj.
+    split=> [| _ _ _ _ m_L m_R eq_exc m_L_x2_eq m_R_x2_eq].
+    split.
+    congr; rewrite fsetP=> z; rewrite 2!mem_fdom 2!dom_restr /in_dom_with mem_set.
+    case (z = x{2})=> [-> /=| ne_z_x2 /=].
+    by rewrite get_set_sameE oget_some /= negb_and.
+    by rewrite get_setE ne_z_x2.
+    split=> [x0 |].
+    rewrite -memE mem_fdom dom_restr /in_dom_with.
+    case (x{2} = x0)=> [<- [#] | //]; by elim x2_disj.
+    rewrite get_set_sameE /mx2 /= eq_except_setr.
+    rewrite -fmap_eqP=> z; rewrite get_setE; case (z = x{2})=> [-> |].
+    by rewrite m_R_x2_eq.
+    move=> ne_z_x2; rewrite eq_exceptP in eq_exc; by rewrite eq_exc /pred1.
+qed.
+
+lemma eager_rem :
+  eager [RRO.resample();, FRO.rem ~ RRO.rem, RRO.resample(); :
+         ={x} /\ ={FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc; case ((in_dom_with FRO.m x Unknown){1}).
+  + inline RRO.resample; wp.
+    transitivity{1} 
+      { Iter(RRO.I).iter_1s(x, elems (fdom (restr Unknown FRO.m) `\` fset1 x)); }
+      (={x, FRO.m} /\ (in_dom_with FRO.m x Unknown){1}==> ={x, FRO.m}) 
+      (={x, FRO.m} /\ (in_dom_with FRO.m x Unknown){1} ==>
+       (rem FRO.m x){1} = FRO.m{2})=> //.
+    + by move=> ? &mr [#] 2-> ?; exists FRO.m{mr} x{mr}.   
+    + symmetry; call (iter1_perm RRO.I iter_perm2);
+        skip=> ? &mr [#] 2! -> ? /=; split=> //.
+      by apply /perm_eq_sym /perm_to_rem /mem_fdom /dom_restr. 
+    inline{1} Iter(RRO.I).iter_1s.
+    seq 3 1: (={x} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+              l{1} = (elems (fdom (restr Unknown FRO.m))){2} /\ !mem l{1} x{1} /\
+              (FRO.m.[x] = None){2}).
+    + inline *; auto=> &1 &2 [#] 2-> Hidm /=.
+      split=> [| _ c _]; first apply sampleto_ll.
+      rewrite (eq_except_rem _ FRO.m{2} (pred1 x{2}) x{2}) /pred1 //
+              1:eq_except_setl /= remE -memE in_fsetD1 negb_and /=
+              restr_rem Hidm /=.
+      congr; by rewrite fdom_rem.
+    exists* x{1}, (FRO.m.[x]{1}); elim*=> x1 mx1.
+    call (iter_inv RRO.I (fun z=> x1<>z) 
+         (fun o1 o2 => eq_except (pred1 x1) o1 o2 /\ o1.[x1] = mx1 /\
+                       o2.[x1] = None) _).
+    + by conseq (I_f_eqex x1 mx1 None).
+    auto=> &1 &2 [#] 3-> Hex -> Hx -> /=.
+    split=> [ | _ mL mR [#] /eq_exceptP Hex' ? Heq].
+    move=> /> z.
+    rewrite -memE mem_fdom dom_restr /in_dom_with.
+    rewrite -memE mem_fdom dom_restr /in_dom_with in Hx.
+    case (x{2} = z) => [<- // | //].
+    apply fmap_eqP=> z; rewrite remE; case (z = x{2})=> [-> /= | Hneq];
+      [by rewrite Heq | by apply Hex'].
+  inline RRO.resample; wp.
+  exists *x{1}, (FRO.m.[x]{1}); elim*=> x1 mx1.
+  call (iter_inv RRO.I (fun z=> x1<>z) 
+         (fun o1 o2 => eq_except (pred1 x1) o1 o2 /\ o1.[x1] = mx1 /\
+                       o2.[x1]=None) _).
+  + by conseq (I_f_eqex x1 mx1 None).
+  auto=> ? &mr [#] 4-> /= Hin; rewrite restr_rem Hin /= remE.
+  split=> [| _ m_L m_R [#] Heqx m_L_x m_R_x]. split=> [z |].
+  rewrite -memE mem_fdom dom_restr /in_dom_with.
+  rewrite /in_dom_with in Hin.
+  case (x{mr} = z) => [<- // | //].
+  split=> //; rewrite eq_except_rem //.
+  rewrite -fmap_eqP=> z; rewrite remE.
+  case (z = x{mr})=> [-> | ne_z_xmr];
+    [by rewrite m_R_x |
+     by rewrite eq_exceptP in Heqx; rewrite Heqx /pred1].
+qed.
+
+lemma eager_sample :
+  eager [RRO.resample();, FRO.sample ~ RRO.sample, RRO.resample(); :
+         ={x, FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc.
+  case (! dom (FRO.m{2}) x{2}).
+  + rcondt{2} 2 ; 1:by auto.
+    transitivity{2}
+      { c <$ sampleto x; FRO.m.[x] <- (c, Unknown);
+        Iter(RRO.I).iter_1s(x, elems ((fdom (restr Unknown FRO.m)) `\` fset1 x)); }
+      (={x, FRO.m} /\ ! dom FRO.m{2} x{2} ==> ={x, FRO.m}) 
+      (={x, FRO.m} /\ ! dom FRO.m{2} x{2} ==> ={x, FRO.m})=>//; last first.
+    + inline{2} RRO.resample; call (iter1_perm RRO.I iter_perm2);
+        auto=> |> &2 Hmem ??.
+      by apply /perm_eq_sym /perm_to_rem; rewrite restr_set /= mem_fdom mem_set.
+    + by move=> ? &mr [#] 2-> ?; exists FRO.m{mr} x{mr}.
+    inline Iter(RRO.I).iter_1s RRO.I.f RRO.resample; wp; swap{1} -1.
+    seq 1 7 : (={x} /\ eq_except (pred1 x{1}) FRO.m{1} FRO.m{2} /\
+               l{2} = (elems (fdom (restr Unknown FRO.m))){1} /\
+               (FRO.m.[x]){2} = Some (c{1}, Unknown) /\ (FRO.m.[x]){1} = None).
+    + wp; rnd; auto=> ? &mr [#] 2->; rewrite domE /=.
+      move=> Heq; split; first apply sampleto_ll.
+      move=> _ c _ cL ?; split=> // _.
+      rewrite get_set_sameE restr_set /=.
+      split; first rewrite set_set_sameE eq_except_setr.
+      split=> //.
+      congr; rewrite fsetP=> z;
+        rewrite in_fsetD1 !mem_fdom  mem_set !dom_restr /in_dom_with.
+      case (z = x{mr})=> [-> | //]; by rewrite domE Heq.
+    exists* x{1}, c{1}; elim*=> x1 c1; pose mx2 := Some (c1, Unknown).
+    call (iter_inv RRO.I (fun z=> x1<>z) 
+         (fun o1 o2 => eq_except (pred1 x1) o1 o2 /\ o1.[x1]= None /\
+                       o2.[x1]=mx2) _).
+    + by conseq (I_f_eqex x1 None mx2).
+    auto=> ? &mr [#] 2<- -> Hex 2!-> ^ Hx1 -> /=.
+    split. split.
+    move=> z; rewrite -memE mem_fdom dom_restr /in_dom_with.
+    case (x{mr} = z)=> [<- [#] | //]; by rewrite domE.
+    split=> //.
+    move=> _ m_L m_R [#] Hex' m_L_x m_R_x.
+    case (x{mr} \in m_L)=> [x_in /= | x_not_in /=].
+    rewrite -fmap_eqP=> z.
+    case (z = x{mr})=> [| ne_z_xmr].
+    by rewrite domE in x_in.
+    rewrite eq_exceptP in Hex'; rewrite Hex'.
+    by rewrite /pred1.
+    by rewrite domE // in x_in.
+    rewrite -fmap_eqP=> z.
+    case (z = x{mr})=> [-> | ne_z_xmr].
+    by rewrite get_set_sameE m_R_x /mx2.
+    rewrite get_setE ne_z_xmr /=.
+    rewrite eq_exceptP in Hex'.
+    by rewrite Hex' /pred1.
+  rcondf{2} 2; 1:by auto. 
+  swap{1} 2 -1; inline*; auto.
+  while (={l, FRO.m} /\ (dom FRO.m x){1}); auto.
+  move=> ?&mr [#] 2-> Hm Hl _ /= ? ->; rewrite -mem_fdom fdom_set in_fsetU.
+  left; by rewrite mem_fdom.
+qed.
+
+lemma eager_in_dom :
+  eager [RRO.resample();, FRO.in_dom ~ RRO.in_dom, RRO.resample(); :
+         ={x, f} /\ ={FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc; inline *; wp.
+  while (={l, FRO.m} /\ (forall z, mem l z => in_dom_with FRO.m z Unknown){1} /\
+         in_dom_with FRO.m{1} x{1} f{1} = result{2}).
+  + auto=> &1 &2 [#] 2-> Hz <- l2_nonemp _ /= ? -> /=. 
+    split=>[z /mem_drop Hm |].
+    rewrite /in_dom_with mem_set get_setE;
+      case (z = head witness l{2})=> [-> //= | ne /=].
+    by rewrite /in_dom_with in Hz; rewrite Hz.
+    rewrite /in_dom_with mem_set get_setE.
+    case (x{1} = head witness l{2})=> [-> /= | //].
+    rewrite /=; rewrite /in_dom_with in Hz.
+    have [# -> -> //] :
+      (head witness l{2} \in FRO.m{2}) /\
+      (oget FRO.m{2}.[head witness l{2}]).`2 = Unknown
+      by rewrite (Hz (head witness l{2}))
+         -(mem_head_behead witness l{2} l2_nonemp (head witness l{2})); left.
+  by auto=> ? &mr /= [#] 3-> /=; split=>// z; rewrite -memE mem_fdom dom_restr. 
+qed.
+
+lemma eager_restrK :
+  eager [RRO.resample();, FRO.restrK ~ RRO.restrK, RRO.resample(); :
+         ={FRO.m} ==> ={res, FRO.m}].
+proof.
+  eager proc; inline *; wp.
+  while (={l, FRO.m} /\ (forall z, mem l z => in_dom_with FRO.m z Unknown){1} /\
+         restr Known FRO.m{1} = result{2}).
+  + auto=> |> &2 Hz l2_nonemp ? /= ?.
+    split=>[z /mem_drop Hm |];1:rewrite /in_dom_with mem_set get_setE.
+    case (z = head witness l{2})=> [-> //= | ne /=]; 1: by apply Hz.
+    rewrite restr_set rem_id ?dom_restr //.
+    by move: l2_nonemp=> /(mem_head_behead witness) /(_ (head witness l{2}))
+                         /= /Hz @/in_dom_with />;
+       rewrite neqK_eqU.
+  by auto=> ? &mr /= -> /=; split=> // z; rewrite -memE mem_fdom dom_restr. 
+qed.
+
+section.
+
+declare module D <: FRO_Distinguisher {-FRO}.
+
+lemma eager_D :
+  eager [RRO.resample();, D(FRO).distinguish ~ 
+         D(RRO).distinguish, RRO.resample(); :
+         ={glob D, FRO.m} ==> ={FRO.m, glob D} /\ ={res}].
+proof.
+  eager proc (H_: RRO.resample(); ~ RRO.resample();: ={FRO.m} ==> ={FRO.m})
+             (={FRO.m}) =>//; try by sim.
+  + by apply eager_init. + by apply eager_get. + by apply eager_set. 
+  + by apply eager_rem. + by apply eager_sample. 
+  + by apply eager_in_dom. + by apply eager_restrK. 
+qed.
+
+module Eager (D : FRO_Distinguisher) = {
+  proc main1() = {
+    var b;
+    FRO.init();
+    b <@ D(FRO).distinguish();
+    return b;
+  }
+
+  proc main2() = {
+    var b;
+    FRO.init();
+    b <@ D(RRO).distinguish();
+    RRO.resample();
+    return b;
+  }
+}.
+
+equiv Eager_1_2 : Eager(D).main1 ~ Eager(D).main2 :
+  ={glob D} ==> ={res, glob FRO, glob D}.
+proof.
+  proc.
+  transitivity{1} 
+    { FRO.init(); RRO.resample(); b <@ D(FRO).distinguish(); }
+    (={glob D} ==> ={b, FRO.m, glob D})
+    (={glob D} ==> ={b, FRO.m, glob D})=> //.
+  + by move=> ? &mr ->; exists (glob D){mr}.
+  + inline *; rcondf{2} 3; 2:by sim.
+    by auto=> ?; rewrite restr0 fdom0 elems_fset0.
+  seq 1 1 : (={glob D, FRO.m}); 1:by inline *; auto.
+  by eager call eager_D. 
+qed.
+
+end section.
+
+(* now we show we can move from LRO to RRO as long as their maps agree
+   on known (in RRO) settings *)
+
+equiv LRO_RRO_init : LRO.init ~ RRO.init : true ==> RO.m{1} = restr Known FRO.m{2}.
+proof. by proc; auto=> /=; rewrite restr0. qed.
+
+equiv LRO_RRO_get : LRO.get ~ RRO.get :
+   ={x} /\ RO.m{1} = restr Known FRO.m{2} ==>
+   ={res} /\ RO.m{1} = restr Known FRO.m{2}.
+proof. 
+  proc; auto=> ? &ml [] -> -> /= ? -> /=.
+  rewrite dom_restr orabP negb_and neqK_eqU.
+  rewrite !restr_set /= !get_set_sameE oget_some; progress.
+  move: H; rewrite negb_or /= restrP domE.
+  by move=> [/some_oget -> /=]; rewrite -neqK_eqU /= => ->.
+qed.
+
+equiv LRO_RRO_set : LRO.set ~ RRO.set :
+   ={x, y} /\ RO.m{1} = restr Known FRO.m{2} ==> RO.m{1} = restr Known FRO.m{2}.
+proof. by proc; auto=> ? &ml [#] 3->; rewrite restr_set. qed.
+
+equiv LRO_RRO_rem : LRO.rem ~ RRO.rem :
+   ={x} /\ RO.m{1} = restr Known FRO.m{2} ==> RO.m{1} = restr Known FRO.m{2}.
+proof. 
+  proc; inline *; auto=> ? &mr [#] -> ->. rewrite restr_rem.
+  case (in_dom_with FRO.m{mr} x{mr} Known)=>// Hidw.
+  by rewrite rem_id // dom_restr.
+qed.
+
+equiv LRO_RRO_sample : LRO.sample ~ RRO.sample :
+   ={x} /\ RO.m{1} = restr Known FRO.m{2} ==> RO.m{1} = restr Known FRO.m{2}.
+proof. 
+  proc; auto=> ? &ml [] _ ->.
+  split=> [| _ ? _]; first apply sampleto_ll.
+  rewrite restr_set /==> Hnd. 
+  by rewrite rem_id // dom_restr /in_dom_with Hnd.
+qed.
+
+lemma LRO_RRO_D (D <: RO_Distinguisher{-RO, -FRO}) :
+  equiv [D(LRO).distinguish ~ D(RRO).distinguish : 
+         ={glob D} /\ RO.m{1} = restr Known FRO.m{2} ==>
+         ={res, glob D} /\ RO.m{1} = restr Known FRO.m{2}].
+proof.
+  proc (RO.m{1} = restr Known FRO.m{2})=> //.
+  + by conseq LRO_RRO_init. + by conseq LRO_RRO_get. + by conseq LRO_RRO_set.
+  + by conseq LRO_RRO_rem. + by conseq LRO_RRO_sample. 
+qed.
+
+section.
+
+declare module D <: RO_Distinguisher{-RO, -FRO}.
+
+local module M = {
+  proc main1() = {
+    var b;
+    RRO.resample();
+    b <@ D(FRO).distinguish();
+    return b;
+  }
+  
+  proc main2() = {
+    var b;
+    b <@ D(RRO).distinguish();
+    RRO.resample();
+    return b;
+  }
+}.
+
+lemma RO_LRO_D :
+  equiv [D(RO).distinguish ~ D(LRO).distinguish :
+         ={glob D, RO.m} ==> ={res, glob D}].
+proof.
+  transitivity M.main1 
+     (={glob D} /\ FRO.m{2} = map (fun _ c => (c, Known)) RO.m{1} ==>
+        ={res, glob D})
+     (={glob D} /\ FRO.m{1} = map (fun _ c => (c, Known)) RO.m{2} ==>
+        ={res, glob D})=> //.
+  + by move=> ? &mr [] 2!->;
+      exists (glob D){mr} (map (fun _ c =>(c, Known)) RO.m{mr}).
+  + proc*; inline M.main1; wp; call (RO_FRO_D D); inline *; rcondf{2} 2; auto.
+    + move=> &mr [] _ ->; apply mem_eq0=> z;
+        rewrite -memE mem_fdom dom_restr /in_dom_with mapE mem_map domE.
+     by case (RO.m{m}.[_]).
+     by move=> ? &mr [] 2!-> /=; rewrite /noflags map_comp /fst /= map_id.
+  transitivity M.main2
+     (={glob D, FRO.m} ==> ={res, glob D})
+     (={glob D} /\ FRO.m{1} = map (fun _ c => (c, Known)) RO.m{2} ==>
+        ={res, glob D})=>//.
+  + by move=> ? &mr [] 2!->;
+      exists (glob D){mr} (map(fun _ c =>(c, Known)) RO.m{mr}).
+  + by proc; eager call (eager_D D); auto.
+  proc*; inline M.main2; wp; call{1} RRO_resample_ll. 
+  symmetry; call (LRO_RRO_D D); auto=> &ml &mr [#] 2->; split=> //=.
+  by rewrite -fmap_eqP=> x; rewrite restrP mapE; case (RO.m{ml}.[x]).
+qed.
+
+end section.
+
+end GenEager.

--- a/examples/UC/composition_cost.ec
+++ b/examples/UC/composition_cost.ec
@@ -1,0 +1,1774 @@
+require import AllCore Real Distr.
+require import CHoareTactic.
+import StdBigop Bigint BIA.
+
+type ('a, 'b) sum = [
+  | Left of 'a
+  | Right of 'b
+].
+
+op getl (s:('a, 'b) sum) = 
+  with s = Left a  => Some a
+  with s = Right _ => None.
+
+op getr (s:('a, 'b) sum) = 
+  with s = Left a  => None
+  with s = Right b => Some b.
+
+schema cost_getl ['a 'b] `{P} {s:('a, 'b) sum} : cost[P:getl s] = N 2 + cost[P:s].
+schema cost_getr ['a 'b] `{P} {s:('a, 'b) sum} : cost[P:getr s] = N 2 + cost[P:s].
+hint simplify cost_getl, cost_getr.
+
+op smap (fa:'a -> 'c) (fb:'b -> 'd) (s: ('a, 'b) sum) = 
+  with s = Left a  => Left (fa a)
+  with s = Right b => Right (fb b).
+
+schema cost_obind_getr ['a 'b] `{P} {e : ('a,'b)sum option}: 
+  cost[P : obind getr e] = cost[P : e] + N 3.
+hint simplify cost_obind_getr.
+
+schema cost_obind_getl ['a 'b] `{P} {e : ('a,'b)sum option}: 
+  cost[P : obind getl e] = cost[P : e] + N 3.
+hint simplify cost_obind_getl.
+
+schema cost_omap_Left ['a 'b] `{P} {e : 'a option}:
+  cost[P : omap (Left<:'a,'b>) e] = cost[P:e] + N 2.
+hint simplify cost_omap_Left.
+
+schema cost_omap_Right ['a 'b] `{P} {e : 'b option}:
+  cost[P : omap (Right<:'a,'b>) e] = cost[P:e] + N 2.
+hint simplify cost_omap_Right.
+
+schema cost_Left ['a 'b] `{P} {e:'a}:
+  cost[P: Left<:'a, 'b> e] = cost [P: e] + N 1.
+
+schema cost_Right ['a 'b] `{P} {e:'b}:
+  cost[P: Right<:'a, 'b> e] = cost [P: e] + N 1.
+hint simplify cost_Left.
+hint simplify cost_Right.
+
+type cenv = {
+  cd    : int; (* self complexity of the distinguisher *)
+  ci    : int; (* number of call to inputs             *)
+  co    : int; (* number of call to outputs            *)
+  cs    : int; (* number of call to step               *)
+  cb    : int; (* number of call to backdoor           *)
+}.
+  
+op cenv_pos (c:cenv) = 
+   0 <= c.`cd /\
+   0 <= c.`ci /\
+   0 <= c.`co /\
+   0 <= c.`cs /\
+   0 <= c.`cb.
+
+type cprot = {
+  cpinit     : int;
+  cpinputs   : int;
+  cpoutputs  : int;
+  cpstep     : int;
+  cpbackdoor : int;
+}.
+
+op cprot_pos (cp:cprot) = 
+  0 <= cp.`cpinit     /\
+  0 <= cp.`cpinputs   /\
+  0 <= cp.`cpoutputs  /\
+  0 <= cp.`cpstep     /\
+  0 <= cp.`cpbackdoor.
+
+abstract theory ProtocolType.
+
+(*
+     
+exists S, forall Z
+
+We take the formalisation using dummy adversary 
+      ------------------------      ------------------------
+      |       Z              |      |       Z              |
+      ------------------|    |      ------------------|    |
+            : I/O       |    |            : I/O       |    |
+      |-------------|   |    |      |-------------|   |    |
+      |     P       |   |    |      |     P'      |   |    |
+      |             |   |    |      |   |---------|   |    |
+      |             | - |    |      |   |     : L     |    |
+      |             | M |    |      |   | |-------|   |    |
+      |             |   |    |      |   | |   S   | - |    |
+      |-------------|   |----|      |-- | |-------| M |----|
+
+Z communicates with P/P' and S 
+P' (can also be a functionality F) communicates with S
+
+*)
+      
+type inputs.         (* Z can send inputs to P/F *)
+type ask_outputs.    (* Z can ask outputs to P/F *)
+type outputs.        
+
+type step.           (* Z can ask to do step *)
+type ask_backdoor.   (* Z can ask backdoors to P/S, S can ask backdoors to F*)
+type backdoor.
+
+end ProtocolType.
+
+abstract theory EXEC_MODEL.
+
+clone include ProtocolType.
+
+module type IO = {
+  proc inputs (i:inputs) : unit
+  proc outputs(o:ask_outputs) : outputs option
+}.
+
+module type BACKDOORS = {
+  proc step (m:step) : unit
+  proc backdoor (m:ask_backdoor) : backdoor option
+}.
+
+module type E_INTERFACE = {
+  include IO
+  include BACKDOORS
+}.
+
+module type PROTOCOL = {
+  proc init() : unit
+  include E_INTERFACE
+}.
+
+module type ENV (I:E_INTERFACE) = {
+  proc distinguish () : bool
+}.
+
+module UC_emul (E:ENV) (P:PROTOCOL) = {
+  proc main() = {
+    var b;
+    P.init();
+    b <@ E(P).distinguish();
+    return b;
+  }
+}.
+
+abstract theory C.
+
+  op c : cenv.
+
+  axiom c_pos : cenv_pos c.
+
+  module type CENV (I : E_INTERFACE) = {
+    proc distinguish() : bool `{N c.`cd, I.inputs:c.`ci, I.outputs:c.`co, I.step:c.`cs, I.backdoor:c.`cb}
+  }.
+
+end C.
+
+abstract theory CP.
+
+  op cp : cprot.
+
+  axiom cp_pos : cprot_pos cp.
+
+  module type CPROTOCOL  = {
+    proc init() : unit `{N cp.`cpinit}
+    
+    proc inputs(i : inputs) : unit `{N cp.`cpinputs}
+    
+    proc outputs(o : ask_outputs) : outputs option `{N cp.`cpoutputs}
+    
+    proc step(m : step) : unit `{N cp.`cpstep}
+    
+    proc backdoor(m : ask_backdoor) : backdoor option `{N cp.`cpbackdoor}
+  }.
+
+end CP.
+
+end EXEC_MODEL.
+
+type csim = {
+  cinit : int;
+  cstep : int;
+  cs_s  : int;
+  cs_b  : int;
+  cbackdoor : int;
+  cb_s  : int;
+  cb_b  : int;
+}.
+
+op csim_pos (c:csim) = 
+  0 <= c.`cinit /\
+  0 <= c.`cstep /\
+  0 <= c.`cs_s  /\ 
+  0 <= c.`cs_b  /\ 
+  0 <= c.`cbackdoor /\ 
+  0 <= c.`cb_s  /\
+  0 <= c.`cb_b.
+
+abstract theory REAL_IDEAL.
+
+  clone EXEC_MODEL as REAL.
+  clone EXEC_MODEL as IDEAL with
+    type inputs      <- REAL.inputs,
+    type ask_outputs <- REAL.ask_outputs,
+    type outputs     <- REAL.outputs.        
+
+  module type SIMULATOR (FB:IDEAL.BACKDOORS) = {
+    proc init() : unit {}
+    include REAL.BACKDOORS
+  }.
+
+  (* Compose a functionality with a simulator --> protocol *)
+
+  module CompS(F:IDEAL.PROTOCOL, S:SIMULATOR) : REAL.PROTOCOL = {
+    proc init() = {
+      F.init();
+      S(F).init();
+    }
+    include F [ inputs, outputs]
+    include S(F) [step, backdoor]
+  }.
+
+  abstract theory C.
+    clone include REAL.C.
+
+    op csi : csim.
+    axiom csi_pos : csim_pos csi.
+
+    module type CSIMULATOR (FB:IDEAL.BACKDOORS) = {
+      proc init() : unit {} `{N csi.`cinit}
+      proc step(m : REAL.step) : unit `{N csi.`cstep, FB.step:csi.`cs_s, FB.backdoor:csi.`cs_b}
+      proc backdoor(m : REAL.ask_backdoor) : REAL.backdoor option `{N csi.`cbackdoor, FB.step:csi.`cb_s, FB.backdoor:csi.`cb_b}
+    }.
+
+  end C.
+
+end REAL_IDEAL.
+
+abstract theory NON_DUMMY.
+
+  clone REAL_IDEAL as RI.
+
+  (* We put the non-dummy adversary inside the protocol. *)
+
+  type step_A.
+  type ask_A.
+  type get_A.
+
+  clone REAL_IDEAL as NONDUMMY_RI with
+    type REAL.inputs        <- RI.REAL.inputs,
+    type REAL.ask_outputs   <- RI.REAL.ask_outputs,
+    type REAL.outputs       <- RI.REAL.outputs,
+    type REAL.step          <- step_A,
+    type REAL.ask_backdoor  <- ask_A, 
+    type REAL.backdoor      <- get_A,
+    type IDEAL.step         <- RI.IDEAL.step,
+    type IDEAL.ask_backdoor <- RI.IDEAL.ask_backdoor,
+    type IDEAL.backdoor     <- RI.IDEAL.backdoor.
+
+  (* A Can't have an init, which seems fine *)
+  module type ADV(B : RI.REAL.BACKDOORS) = { 
+     include NONDUMMY_RI.REAL.BACKDOORS
+  }.
+
+  module A_PROTOCOL(A : ADV, P : RI.REAL.PROTOCOL) : NONDUMMY_RI.REAL.PROTOCOL = {
+     proc init() : unit = {
+         P.init();
+     }
+     include P [inputs, outputs]
+     include A(P) [step,backdoor]
+  }.
+
+(*  
+  module P : DUMMY_RI.REAL.PROTOCOL.
+  module F : DUMMY_RI.IDEAL.PROTOCOL.
+
+  op eps : real.
+
+  axiom security : 
+    exists (S<: NONDUMMY_RI.SIMULATOR),
+       forall (Z<: NONDUMMY_RI.REAL.ENV),
+         `| Pr[NONDUMMY_RI.REAL.UC_emul(Z,A_PROTOCOL(A,P)).main() @ &m : res] -
+            Pr[NONDUMMY_RI.REAL.UC_emul(Z,NONDUMMY_RI.CompS(F,S)).main() @ &m : res] | <= eps.
+*)
+
+end NON_DUMMY.
+
+theory NONDUMMY_EQUIV_DUMMY.
+
+  clone import NON_DUMMY as NON_DUMMY.
+  
+  type cadv = {
+    cas   : int;
+    cas_s : int;
+    cas_b : int;
+    cab   : int;
+    cab_s : int;
+    cab_b : int
+  }.
+
+  op cadv_pos cA = 
+    0 <= cA.`cas   /\
+    0 <= cA.`cas_s /\
+    0 <= cA.`cas_b /\
+    0 <= cA.`cab   /\
+    0 <= cA.`cab_s /\
+    0 <= cA.`cab_b.
+  
+   module (SeqSA(A:ADV, S:RI.SIMULATOR): NONDUMMY_RI.SIMULATOR) (B:NONDUMMY_RI.IDEAL.BACKDOORS) = {
+     proc init () = {
+       S(B).init();
+     }
+
+     include A(S(B))
+  }.
+
+  module SeqZA(Z:NONDUMMY_RI.REAL.ENV) (A:ADV) (I: RI.REAL.E_INTERFACE) = { 
+    module IA = {
+      proc inputs  = I.inputs
+      proc outputs = I.outputs
+      proc step    = A(I).step
+      proc backdoor = A(I).backdoor
+    }
+    proc distinguish = Z(IA).distinguish
+  }.
+
+  op csa (cA:cadv) (cS:csim) = {|
+    cinit = cS.`cinit;
+    cstep = cA.`cas + cS.`cstep * cA.`cas_s + cS.`cbackdoor * cA.`cas_b;
+    cs_s  = cS.`cs_s * cA.`cas_s + cS.`cb_s * cA.`cas_b;
+    cs_b  = cS.`cs_b * cA.`cas_s + cS.`cb_b * cA.`cas_b;
+    cbackdoor =  cA.`cab + cS.`cstep * cA.`cab_s + cS.`cbackdoor * cA.`cab_b;
+    cb_s  = cS.`cs_s * cA.`cab_s + cS.`cb_s * cA.`cab_b;
+    cb_b  = cS.`cs_b * cA.`cab_s + cS.`cb_b * cA.`cab_b;
+  |}.
+
+  lemma dummy_nondummy (P<:RI.REAL.PROTOCOL) (F<:RI.IDEAL.PROTOCOL) &m eps (cS: csim) :
+    csim_pos cS => 
+    forall (S<: RI.SIMULATOR
+                 [init : `{N cS.`cinit} {},
+                  step : `{N cS.`cstep, #FB.step : cS.`cs_s, #FB.backdoor : cS.`cs_b},
+                  backdoor : `{N cS.`cbackdoor, #FB.step: cS.`cb_s, #FB.backdoor : cS.`cb_b}]
+                 {-F}),
+      (forall (Z<: RI.REAL.ENV {-P,-F,-S}),
+        `| Pr[RI.REAL.UC_emul(Z,P).main() @ &m : res] -
+           Pr[RI.REAL.UC_emul(Z,RI.CompS(F,S)).main() @ &m : res] | <= eps) =>
+
+    forall (cA:cadv) (A<:ADV [step : `{N cA.`cas, #B.step: cA.`cas_s, #B.backdoor: cA.`cas_b},
+                              backdoor : `{N cA.`cab, #B.step: cA.`cab_s, #B.backdoor: cA.`cab_b}]
+                              {-F, -P, -S}),
+     cadv_pos cA =>                       
+     let csa = csa cA cS in
+     exists (S1<: NONDUMMY_RI.SIMULATOR 
+                  [init : `{N csa.`cinit} {},
+                   step : `{N csa.`cstep, #FB.step : csa.`cs_s, #FB.backdoor : csa.`cs_b},
+                   backdoor : `{N csa.`cbackdoor, #FB.step: csa.`cb_s, #FB.backdoor : csa.`cb_b}]
+                  {+S, + A, -F}), (* Remark the -F, is redoundant since S and A cannot use it *)
+      forall (Z<: NONDUMMY_RI.REAL.ENV {-A, -P, -F, -S1}),
+        `| Pr[NONDUMMY_RI.REAL.UC_emul(Z,A_PROTOCOL(A,P)).main() @ &m : res] -
+           Pr[NONDUMMY_RI.REAL.UC_emul(Z,NONDUMMY_RI.CompS(F,S1)).main() @ &m : res] | <= eps.
+  proof.
+    move=> hcS S hS cA A hcA csa.
+    exists (SeqSA(A,S)); split.
+    + (split; last split) => kb ks FB hkb hks.
+      + by proc; call (:true; time []); skip => /= /#. 
+      + move=> /=; proc true : time 
+              [S(FB).step : [N (cS.`cstep + ks * cS.`cs_s + kb * cS.`cs_b)],
+               S(FB).backdoor : [N (cS.`cbackdoor + ks * cS.`cb_s + kb * cS.`cb_b)]] => //=.
+        + by rewrite !bigi_constz /#. 
+        + move=> ???.
+          proc true : time [FB.step : [N ks],
+                            FB.backdoor : [N kb]] => //=.
+          + by rewrite !bigi_constz /#.
+          + by move=> ???;proc true : time [].
+          by move=> ???;proc true : time [].
+        move=> ???.
+        proc true : time [FB.step : [N ks],
+                          FB.backdoor : [N kb]] => //=.
+        + by rewrite !bigi_constz /#.
+        + by move=> ???;proc true : time [].
+        by move=> ???;proc true : time [].
+      move=> /=; proc true : time 
+              [S(FB).step : [N (cS.`cstep + ks * cS.`cs_s + kb * cS.`cs_b)],
+               S(FB).backdoor : [N (cS.`cbackdoor + ks * cS.`cb_s + kb * cS.`cb_b)]] => //=.
+      + by rewrite !bigi_constz /#. 
+      + move=> ???.
+        proc true : time [FB.step : [N ks],
+                          FB.backdoor : [N kb]] => //=.
+        + by rewrite !bigi_constz /#.
+        + by move=> ???;proc true : time [].
+        by move=> ???;proc true : time [].
+      move=> ???.
+      proc true : time [FB.step : [N ks],
+                        FB.backdoor : [N kb]] => //=.
+      + by rewrite !bigi_constz /#.
+      + by move=> ???;proc true : time [].
+      by move=> ???;proc true : time [].
+    move=> Z.
+    have := hS (SeqZA(Z,A)).
+    have -> : Pr[RI.REAL.UC_emul(SeqZA(Z, A), P).main() @ &m : res] = 
+              Pr[NONDUMMY_RI.REAL.UC_emul(Z, A_PROTOCOL(A, P)).main() @ &m : res].
+    + by byequiv => //; proc; inline *; sim.
+    have -> // : Pr[RI.REAL.UC_emul(SeqZA(Z, A), RI.CompS(F, S)).main() @ &m : res] = 
+                 Pr[NONDUMMY_RI.REAL.UC_emul(Z, NONDUMMY_RI.CompS(F, SeqSA(A, S))).main() @ &m : res].
+    by byequiv => //; proc; inline *; sim.
+  qed.
+
+  theory NONDUMMY_DUMMY.
+
+  clone import NON_DUMMY as ASSUMPTION1 with
+      type step_A = RI.REAL.step,
+      type ask_A  = RI.REAL.ask_backdoor,
+      type get_A  = RI.REAL.backdoor.
+
+  module (DUMMY_A : ADV) (B :RI.REAL.BACKDOORS)  = {
+     proc step(s : RI.REAL.step) : unit = {
+        B.step(s);
+     }
+
+     proc backdoor(b : RI.REAL.ask_backdoor) : RI.REAL.backdoor option = {
+        var l;
+        l <@ B.backdoor(b);
+        return l;
+     }
+  }.
+
+  (* A module with no exported procedure, this is used to encode any set of variable *)
+  module type MEM = { }.
+
+  lemma nondummy_dummy (P<:RI.REAL.PROTOCOL) (F<:RI.IDEAL.PROTOCOL) &m eps (cS: cadv -> csim) (Mem <: MEM):
+    (forall cA, cadv_pos cA => csim_pos (cS cA)) => 
+    (forall (cA:cadv) (A<:ADV [step : `{N cA.`cas, #B.step: cA.`cas_s, #B.backdoor: cA.`cas_b},
+                     backdoor : `{N cA.`cab, #B.step: cA.`cab_s, #B.backdoor: cA.`cab_b} ]),
+     let csa = cS cA in
+     exists (S<: NONDUMMY_RI.SIMULATOR 
+                  [init : `{N csa.`cinit} {},
+                   step : `{N csa.`cstep, #FB.step : csa.`cs_s, #FB.backdoor : csa.`cs_b},
+                   backdoor : `{N csa.`cbackdoor, #FB.step: csa.`cb_s, #FB.backdoor : csa.`cb_b}]
+                  {+Mem, -F}),
+      forall (Z<: NONDUMMY_RI.REAL.ENV {-A, -P, -F, -S}),
+        `| Pr[NONDUMMY_RI.REAL.UC_emul(Z,A_PROTOCOL(A,P)).main() @ &m : res] -
+           Pr[NONDUMMY_RI.REAL.UC_emul(Z,NONDUMMY_RI.CompS(F,S)).main() @ &m : res] | <= eps) =>
+    let cdA = {| cas = 0; cas_s = 1; cas_b = 0; cab = 0; cab_s = 0; cab_b = 1 |} in
+    let csd = cS cdA in
+    (exists (S<: RI.SIMULATOR
+                 [init : `{N csd.`cinit} {},
+                  step : `{N csd.`cstep, #FB.step : csd.`cs_s, #FB.backdoor : csd.`cs_b},
+                  backdoor : `{N csd.`cbackdoor, #FB.step: csd.`cb_s, #FB.backdoor : csd.`cb_b}]
+                 {+Mem, -F}),
+      forall (Z<: RI.REAL.ENV {-P,-F,-S}),
+        `| Pr[RI.REAL.UC_emul(Z,P).main() @ &m : res] -
+           Pr[RI.REAL.UC_emul(Z,RI.CompS(F,S)).main() @ &m : res] | <= eps).
+  proof.
+    move=> hcS hA cdA csd.  
+    have /= [S hS]:= hA cdA (<:DUMMY_A) _ _.     
+    + by move=> kBb kBs B ??; proc; call(:true; time []); auto.
+    + by move=> kBb kBs B ??; proc; call(:true; time []); auto.
+    exists S; split.
+    + (split; last split) => kBb kBs FB ??.
+      + by proc true : time []. 
+      + proc true : time [FB.step : [N kBs],FB.backdoor :[N kBb]] => //=.
+        + have cS_pos := hcS cdA _; 1: done.
+          by rewrite !bigi_constz /#. 
+        + by move=> *; proc true : time [].
+        by move=> *; proc true : time [].
+      proc true : time [FB.step : [N kBs],FB.backdoor :[N kBb]] => //=.
+      + have cS_pos := hcS cdA _; 1: done.
+        by rewrite !bigi_constz /#. 
+      + by move=> *; proc true : time [].
+      by move=> *; proc true : time [].                 
+    move=> Z; have := hS Z. 
+    have -> : Pr[NONDUMMY_RI.REAL.UC_emul(Z, A_PROTOCOL(DUMMY_A, P)).main() @ &m : res] = 
+              Pr[RI.REAL.UC_emul(Z, P).main() @ &m : res].
+    + byequiv => //; last by move=> ?? ->.
+      proc; call (_: ={glob P}).
+      + by proc *; inline *; call (:true).
+      + by proc *; inline *; call (:true).
+      + by proc *; inline *; call (:true); auto.
+      + by proc *; inline *; wp; call (:true); auto.
+      by inline *; call(:true); auto => /> ?? 4!->.
+    have -> // : Pr[NONDUMMY_RI.REAL.UC_emul(Z, NONDUMMY_RI.CompS(F, S)).main() @ &m : res] =
+              Pr[RI.REAL.UC_emul(Z, RI.CompS(F, S)).main() @ &m : res].
+    byequiv => //; last by move=> ?? ->.
+    proc; call (_: ={glob F, glob S}).
+    + by proc *; inline *; call (:true).
+    + by proc *; inline *; call (:true).
+    + by proc *; inline *; call (: ={glob F}); auto; proc true.
+    + by proc *; inline *; call (: ={glob F}); auto; proc true.
+    by inline *; call(: ={glob F}); call(: true); auto => /> ?? 6!->.
+  qed.
+
+  end NONDUMMY_DUMMY.
+
+end NONDUMMY_EQUIV_DUMMY.
+
+abstract theory TRANSITIVITY.
+
+  (* H1 := P2 realizes P1 /\ H2 := P3 realizes P2 => P3 realizes P1 *)
+
+  clone REAL_IDEAL as H1.
+
+  clone REAL_IDEAL as H2 with
+    type REAL.inputs       <- H1.REAL.inputs,
+    type REAL.ask_outputs  <- H1.REAL.ask_outputs,
+    type REAL.outputs      <- H1.REAL.outputs,
+    type REAL.step         <- H1.IDEAL.step,
+    type REAL.ask_backdoor <- H1.IDEAL.ask_backdoor, 
+    type REAL.backdoor     <- H1.IDEAL.backdoor.
+
+  clone REAL_IDEAL as GOAL with
+    type REAL.inputs       <- H1.REAL.inputs,
+    type REAL.ask_outputs  <- H1.REAL.ask_outputs,
+    type REAL.outputs      <- H1.REAL.outputs,
+    type REAL.step         <- H1.REAL.step,
+    type REAL.ask_backdoor <- H1.REAL.ask_backdoor, 
+    type REAL.backdoor     <- H1.REAL.backdoor,
+    type IDEAL.step         <- H2.IDEAL.step,
+    type IDEAL.ask_backdoor <- H2.IDEAL.ask_backdoor, 
+    type IDEAL.backdoor     <- H2.IDEAL.backdoor.
+
+   module (SeqS(S1:H2.SIMULATOR, S2:H1.SIMULATOR): GOAL.SIMULATOR) (FB:GOAL.IDEAL.BACKDOORS) = {
+     proc init () = {
+       S1(FB).init();
+       S2(S1(FB)).init();
+     }
+
+     include S2(S1(FB)) [-init] 
+   }.
+
+  module (CompZS(Z:GOAL.REAL.ENV)(S:H1.SIMULATOR) : H2.REAL.ENV) (I:H2.REAL.E_INTERFACE) = {
+    module IZ = {
+      include I [inputs, outputs]
+      include S(I) 
+    }
+
+    proc distinguish() = {
+      var b;
+      IZ.init();
+      b <@ Z(IZ).distinguish();
+      return b;
+    }
+    
+  }.
+
+  section TRANS.
+     declare module P1 <: GOAL.REAL.PROTOCOL.
+     declare module P2 <: H1.IDEAL.PROTOCOL.
+     declare module P3 <: H2.IDEAL.PROTOCOL.
+     declare module S12 <: H1.SIMULATOR {-P2, -P3}.
+     declare module S23 <: H2.SIMULATOR {-P3, -S12}.
+  
+     declare module Z <: GOAL.REAL.ENV { -P1, -P2, -P3, -S12, -S23}.
+ 
+     lemma uc_transitivity &m : 
+       `| Pr[GOAL.REAL.UC_emul(Z, P1).main() @ &m : res] - 
+          Pr[GOAL.REAL.UC_emul(Z, GOAL.CompS(P3, SeqS(S23, S12))).main() @ &m : res] | <= 
+       `| Pr[  H1.REAL.UC_emul(Z, P1).main() @ &m : res] - 
+          Pr[  H1.REAL.UC_emul(Z, H1.CompS(P2, S12)).main() @ &m : res] | + 
+       `| Pr[  H2.REAL.UC_emul(CompZS(Z,S12),P2).main() @ &m : res] - 
+          Pr[  H2.REAL.UC_emul(CompZS(Z,S12),H2.CompS(P3, S23)).main() @ &m : res] |.
+     proof.
+      have -> : Pr[GOAL.REAL.UC_emul(Z,P1).main() @ &m : res] = Pr[H1.REAL.UC_emul(Z,P1).main() @ &m : res].
+      + by byequiv => //; sim.
+      have -> : 
+        Pr[H1.REAL.UC_emul(Z, H1.CompS(P2, S12)).main() @ &m : res] = 
+        Pr[H2.REAL.UC_emul(CompZS(Z,S12),P2).main() @ &m : res].
+      + by byequiv => //; proc; inline *; wp; sim.
+      have -> /#: 
+        Pr[GOAL.REAL.UC_emul(Z, GOAL.CompS(P3, SeqS(S23, S12))).main() @ &m : res] = 
+        Pr[H2.REAL.UC_emul(CompZS(Z, S12), H2.CompS(P3, S23)).main() @ &m : res].
+      by byequiv => //; proc; inline *; wp; sim. 
+    qed.
+
+   end section TRANS.
+
+   abstract theory C.
+
+   op cz   : cenv.
+   op cs12 : csim.
+   op cs23 : csim.
+
+   axiom cz_pos   : cenv_pos cz.
+   axiom cs12_pos : csim_pos cs12.
+   axiom cs23_pos : csim_pos cs23.
+
+   op cz23 = {|
+     cd = cz.`cd + cs12.`cinit + cz.`cs * cs12.`cstep + cz.`cb * cs12.`cbackdoor; 
+     ci = cz.`ci;
+     co = cz.`co;
+     cs = cz.`cs * cs12.`cs_s + cz.`cb * cs12.`cb_s;
+     cb = cz.`cs * cs12.`cs_b + cz.`cb * cs12.`cb_b;
+   |}.
+
+   op cs13 = {| 
+       cinit = cs12.`cinit + cs23.`cinit;
+       cstep = cs12.`cstep + cs23.`cstep * cs12.`cs_s + cs23.`cbackdoor * cs12.`cs_b;
+       cs_s  = cs12.`cs_s * cs23.`cs_s + cs12.`cs_b * cs23.`cb_s;
+       cs_b  = cs12.`cs_s * cs23.`cs_b + cs12.`cs_b * cs23.`cb_b;
+       cbackdoor = cs12.`cbackdoor + cs23.`cstep * cs12.`cb_s + cs23.`cbackdoor * cs12.`cb_b;
+       cb_s  = cs12.`cb_s * cs23.`cs_s + cs12.`cb_b * cs23.`cb_s;
+       cb_b  = cs12.`cb_s * cs23.`cs_b + cs12.`cb_b * cs23.`cb_b;
+     |}.
+
+   clone H1.C as CH1 with
+     op c <- cz,
+     op csi <- cs12
+     proof * by smt(cz_pos cs12_pos cs23_pos).
+   
+   clone H2.C as CH2 with 
+     op c <- cz23,
+     op csi <- cs23
+     proof * by smt(cz_pos cs12_pos cs23_pos).
+
+   clone GOAL.C as CGOAL with
+     op c <- cz,
+     op csi <- cs13 
+     proof * by smt (cz_pos cs12_pos cs23_pos).
+
+   section.
+
+   declare module P1  <: GOAL.REAL.PROTOCOL.
+   declare module P2  <: H1.IDEAL.PROTOCOL.
+   declare module P3  <: H2.IDEAL.PROTOCOL.
+   declare module S12 <: CH1.CSIMULATOR {-P2, -P3}.
+   declare module S23 <: CH2.CSIMULATOR {-P3, -S12}.
+
+   lemma cost_S23_step (kbackdoor kstep : int) (FB <: GOAL.IDEAL.BACKDOORS[backdoor : `{N kbackdoor} , step : `{N kstep} ]) :
+     choare[S23(FB).step] time [N cs23.`cstep; FB.step : cs23.`cs_s; FB.backdoor : cs23.`cs_b].
+   proof.
+     proc true : time [FB.step : [N kstep], FB.backdoor : [N kbackdoor]] => //=.
+     + by rewrite !bigi_constz; smt(cs23_pos). 
+     + by move=> /= *; proc true : time [].
+     by move=> /= *; proc true : time [].
+   qed.
+
+   lemma cost_S23_backdoor (kbackdoor kstep : int) (FB <: GOAL.IDEAL.BACKDOORS[backdoor : `{N kbackdoor} , step : `{N kstep} ]) :
+       choare[S23(FB).backdoor] time [N cs23.`cbackdoor; FB.step : cs23.`cb_s; FB.backdoor : cs23.`cb_b].
+   proof.
+     proc true : time [FB.step : [N kstep], FB.backdoor : [N kbackdoor]] => //=.
+     + by rewrite !bigi_constz; smt(cs23_pos). 
+     + by move=> /= *; proc true : time [].
+     by move=> /= *; proc true : time [].
+   qed.
+
+   lemma cost_SeqS_init (FB <: GOAL.IDEAL.BACKDOORS):
+      choare[SeqS(S23, S12, FB).init] time [N cs13.`cinit].
+   proof. proc; call(:true);call(:true);skip => /#. qed.
+  
+   lemma cost_SeqS_step (kbackdoor kstep : int) (FB <: GOAL.IDEAL.BACKDOORS[backdoor : `{N kbackdoor} , step : `{N kstep} ]): 
+      choare[S12(S23(FB)).step] time [N cs13.`cstep; FB.step : cs13.`cs_s; FB.backdoor : cs13.`cs_b].
+   proof.
+     proc true: time [S23(FB).step: [N cs23.`cstep; FB.step: cs23.`cs_s; FB.backdoor: cs23.`cs_b],
+                      S23(FB).backdoor: [N cs23.`cbackdoor; FB.step: cs23.`cb_s; FB.backdoor: cs23.`cb_b]] => //=.
+     + by rewrite !bigi_constz; smt(cs12_pos).
+     + by move=> ???; apply (cost_S23_step kbackdoor kstep FB).
+     by move=> ???; apply (cost_S23_backdoor kbackdoor kstep FB).
+   qed.
+
+   lemma cost_SeqS_backdoor (kbackdoor kstep : int) (FB <: GOAL.IDEAL.BACKDOORS[backdoor : `{N kbackdoor} , step : `{N kstep} ]): 
+      choare[S12(S23(FB)).backdoor] time [N cs13.`cbackdoor; FB.step : cs13.`cb_s; FB.backdoor : cs13.`cb_b].
+   proof.
+     proc true: time [S23(FB).step: [N cs23.`cstep; FB.step: cs23.`cs_s; FB.backdoor: cs23.`cs_b],
+                      S23(FB).backdoor: [N cs23.`cbackdoor; FB.step: cs23.`cb_s; FB.backdoor: cs23.`cb_b]] => //=.
+     + by rewrite !bigi_constz; smt(cs12_pos). 
+     + move=> *; apply (cost_S23_step kbackdoor kstep FB).
+     by move=> *; apply (cost_S23_backdoor kbackdoor kstep FB).
+   qed. 
+
+   lemma ex_uc_transitivity &m (e1 e2:real):
+      (forall (Z<:CH1.CENV{-P1, -P2, -S12, -P3, -S23}),
+          `| Pr[H1.REAL.UC_emul(Z,P1).main() @ &m : res] - 
+             Pr[H1.REAL.UC_emul(Z,H1.CompS(P2, S12)).main() @ &m : res] | <= e1) =>
+      (forall (Z<:CH2.CENV{-P2,-P3,-S23, -P1}),
+          `| Pr[H2.REAL.UC_emul(Z,P2).main() @ &m : res] - 
+             Pr[H2.REAL.UC_emul(Z,H2.CompS(P3, S23)).main() @ &m : res] | <= e2) =>
+      (exists (S13<:CGOAL.CSIMULATOR {+S12,+S23, -P3}),
+        forall (Z<:CGOAL.CENV{-P1,-P2,-P3,-S12,-S23}),
+          `| Pr[GOAL.REAL.UC_emul(Z,P1).main() @ &m : res] - 
+             Pr[GOAL.REAL.UC_emul(Z,GOAL.CompS(P3, S13)).main() @ &m : res] | <= e1 + e2).
+   proof.
+     move=> hS12 hS23. 
+     exists (SeqS(S23, S12)) => /=. 
+     split.
+     + split.
+       + by move=> k1 k2 FB *; apply (cost_SeqS_init FB). 
+       split.
+       + by move=> k1 k2 FB *; apply (cost_SeqS_step k1 k2 FB).
+       by move=> k1 k2 FB *; apply (cost_SeqS_backdoor k1 k2 FB).
+     move=> Z.
+     have := uc_transitivity P1 P2 P3 S12 S23 Z &m.
+     have := hS12 Z. 
+     have /# := hS23 (CompZS(Z,S12)) _.
+     move=> kb ks ko ki I ????.
+     proc; inline *.
+     call (_:true; time [CompZS(Z, S12, I).IZ.inputs:['0; I.inputs: 1],
+                         CompZS(Z, S12, I).IZ.outputs:['0; I.outputs: 1],
+                         CompZS(Z, S12, I).IZ.step:
+                                 [             N cs12.`cstep; 
+                                  I.step     : cs12.`cs_s; 
+                                  I.backdoor : cs12.`cs_b],
+                         CompZS(Z, S12, I).IZ.backdoor:
+                                 [             N cs12.`cbackdoor; 
+                                  I.step     : cs12.`cb_s; 
+                                  I.backdoor : cs12.`cb_b]]).
+     + by move=> /= *; proc true : time []. 
+     + by move=> /= *; proc true : time [].
+     + move=> * /=.
+       proc true: time [I.step :[N ks], I.backdoor : [N kb]] => //.
+       + by rewrite !bigi_constz; smt(cs12_pos).
+       + by move=> /= *; proc true : time [].
+       by move=> /= *; proc true : time []. 
+     + move=> * /=.
+       proc true: time [I.step :[N ks], I.backdoor : [N kb]] => //.
+       + by rewrite !bigi_constz; smt(cs12_pos).
+       + by move=> /= *; proc true : time [].
+       by move=> /= *; proc true : time []. 
+     call (:true); skip => /=.
+     by rewrite !big1_eq /= !bigi_constz /=;smt(cz_pos).
+   qed.
+
+  end section.
+
+  end C.
+
+end TRANSITIVITY.
+
+theory COMPOSITION.
+
+  (* Pi realizes f => R^Pi realizes R^f 
+      
+  ____IO___
+  |    ____|    
+  | R  |_f_| - backdoor
+  |________| - backdoor *)
+
+  clone REAL_IDEAL as Pi.
+
+  clone EXEC_MODEL as R.
+
+  clone REAL_IDEAL as RPi with
+    type REAL.inputs       <- R.inputs,
+    type REAL.ask_outputs  <- R.ask_outputs,
+    type REAL.outputs      <- R.outputs,  
+    type REAL.step         = (R.step, Pi.REAL.step) sum,
+    type REAL.ask_backdoor = (R.ask_backdoor, Pi.REAL.ask_backdoor) sum,
+    type REAL.backdoor     = (R.backdoor, Pi.REAL.backdoor) sum,
+    type IDEAL.step         = (R.step, Pi.IDEAL.step) sum,
+    type IDEAL.ask_backdoor = (R.ask_backdoor, Pi.IDEAL.ask_backdoor) sum,
+    type IDEAL.backdoor     = (R.backdoor, Pi.IDEAL.backdoor) sum.
+
+  module type RHO (P:Pi.REAL.IO) = {
+    proc init() : unit {}
+    include R.PROTOCOL [-init]
+  }.
+
+  module CompR_I(Rho:RHO) (P:Pi.REAL.E_INTERFACE) : RPi.REAL.E_INTERFACE = {
+
+    include Rho(P) [inputs, outputs]
+
+    proc step (m:RPi.REAL.step) : unit = {
+      match (m) with
+      | Left  m1 => { Rho(P).step(m1); }
+      | Right m2 => { P.step(m2); }
+      end;
+    }
+
+    proc backdoor (m:RPi.REAL.ask_backdoor) : RPi.REAL.backdoor option = {
+      var r1, r2, r;
+      match (m) with
+      | Left m1  => { r1 <@ Rho(P).backdoor(m1); r <- omap Left r1; }
+      | Right m2 => { r2 <@ P.backdoor(m2);      r <- omap Right r2; }
+      end;
+      return r;
+    }
+  }.
+
+  module CompRP(Rho:RHO) (P:Pi.REAL.PROTOCOL) : RPi.REAL.PROTOCOL = {
+    
+    proc init () = {
+      P.init();
+      Rho(P).init();
+    }
+    include CompR_I(Rho,P) 
+  }.
+
+  module CompRF(Rho:RHO) (F:Pi.IDEAL.PROTOCOL) : RPi.IDEAL.PROTOCOL = {
+    
+    proc init () = {
+      F.init();
+      Rho(F).init();
+    }
+    
+    include Rho(F) [inputs, outputs]
+
+    proc step (m:RPi.IDEAL.step) : unit = {
+      match (m) with
+      | Left  m1 => { Rho(F).step(m1); }
+      | Right m2 => { F.step(m2); }
+      end;
+    }
+
+    proc backdoor (m:RPi.IDEAL.ask_backdoor) : RPi.IDEAL.backdoor option = {
+      var r1, r2, r;
+      match (m) with
+      | Left m1  => { r1 <@ Rho(F).backdoor(m1); r <- omap Left r1; }
+      | Right m2 => { r2 <@ F.backdoor(m2); r <- omap Right r2; }
+      end;
+      return r;
+    }
+
+  }.
+
+  module (Sid(Sf:Pi.SIMULATOR) : RPi.SIMULATOR) (FB : RPi.IDEAL.BACKDOORS) = {
+  
+    module FBPi = {
+      proc step(m:Pi.IDEAL.step) : unit = {
+        FB.step(Right m);
+      }
+      
+      proc backdoor(m:Pi.IDEAL.ask_backdoor) : Pi.IDEAL.backdoor option = {
+        var r;
+        r <@ FB.backdoor (Right m);
+        return obind getr r;
+      }
+    }
+    
+    proc init = Sf(FBPi).init 
+
+    proc step(m:RPi.REAL.step) : unit = {
+      match (m) with
+      | Left m1  => { FB.step(Left m1); }
+      | Right m2 => { Sf(FBPi).step(m2); }
+      end;
+    }
+    
+    proc backdoor(m:RPi.REAL.ask_backdoor) : RPi.REAL.backdoor option = {
+      var r1, r2;
+      var r :RPi.REAL.backdoor option;
+      match (m) with
+      | Left  m1 => { r1 <@ FB.backdoor(Left m1); r <- omap Left (obind getl r1); } 
+      | Right m2 => { r2 <@ Sf(FBPi).backdoor(m2); r <- omap Right r2; }
+      end;
+      return r;
+    }
+  }.
+
+  module (CompZR(Z:RPi.REAL.ENV, Rho:RHO):Pi.REAL.ENV) (I : Pi.REAL.E_INTERFACE) = {
+    proc distinguish() : bool = {
+      var b;
+      Rho(I).init();
+      b <@ Z(CompR_I(Rho,I)).distinguish();
+      return b;
+    }
+  }.
+      
+  section COMP.
+ 
+    declare module P  <: Pi.REAL.PROTOCOL.
+    declare module Ff <: Pi.IDEAL.PROTOCOL.
+    declare module Sf <: Pi.SIMULATOR {-Ff}.
+
+    declare module Rho<: RHO {-P, -Ff, -Sf}.
+ 
+    declare module Z<: RPi.REAL.ENV {-Rho, -P, -Ff, -Sf}.
+
+    lemma compose &m : 
+      Pr[RPi.REAL.UC_emul(Z,CompRP(Rho,P)).main() @ &m : res] - 
+        Pr[RPi.REAL.UC_emul(Z,RPi.CompS(CompRF(Rho,Ff), Sid(Sf))).main() @ &m : res] = 
+      Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), P).main() @ &m : res] - 
+        Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), Pi.CompS(Ff,Sf)).main() @ &m : res].
+    proof.
+      have -> :  
+        Pr[RPi.REAL.UC_emul(Z,CompRP(Rho,P)).main() @ &m : res] =
+        Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), P).main() @ &m : res].
+      + by byequiv => //; proc; inline *; wp; sim.
+      have -> // : 
+        Pr[RPi.REAL.UC_emul(Z,RPi.CompS(CompRF(Rho,Ff), Sid(Sf))).main() @ &m : res] =
+        Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), Pi.CompS(Ff,Sf)).main() @ &m : res]. 
+      byequiv => //; proc; inline *; wp.
+      call (_ : = {glob Rho, glob Ff, glob Sf}); 1,2:sim. 
+      + proc; match; 1,2: smt().
+        + move => m1 m2; inline *; match Left {1} 2.  
+          + by auto => /#.
+          call (_: ={glob Ff}); 1,2:sim.
+          by auto => /> /#.
+        move => m1 m2; call (_: ={glob Rho, glob Ff}); last by auto => />.
+        + proc *; inline *; match Right {1} 3; 1: by auto => /#.
+          by call (_: true); auto => /> /#.
+        proc *; inline *;match Right {1} 3; 1: by auto => /#.
+        by wp; call (_: true); auto => /> /#.
+      + proc; match; 1,2: smt().
+        + move=> m1 m2; wp; inline *; match Left {1} 2; 1: by auto => /#.
+          by wp; call (_: ={glob Ff}); 1,2:sim; auto => /> /#.
+        move=> m1 m2; wp; inline *; call (_: ={glob Rho, glob Ff}). 
+        + proc *; inline *; match Right {1} 3; 1: by auto => /#.
+          by call (_: true); auto => /> /#.
+        + proc *; inline *; match Right {1} 3; 1: by auto => /#.
+          by wp; call (_: true); auto => /> /#.       
+        by auto => />.
+      by swap{1} 2 1; sim />. 
+    qed.
+ 
+  end section COMP.
+
+  abstract theory C.
+
+  type crho = {
+    cr_init : int;
+    cr_in   : int;
+    cr_in_i : int;
+    cr_in_o : int;
+    cr_out  : int;
+    cr_out_i : int;
+    cr_out_o : int;
+    cr_st    : int;
+    cr_st_i  : int;
+    cr_st_o  : int;
+    cr_bk    : int;
+    cr_bk_i  : int;
+    cr_bk_o  : int;
+  }.
+
+  op crho_pos (cr: crho) = 
+    0 <= cr.`cr_init  /\
+    0 <= cr.`cr_in    /\
+    0 <= cr.`cr_in_i  /\
+    0 <= cr.`cr_in_o  /\
+    0 <= cr.`cr_out   /\
+    0 <= cr.`cr_out_i /\
+    0 <= cr.`cr_out_o /\
+    0 <= cr.`cr_st    /\
+    0 <= cr.`cr_st_i  /\
+    0 <= cr.`cr_st_o  /\
+    0 <= cr.`cr_bk    /\
+    0 <= cr.`cr_bk_i  /\
+    0 <= cr.`cr_bk_o.
+  
+  op cr : crho.
+  axiom cr_pos : crho_pos cr.
+
+  module type CRHO(P : Pi.REAL.IO)  = {
+    proc init() : unit {} `{ N cr.`cr_init}
+  
+    proc inputs(i : R.inputs) : unit `{N cr.`cr_in, P.inputs : cr.`cr_in_i, P.outputs : cr.`cr_in_o} 
+  
+    proc outputs(o : R.ask_outputs) : R.outputs option `{N cr.`cr_out, P.inputs : cr.`cr_out_i, P.outputs : cr.`cr_out_o} 
+  
+    proc step(m : R.step) : unit `{N cr.`cr_st, P.inputs : cr.`cr_st_i, P.outputs : cr.`cr_st_o} 
+  
+    proc backdoor(m : R.ask_backdoor) : R.backdoor option `{N cr.`cr_bk, P.inputs : cr.`cr_bk_i, P.outputs : cr.`cr_bk_o} 
+  }.
+
+  op csi : csim.
+  axiom csi_pos : csim_pos csi.
+
+  op rcsi = {|
+    cinit = csi.`cinit;
+    cstep = max 2 (1 + csi.`cs_s + csi.`cs_b * 4 + csi.`cstep) ;
+    cs_s  = max 1 csi.`cs_s;
+    cs_b  = csi.`cs_b;
+    cbackdoor = max 7 (3 + csi.`cb_s + csi.`cb_b * 4 + csi.`cbackdoor + csi.`cstep);
+    cb_s = csi.`cb_s;
+    cb_b = max 1 csi.`cb_b; 
+  |}.
+
+  lemma rcsi_pos : csim_pos rcsi by smt(csi_pos).
+
+  (* complexity or the environement for the reduction CompRP(Rho,P) *)
+  op rc : cenv.
+  axiom rc_pos : cenv_pos rc.
+
+  (* complexity or the environement of the reduction *)
+  op c = {|
+    cd = cr.`cr_init + rc.`cd + rc.`ci * cr.`cr_in + rc.`co * cr.`cr_out + rc.`cs * (1 + cr.`cr_st) + rc.`cb * (3 + cr.`cr_bk);
+    ci = cr.`cr_in_i * rc.`ci + cr.`cr_out_i * rc.`co + cr.`cr_st_i * rc.`cs + cr.`cr_bk_i * rc.`cb;
+    co = cr.`cr_in_o * rc.`ci + cr.`cr_out_o * rc.`co + cr.`cr_st_o * rc.`cs + cr.`cr_bk_o * rc.`cb;
+    cs = rc.`cs;
+    cb = rc.`cb;
+  |}.  
+
+  lemma c_pos : cenv_pos c by smt (rc_pos cr_pos). 
+
+  clone Pi.C as CPi with
+    op csi <- csi,
+    op c   <- c
+    proof csi_pos by apply csi_pos
+    proof c_pos by apply c_pos.
+
+  clone RPi.C as CRPi with
+    op csi <- rcsi,
+    op c <- rc
+    proof csi_pos by apply rcsi_pos
+    proof c_pos by apply rc_pos.
+
+  section.
+
+   declare module P  <: Pi.REAL.PROTOCOL.
+   declare module Ff <: Pi.IDEAL.PROTOCOL.
+   declare module Sf <: CPi.CSIMULATOR {-Ff}.
+
+   declare module Rho<: CRHO {-P, -Ff, -Sf}.
+
+   lemma ex_compose e &m : 
+     (forall (Z <: CPi.CENV {-P, -Ff, -Sf}),
+       `|Pr[Pi.REAL.UC_emul(Z, P).main() @ &m : res] - 
+          Pr[Pi.REAL.UC_emul(Z, Pi.CompS(Ff,Sf)).main() @ &m : res]| <= e) =>
+     exists (S<:CRPi.CSIMULATOR{+Sf}),
+     (forall (Z <: CRPi.CENV {-Rho,-P,-Ff,-Sf}),
+       `|Pr[RPi.REAL.UC_emul(Z,CompRP(Rho,P)).main() @ &m : res] - 
+          Pr[RPi.REAL.UC_emul(Z,RPi.CompS(CompRF(Rho,Ff), S)).main() @ &m : res]| <= e).
+   proof.
+     move=> h; exists (Sid(Sf)); split.
+     (* Complexity of the simulator *)
+     + split.
+       + by move=> kb ks FB hkb hks; proc true : time [].
+       split.
+       + move=> kb ks FB hkb hks; proc.
+         exlim m => -[] mi. 
+         + match Left 1; [1: by auto; smt() | 2: done].
+           call(:true; time []); auto => />; smt(csi_pos).  
+         match Right 1; [1: by auto; smt() | 2: done].
+         call (:true; time [Sid(Sf, FB).FBPi.step : ['1; FB.step : 1], Sid(Sf, FB).FBPi.backdoor : [N 4; FB.backdoor : 1]]).
+         + by move=> *; proc; call (:true; time []); skip => />.
+         + by move=> *; proc; call (:true; time []); skip => />.
+         by skip => &hr />; rewrite !bigi_constz /=; smt(csi_pos).
+       move=> kb ks FB hkb hks; proc.
+       exlim m => -[] mi.  
+       + match Left 1; [1: by auto; smt() | 2: done].
+         wp; call(:true; time []); auto => />; smt(csi_pos).
+       match Right 1; [1: by auto; smt() | 2: done].
+       wp;call (:true; time [Sid(Sf, FB).FBPi.step : ['1; FB.step : 1], Sid(Sf, FB).FBPi.backdoor : [N 4; FB.backdoor : 1]]).
+       + by move=> *; proc; call (:true; time []); skip => />.
+       + by move=> *; proc; call (:true; time []); skip => />.
+       skip => &hr />; rewrite !bigi_constz /=; smt(csi_pos).
+     move=> Z; rewrite (compose P Ff Sf Rho Z &m).
+     (* Complexity of the environment *)
+     apply (h (CompZR(Z,Rho))).
+     move=> kb ks ko ki I hkb hks hko hki; proc.
+     call(:true;time[CompR_I(Rho, I).inputs   : [N cr.`cr_in; I.inputs : cr.`cr_in_i; I.outputs : cr.`cr_in_o],
+                     CompR_I(Rho, I).outputs  : [N cr.`cr_out; I.inputs : cr.`cr_out_i; I.outputs : cr.`cr_out_o],
+                     CompR_I(Rho, I).step     : [N (1 + cr.`cr_st); I.inputs : cr.`cr_st_i; I.outputs : cr.`cr_st_o; I.step : 1],
+                     CompR_I(Rho, I).backdoor : [N (3 + cr.`cr_bk); I.inputs : cr.`cr_bk_i; I.outputs : cr.`cr_bk_o; I.backdoor : 1]]).
+     + move=> *; proc true : time [I.inputs: [N ki], I.outputs: [N ko]] => />.
+       + by rewrite !bigi_constz /=; smt (cr_pos).
+       + by move=> *; proc true : time [].
+       by move=> *; proc true : time [].
+     + move=> *; proc true : time [I.inputs : [N ki], I.outputs : [N ko]] => />.
+       + rewrite !bigi_constz /=; smt (cr_pos). 
+       + by move=> *; proc true : time [].
+       by move=> *; proc true : time [].
+     + move=> *; proc.
+       exlim m => -[] mi. 
+       + match Left 1; [1: by auto; smt() | 2: done].
+         call(:true; time [I.inputs : [N ki], I.outputs : [N ko]]).
+         + by move=> *; proc true : time [].
+         + by move=> *; proc true : time [].
+         skip => />; rewrite !bigi_constz /=; smt(cr_pos). 
+       match Right 1; [1: by auto; smt() | 2: done].
+       by call (:true); skip => />; smt (cr_pos).
+     + move=> *; proc.
+       exlim m => -[] mi. 
+       + match Left 1; [1: by auto; smt() | 2: done].
+         wp; call(:true; time [I.inputs : [N ki], I.outputs : [N ko]]).
+         + by move=> *; proc true : time [].
+         + by move=> *; proc true : time [].
+         skip => />; rewrite !bigi_constz /=; smt(cr_pos).
+       match Right 1; [1: by auto; smt() | 2: done].
+       by wp; call (:true); skip => />; smt (cr_pos). 
+     call (:true); skip => />.
+     rewrite !bigi_constz /=; smt(rc_pos).
+   qed.
+  
+  end section.
+  
+  end C.
+
+  clone import TRANSITIVITY as TRANS with 
+    type H1.REAL.inputs       <- R.inputs,
+    type H1.REAL.ask_outputs  <- R.ask_outputs,
+    type H1.REAL.outputs      <- R.outputs,
+    type H1.REAL.step         <- RPi.REAL.step,
+    type H1.REAL.ask_backdoor <- RPi.REAL.ask_backdoor, 
+    type H1.REAL.backdoor     <- RPi.REAL.backdoor,
+    type H1.IDEAL.step         <- RPi.IDEAL.step,
+    type H1.IDEAL.ask_backdoor <- RPi.IDEAL.ask_backdoor, 
+    type H1.IDEAL.backdoor     <- RPi.IDEAL.backdoor.
+
+  section StrongCOMP.
+
+    declare module P  <: Pi.REAL.PROTOCOL.
+    declare module Ff <: Pi.IDEAL.PROTOCOL.
+    declare module Sf <: Pi.SIMULATOR {-Ff}.
+
+    declare module Rho<: RHO {-P, -Ff, -Sf}.
+    declare module F <: H2.IDEAL.PROTOCOL {-Sf}.
+    declare module S <: H2.SIMULATOR {-F, -Sf}.
+
+    declare module Z<: RPi.REAL.ENV {-Rho, -P, -Ff, -Sf, -F, -S}.
+
+    lemma strong_compose &m : 
+      `| Pr[GOAL.REAL.UC_emul(Z,CompRP(Rho,P)).main() @ &m : res] - 
+         Pr[GOAL.REAL.UC_emul(Z,GOAL.CompS(F, SeqS(S, Sid(Sf)))).main() @ &m : res] |
+       <= 
+      `| Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), P).main() @ &m : res] - 
+         Pr[Pi.REAL.UC_emul(CompZR(Z,Rho), Pi.CompS(Ff,Sf)).main() @ &m : res] | + 
+      `| Pr[H2.REAL.UC_emul(CompZS(Z, Sid(Sf)), CompRF(Rho,Ff)).main() @ &m : res] - 
+         Pr[H2.REAL.UC_emul(CompZS(Z, Sid(Sf)), H2.CompS(F,S)).main() @ &m : res] |.
+    proof.
+      have h1 := uc_transitivity (CompRP(Rho,P)) (CompRF(Rho,Ff)) F (Sid(Sf)) S Z &m.
+      have h2 := compose P Ff Sf Rho Z &m.
+      apply (StdOrder.RealOrder.ler_trans _ _ _ h1) => {h1}.
+      have -> : Pr[H1.REAL.UC_emul(Z, CompRP(Rho, P)).main() @ &m : res] = 
+                Pr[Pi.REAL.UC_emul(CompZR(Z, Rho), P).main() @ &m : res].
+      + by byequiv=> //; proc; inline *; wp; sim.
+      have -> // : Pr[H1.REAL.UC_emul(Z, H1.CompS(CompRF(Rho, Ff), Sid(Sf))).main() @ &m : res] =
+                   Pr[Pi.REAL.UC_emul(CompZR(Z, Rho), Pi.CompS(Ff, Sf)).main() @ &m : res].
+      byequiv=> //; proc; inline *; wp. swap{1} 2 1.
+      call (_: ={glob Rho, glob Ff,glob Sf}); 1,2:sim.
+      + proc; match; 1,2: smt().
+        + move=> m1 m2; inline *; match Left {1} 2; 1: by auto => /> /#.
+          call (_: ={glob Ff} ); 1,2:sim.
+          by auto => /#.
+        move=> m1 m2; inline *; call (_: ={glob Rho, glob Ff}). 
+        + proc *; inline *; match Right {1} 3; 1: by auto => /> /#.
+          by call (_: true); auto => /> /#.
+        + proc *; inline *; match Right {1} 3; 1: by auto => /> /#.
+          auto; call (_: true);auto => /> /#.
+        by auto => />.
+      + proc; match;1,2: smt().
+        + move=> m1 m2; inline *; match Left {1} 2; 1: by auto => /> /#.
+          wp;call (_: ={glob Ff} ); 1,2:sim.
+          by auto => /#.
+        move=> m1 m2; inline *; wp; call (_: ={glob Rho, glob Ff}). 
+        + proc *; inline *; match Right {1} 3; 1: by auto => /> /#.
+          by call (_: true); auto => /> /#.
+        + proc *; inline *; match Right {1} 3; 1: by auto => /> /#.
+          auto; call (_: true);auto => /> /#.
+        by auto => />.
+      sim />.
+     qed.
+
+  end section StrongCOMP.
+
+  abstract theory SC.
+
+  op csi : csim.
+
+  axiom csi_pos : csim_pos csi.
+
+  op rcsi : csim =
+    {| cinit = csi.`cinit; cstep = max 2 (1 + csi.`cs_s + csi.`cs_b * 4 + csi.`cstep); cs_s =
+      max 1 csi.`cs_s; cs_b = csi.`cs_b; cbackdoor =
+      max 7 (3 + csi.`cb_s + csi.`cb_b * 4 + csi.`cbackdoor + csi.`cstep); cb_s = csi.`cb_s; cb_b =
+      max 1 csi.`cb_b; |}.
+  
+  lemma rcsi_pos : csim_pos rcsi by smt (csi_pos).
+
+  clone TRANS.C as CT
+    with op cs12 <- rcsi
+    proof cs12_pos by apply rcsi_pos.
+
+  clone COMPOSITION.C as C0 with 
+    op rc <- CT.cz,
+    op csi <- csi
+    proof rc_pos by apply CT.cz_pos
+    proof csi_pos by apply csi_pos.
+
+  section.  
+    declare module P  <: Pi.REAL.PROTOCOL.
+    declare module Ff <: Pi.IDEAL.PROTOCOL.
+    declare module Sf <: C0.CPi.CSIMULATOR {-Ff}.
+
+    declare module Rho<: C0.CRHO {-P, -Ff, -Sf}.
+    declare module F <: H2.IDEAL.PROTOCOL {-Sf}.
+    declare module S <: CT.CH2.CSIMULATOR {-F, -Sf}.
+
+    lemma ex_strong_compose &m e1 e2 : 
+      (forall (Z <: C0.CPi.CENV {-P, -Ff, -Sf}),
+        `| Pr[Pi.REAL.UC_emul(Z, P).main() @ &m : res] - 
+         Pr[Pi.REAL.UC_emul(Z, Pi.CompS(Ff,Sf)).main() @ &m : res] | <= e1) =>
+      (forall (Z <: CT.CH2.CENV {-CompRF(Rho,Ff), -F, -S}),
+        `| Pr[H2.REAL.UC_emul(Z, CompRF(Rho,Ff)).main() @ &m : res] - 
+           Pr[H2.REAL.UC_emul(Z, H2.CompS(F,S)).main() @ &m : res] | <= e2) =>
+      exists (S' <: CT.CGOAL.CSIMULATOR {+S, +Sf, -F}), 
+      (forall (Z <: CT.CGOAL.CENV {-Rho, -P, -Ff, -Sf, -F, -S}),
+        `| Pr[GOAL.REAL.UC_emul(Z,CompRP(Rho,P)).main() @ &m : res] - 
+           Pr[GOAL.REAL.UC_emul(Z,GOAL.CompS(F, S')).main() @ &m : res] | <= e1 + e2).
+    proof.
+      move=> hP HR.
+      have [Srho HSrho]:= C0.ex_compose P Ff Sf Rho e1 &m _; 1: by move=> Z0; apply (hP Z0).
+      have := CT.ex_uc_transitivity (CompRP(Rho,P)) (CompRF(Rho,Ff)) F Srho S &m e1 e2 _ _.
+      + move=> Z1; have := HSrho Z1.
+        + have -> : Pr[RPi.REAL.UC_emul(Z1, CompRP(Rho, P)).main() @ &m : res] = 
+                    Pr[H1.REAL.UC_emul(Z1, CompRP(Rho, P)).main() @ &m : res].
+          + by byequiv => //; sim.
+          have -> // : Pr[RPi.REAL.UC_emul(Z1, RPi.CompS(CompRF(Rho, Ff), Srho)).main() @ &m : res] = 
+                    Pr[H1.REAL.UC_emul(Z1, H1.CompS(CompRF(Rho, Ff), Srho)).main() @ &m : res].
+          + by byequiv => //; sim.
+      + by move=> Z1; apply (HR Z1).
+      by move=> [S' hS']; exists S' => Z; apply (hS' Z).
+    qed.
+
+  end section.
+
+  end SC.
+
+end COMPOSITION.
+
+abstract theory PARA.
+  
+  clone EXEC_MODEL as Pi1.
+  clone EXEC_MODEL as Pi2.
+
+  clone EXEC_MODEL as Pi12 with
+    type inputs         = (Pi1.inputs, Pi2.inputs) sum,
+    type ask_outputs    = (Pi1.ask_outputs, Pi2.ask_outputs) sum,
+    type outputs        = (Pi1.outputs, Pi2.outputs) sum,
+    type step           = (Pi1.step, Pi2.step) sum,
+    type ask_backdoor   = (Pi1.ask_backdoor, Pi2.ask_backdoor) sum,
+    type backdoor       = (Pi1.backdoor, Pi2.backdoor) sum.
+
+  (* Build the parallel composition of Pi1 and Pi2 *)
+  
+  module EIPara(P1:Pi1.E_INTERFACE, P2:Pi2.E_INTERFACE) : Pi12.E_INTERFACE = {
+   
+    proc inputs(i: Pi12.inputs) = {
+      match i with
+      | Left i => P1.inputs(i);
+      | Right i => P2.inputs(i);
+      end;
+    }
+
+    proc outputs(o : Pi12.ask_outputs) : Pi12.outputs option = {
+      var r1, r2, r;
+      match o with
+      | Left o  => { r1 <@ P1.outputs(o); r <- omap Left r1; }
+      | Right o => { r2 <@ P2.outputs(o); r <- omap Right r2; }
+      end;
+      return r;
+    }
+  
+    proc step(m : Pi12.step) : unit = {
+      match m with
+      | Left m  => P1.step(m);
+      | Right m => P2.step(m);
+      end;
+    }
+  
+    proc backdoor(m : Pi12.ask_backdoor) : Pi12.backdoor option = {
+      var r1, r2, r;
+      match m with 
+      | Left m  => { r1 <@ P1.backdoor(m); r <- omap Left r1; }
+      | Right m => { r2 <@ P2.backdoor(m); r <- omap Right r2; }
+      end;
+      return r;
+    }
+ 
+  }.
+
+  module PPara (P1:Pi1.PROTOCOL, P2:Pi2.PROTOCOL) : Pi12.PROTOCOL = {
+    proc init() = {
+      P1.init();
+      P2.init();
+    }
+
+    include EIPara(P1,P2)
+  }.
+
+end PARA.
+
+abstract theory PARA_IR.
+
+  clone EXEC_MODEL as Pi1.
+  clone REAL_IDEAL as Pi2.
+
+  clone PARA as R with
+    type Pi1.inputs        <- PARA_IR.Pi1.inputs,
+    type Pi1.ask_outputs   <- PARA_IR.Pi1.ask_outputs,
+    type Pi1.outputs       <- PARA_IR.Pi1.outputs,
+    type Pi1.step          <- PARA_IR.Pi1.step,
+    type Pi1.ask_backdoor  <- PARA_IR.Pi1.ask_backdoor,
+    type Pi1.backdoor      <- PARA_IR.Pi1.backdoor,
+    type Pi2.inputs        <- PARA_IR.Pi2.REAL.inputs,
+    type Pi2.ask_outputs   <- PARA_IR.Pi2.REAL.ask_outputs,
+    type Pi2.outputs       <- PARA_IR.Pi2.REAL.outputs,
+    type Pi2.step          <- PARA_IR.Pi2.REAL.step,
+    type Pi2.ask_backdoor  <- PARA_IR.Pi2.REAL.ask_backdoor,
+    type Pi2.backdoor      <- PARA_IR.Pi2.REAL.backdoor.
+
+  clone PARA as I with
+    type Pi1.inputs        <- PARA_IR.Pi1.inputs,
+    type Pi1.ask_outputs   <- PARA_IR.Pi1.ask_outputs,
+    type Pi1.outputs       <- PARA_IR.Pi1.outputs,
+    type Pi1.step          <- PARA_IR.Pi1.step,
+    type Pi1.ask_backdoor  <- PARA_IR.Pi1.ask_backdoor,
+    type Pi1.backdoor      <- PARA_IR.Pi1.backdoor,
+    type Pi2.inputs        <- PARA_IR.Pi2.REAL.inputs,
+    type Pi2.ask_outputs   <- PARA_IR.Pi2.REAL.ask_outputs,
+    type Pi2.outputs       <- PARA_IR.Pi2.REAL.outputs,
+    type Pi2.step          <- PARA_IR.Pi2.IDEAL.step,
+    type Pi2.ask_backdoor  <- PARA_IR.Pi2.IDEAL.ask_backdoor,
+    type Pi2.backdoor      <- PARA_IR.Pi2.IDEAL.backdoor.
+
+  clone REAL_IDEAL as RI with
+    type REAL.inputs         <- R.Pi12.inputs,
+    type REAL.ask_outputs    <- R.Pi12.ask_outputs,
+    type REAL.outputs        <- R.Pi12.outputs,
+    type REAL.step           <- R.Pi12.step,
+    type REAL.ask_backdoor   <- R.Pi12.ask_backdoor,
+    type REAL.backdoor       <- R.Pi12.backdoor,
+    type IDEAL.step          <- I.Pi12.step,
+    type IDEAL.ask_backdoor  <- I.Pi12.ask_backdoor,
+    type IDEAL.backdoor      <- I.Pi12.backdoor.
+   
+  module (Sid(Sf:Pi2.SIMULATOR) : RI.SIMULATOR) (FB : RI.IDEAL.BACKDOORS) = {
+  
+    module FBPi = {
+      proc step(m:Pi2.IDEAL.step) : unit = {
+        FB.step(Right m);
+      }
+      
+      proc backdoor(m:Pi2.IDEAL.ask_backdoor) : Pi2.IDEAL.backdoor option = {
+        var r;
+        r <@ FB.backdoor (Right m);
+        return obind getr r;
+      }
+    }
+    
+    proc init = Sf(FBPi).init 
+  
+    proc step(m:R.Pi12.step) : unit = {
+      match (m) with
+      | Left m1  => { FB.step(Left m1); }
+      | Right m2 => { Sf(FBPi).step(m2); }
+      end;
+    }
+    
+    proc backdoor(m:R.Pi12.ask_backdoor) : R.Pi12.backdoor option = {
+      var r1, r2, r;
+      match (m) with
+      | Left  m1 => { r1 <@ FB.backdoor(Left m1); r <- omap Left (obind getl r1); } 
+      | Right m2 => { r2 <@ Sf(FBPi).backdoor(m2); r <- omap Right r2; }
+      end;
+      return r;
+    }
+  }.
+
+  module (CompZR(Z:RI.REAL.ENV, F1: Pi1.PROTOCOL) : Pi2.REAL.ENV) (P2:Pi2.REAL.E_INTERFACE) = {
+    proc distinguish() = {
+      var b;
+      F1.init();
+      b <@ Z(R.EIPara(F1,P2)).distinguish();
+      return b;
+    }
+  }.
+  
+  section PROOF.
+
+    declare module F1 <: Pi1.PROTOCOL.
+    declare module P2 <: Pi2.REAL.PROTOCOL {-F1}.
+    declare module F2 <: Pi2.IDEAL.PROTOCOL {-F1, -P2}.
+    declare module S2 <: Pi2.SIMULATOR {-F1, -P2, -F2}.
+
+    declare module Z  <: RI.REAL.ENV { -F1, -P2, -F2, -S2 }.
+
+    equiv F2_step : Sid(S2, I.PPara(F1, F2)).FBPi.step ~ F2.step : ={arg, glob F2, glob F1} ==>  ={res, glob F2, glob F1}.
+    proof.
+      proc *; inline *; sp; match Right {1} 1; 1: by auto; smt(). 
+      by call(:true); skip.
+    qed.
+
+    equiv F2_backdoor: Sid(S2, I.PPara(F1, F2)).FBPi.backdoor ~ F2.backdoor : ={arg, glob F2, glob F1} ==>  ={res, glob F2, glob F1}.
+    proof.
+      proc *; inline *; sp; match Right {1} 1; 1: by auto; smt(). 
+      by wp; call(:true); skip => /> /#.
+    qed.
+
+    lemma compose &m : 
+      Pr[RI.REAL.UC_emul(Z, R.PPara(F1, P2)).main() @ &m : res] -
+      Pr[RI.REAL.UC_emul(Z, RI.CompS(I.PPara(F1,F2), Sid(S2))).main() @ &m : res] = 
+      Pr[Pi2.REAL.UC_emul(CompZR(Z,F1), P2).main() @ &m : res] -
+      Pr[Pi2.REAL.UC_emul(CompZR(Z,F1), Pi2.CompS(F2, S2)).main() @ &m : res].
+    proof.
+      congr.
+      + by byequiv => //; proc; inline *; swap{1} 1 1; sim.
+      congr.
+      byequiv => //; proc; inline *; wp.
+      call (: ={glob F1, glob F2, glob S2}); 1..2: sim.
+      + proc; inline *; match => *; 1..2: smt().
+        + sp; match Left {1} 1; 1: by auto; smt().
+          by call(:true); skip.
+        call(: ={glob F2, glob F1}); last by auto.
+        + by apply F2_step.
+        by apply F2_backdoor.
+      + proc; inline *; match => *; 1..2: smt().
+        + wp; sp; match Left {1} 1; 1: by auto; smt().
+          by wp; call(:true); skip => /#.
+        wp; call(: ={glob F2, glob F1}); last by auto.
+        + by apply F2_step.
+        by apply F2_backdoor.
+      swap{2} 3 -2; sim />.
+    qed.
+
+  end section PROOF.
+
+  abstract theory C.
+
+  op cz  : cenv.  (* complexity of Z   *)
+  op cf1 : cprot. (* complexity of F1  *)
+  op cs2 : csim.  (* complexity of S2  *)
+
+  axiom cz_pos   : cenv_pos cz.
+  axiom cf1_pos  : cprot_pos cf1.
+  axiom cs2_pos  : csim_pos cs2.
+
+  clone Pi1.CP as CPi1 with 
+    op cp <- cf1 
+    proof * by smt (cf1_pos).
+
+  clone RI.C as CRI with
+    op c <- cz,
+    (* complexity of the simulator for Para(F1,P2) *)
+    op csi = {|
+        cinit = cs2.`cinit;
+        cstep = max 2 (1 + cs2.`cstep + cs2.`cs_s + 4 * cs2.`cs_b);
+        cs_s  = max 1 cs2.`cs_s;
+        cs_b  = cs2.`cs_b; 
+        cbackdoor = max 7 (3 + cs2.`cbackdoor + cs2.`cb_s + 4 * cs2.`cb_b);
+        cb_s  = cs2.`cb_s;
+        cb_b  = max 1 cs2.`cb_b;
+      |}
+    proof *by smt(cz_pos cs2_pos).
+  
+  clone Pi2.C as CPi2 with
+    op c = {|
+        cd = cf1.`cpinit + cz.`cd + 
+             (1 + cf1.`cpinputs) * cz.`ci + (4 + cf1.`cpoutputs) * cz.`co + (1 + cf1.`cpstep) * cz.`cs + (4 + cf1.`cpbackdoor) * cz.`cb;
+        ci = cz.`ci;
+        co = cz.`co;
+        cs = cz.`cs;
+        cb = cz.`cb;
+      |},
+    op csi <- cs2
+    proof * by smt(cf1_pos cz_pos cs2_pos).
+
+  section.
+
+    declare module F1 <: CPi1.CPROTOCOL.
+    declare module P2 <: Pi2.REAL.PROTOCOL {-F1}.
+    declare module F2 <: Pi2.IDEAL.PROTOCOL {-F1, -P2}.
+    declare module S2 <: CPi2.CSIMULATOR {-F1, -P2, -F2}.
+
+    lemma ex_compose &m e : 
+      (forall (Z<:CPi2.CENV{-P2, -F2, -S2}), 
+         `|Pr[Pi2.REAL.UC_emul(Z, P2).main() @ &m : res] - 
+            Pr[Pi2.REAL.UC_emul(Z, Pi2.CompS(F2,S2)).main() @ &m : res]| <= e) =>
+      exists (S <: CRI.CSIMULATOR { +S2, -I.PPara(F1,F2)}), 
+        forall (Z <: CRI.CENV{-F1, -P2, -F2, -S2}), 
+         `|Pr[RI.REAL.UC_emul(Z, R.PPara(F1, P2)).main() @ &m : res] -
+             Pr[RI.REAL.UC_emul(Z, RI.CompS(I.PPara(F1,F2), S)).main() @ &m : res]| <= e.
+    proof.
+      move=> h.
+      exists (Sid(S2)); split.
+      + split.
+        + by move=> kbackdoor kstep FB hkb hks; proc true : time [].
+        split => kbackdoor kstep FB hkb hks.
+        + proc; exlim m => -[] mi. 
+          + match Left 1; [1: by auto; smt() | 2: done].
+            call(:true; time []); auto => />; smt(cs2_pos). 
+          match Right 1; [1: by auto; smt() | 2: done].
+          call(:true; time [Sid(S2, FB).FBPi.step     : [ '1; FB.step : 1],
+                            Sid(S2, FB).FBPi.backdoor : [ N 4; FB.backdoor : 1]]).
+          + by move=> * /=; proc; call (:true; time []); auto.
+          + by move=> * /=; proc; call (:true; time []); auto.     
+          skip => />; rewrite !bigi_constz /=; smt(cs2_pos). 
+        proc; exlim m => -[] mi. 
+        + match Left 1; [1:by auto; smt() | 2: done].
+          wp; call(:true; time []); auto => />; smt(cs2_pos).
+        match Right 1; [1: by auto; smt() | 2: done].
+        wp; call(:true; time [Sid(S2, FB).FBPi.step     : [ '1; FB.step : 1],
+                              Sid(S2, FB).FBPi.backdoor : [ N 4; FB.backdoor : 1]]).
+        + by move=> * /=; proc; call (:true; time []); auto.
+        + by move=> * /=; proc; call (:true; time []); auto.     
+        skip => />; rewrite !bigi_constz /=; smt(cs2_pos).
+      move=> Z.
+      rewrite (compose F1 P2 F2 S2 Z).
+      apply (h (CompZR(Z, F1))) => kbackdoor kstep koutputs kinputs I hkb hks hko hki.
+      proc.
+      call (:true; time [R.EIPara(F1, I).inputs   : [N (1 + cf1.`cpinputs)  ; I.inputs   : 1],
+                         R.EIPara(F1, I).outputs  : [N (4 + cf1.`cpoutputs) ; I.outputs  : 1],
+                         R.EIPara(F1, I).step     : [N (1 + cf1.`cpstep)    ; I.step     : 1],
+                         R.EIPara(F1, I).backdoor : [N (4 + cf1.`cpbackdoor); I.backdoor : 1]]) => *.
+      + proc; exlim i => -[] ii.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by call(:true; time []); auto => /> /#.
+        match Right 1; [1: by auto => /# | 2:done].
+        by call(:true; time []); auto => />; smt (cf1_pos).
+      + proc; exlim o => -[] oi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by wp; call(:true; time []); auto => /> /#.
+        match Right 1; [1: by auto => /# | 2:done].
+        by wp; call(:true; time []); auto => />; smt (cf1_pos).
+      + proc; exlim m => -[] mi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by call(:true; time []); auto => /> /#.
+        match Right 1; [1: by auto => /# | 2:done].
+        by call(:true; time []); auto => />; smt (cf1_pos).
+      + proc; exlim m => -[] mi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by wp; call(:true; time []); auto => /> /#.
+        match Right 1; [1: by auto => /# | 2:done].
+        by wp; call(:true; time []); auto => />; smt (cf1_pos).
+      call(:true; time []); skip => />.
+      rewrite !bigi_constz /=; smt(cz_pos cf1_pos).
+    qed.
+  end section.
+  end C.
+
+end PARA_IR.
+
+abstract theory PARA_RI.
+
+  clone REAL_IDEAL as Pi1.
+  clone EXEC_MODEL as Pi2.
+
+  clone PARA as R with
+    type Pi1.inputs        <- PARA_RI.Pi1.REAL.inputs,
+    type Pi1.ask_outputs   <- PARA_RI.Pi1.REAL.ask_outputs,
+    type Pi1.outputs       <- PARA_RI.Pi1.REAL.outputs,
+    type Pi1.step          <- PARA_RI.Pi1.REAL.step,
+    type Pi1.ask_backdoor  <- PARA_RI.Pi1.REAL.ask_backdoor,
+    type Pi1.backdoor      <- PARA_RI.Pi1.REAL.backdoor,
+    type Pi2.inputs        <- PARA_RI.Pi2.inputs,
+    type Pi2.ask_outputs   <- PARA_RI.Pi2.ask_outputs,
+    type Pi2.outputs       <- PARA_RI.Pi2.outputs,
+    type Pi2.step          <- PARA_RI.Pi2.step,
+    type Pi2.ask_backdoor  <- PARA_RI.Pi2.ask_backdoor,
+    type Pi2.backdoor      <- PARA_RI.Pi2.backdoor.
+
+  clone PARA as I with
+    type Pi1.inputs        <- PARA_RI.Pi1.REAL.inputs,
+    type Pi1.ask_outputs   <- PARA_RI.Pi1.REAL.ask_outputs,
+    type Pi1.outputs       <- PARA_RI.Pi1.REAL.outputs,
+    type Pi1.step          <- PARA_RI.Pi1.IDEAL.step,
+    type Pi1.ask_backdoor  <- PARA_RI.Pi1.IDEAL.ask_backdoor,
+    type Pi1.backdoor      <- PARA_RI.Pi1.IDEAL.backdoor,
+    type Pi2.inputs        <- PARA_RI.Pi2.inputs,
+    type Pi2.ask_outputs   <- PARA_RI.Pi2.ask_outputs,
+    type Pi2.outputs       <- PARA_RI.Pi2.outputs,
+    type Pi2.step          <- PARA_RI.Pi2.step,
+    type Pi2.ask_backdoor  <- PARA_RI.Pi2.ask_backdoor,
+    type Pi2.backdoor      <- PARA_RI.Pi2.backdoor.
+
+  clone REAL_IDEAL as RI with
+    type REAL.inputs         <- R.Pi12.inputs,
+    type REAL.ask_outputs    <- R.Pi12.ask_outputs,
+    type REAL.outputs        <- R.Pi12.outputs,
+    type REAL.step           <- R.Pi12.step,
+    type REAL.ask_backdoor   <- R.Pi12.ask_backdoor,
+    type REAL.backdoor       <- R.Pi12.backdoor,
+    type IDEAL.step          <- I.Pi12.step,
+    type IDEAL.ask_backdoor  <- I.Pi12.ask_backdoor,
+    type IDEAL.backdoor      <- I.Pi12.backdoor.
+   
+  module (Sid(Sf:Pi1.SIMULATOR) : RI.SIMULATOR) (FB : RI.IDEAL.BACKDOORS) = {
+  
+    module FBPi = {
+      proc step(m:Pi1.IDEAL.step) : unit = {
+        FB.step(Left m);
+      }
+      
+      proc backdoor(m:Pi1.IDEAL.ask_backdoor) : Pi1.IDEAL.backdoor option = {
+        var r;
+        r <@ FB.backdoor (Left m);
+        return obind getl r;
+      }
+    }
+    
+    proc init = Sf(FBPi).init 
+
+    proc step(m:R.Pi12.step) : unit = {
+      match (m) with
+      | Left m1  => { Sf(FBPi).step(m1); }
+      | Right m2 => { FB.step(Right m2); }
+      end;
+    }
+    
+    proc backdoor(m:R.Pi12.ask_backdoor) : R.Pi12.backdoor option = {
+      var r1, r2, r;
+      match (m) with
+      | Left  m1 => { r1 <@ Sf(FBPi).backdoor(m1); r <- omap Left r1; } 
+      | Right m2 => { r2 <@ FB.backdoor(Right m2); r <- omap Right (obind getr r2); }
+      end;
+      return r;
+    }
+  }.
+
+  module (CompZR(Z:RI.REAL.ENV, F2: Pi2.PROTOCOL) : Pi1.REAL.ENV) (P1:Pi1.REAL.E_INTERFACE) = {
+    proc distinguish() = {
+      var b;
+      F2.init();
+      b <@ Z(R.EIPara(P1,F2)).distinguish();
+      return b;
+    }
+  }.
+  
+  section PROOF.
+
+    declare module F2 <: Pi2.PROTOCOL.
+    declare module P1 <: Pi1.REAL.PROTOCOL {-F2}.
+    declare module F1 <: Pi1.IDEAL.PROTOCOL {-F2, -P1}.
+    declare module S1 <: Pi1.SIMULATOR {-F2, -P1, -F1}.
+
+    declare module Z  <: RI.REAL.ENV { -F2, -P1, -F1, -S1 }.
+
+    equiv F1_step : Sid(S1, I.PPara(F1, F2)).FBPi.step ~ F1.step : ={arg, glob F2, glob F1} ==>  ={res, glob F2, glob F1}.
+    proof.
+      proc *; inline *; sp; match Left {1} 1; 1: by auto; smt(). 
+      by call(:true); skip.
+    qed.
+
+    equiv F1_backdoor: Sid(S1, I.PPara(F1, F2)).FBPi.backdoor ~ F1.backdoor : ={arg, glob F2, glob F1} ==>  ={res, glob F2, glob F1}.
+    proof.
+      proc *; inline *; sp; match Left {1} 1; 1: by auto; smt(). 
+      by wp; call(:true); skip => /> /#.
+    qed.
+
+    lemma compose &m : 
+      Pr[RI.REAL.UC_emul(Z, R.PPara(P1, F2)).main() @ &m : res] -
+      Pr[RI.REAL.UC_emul(Z, RI.CompS(I.PPara(F1,F2), Sid(S1))).main() @ &m : res] = 
+      Pr[Pi1.REAL.UC_emul(CompZR(Z,F2), P1).main() @ &m : res] -
+      Pr[Pi1.REAL.UC_emul(CompZR(Z,F2), Pi1.CompS(F1, S1)).main() @ &m : res].
+    proof.
+      congr.
+      + byequiv => //; proc; inline *; sim.
+      congr.
+      byequiv => //; proc; inline *; wp.
+      call (: ={glob F1, glob F2, glob S1}); 1..2: sim.
+      + proc; inline *; match => *; 1..2: smt().
+        + call(: ={glob F2, glob F1}); last by auto.
+          + by apply F1_step.
+          by apply F1_backdoor.
+        sp; match Right {1} 1; 1: by auto; smt().
+        by call(:true); skip.
+      + proc; inline *; match => *; 1..2: smt().
+        + wp; call(: ={glob F2, glob F1}); last by auto.
+          + by apply F1_step.
+          by apply F1_backdoor.
+        wp; sp; match Right {1} 1; 1: by auto; smt().
+        by wp; call(:true); skip => /#.
+      swap{2} 3 -1; sim />.
+    qed.
+
+  end section PROOF.
+
+  abstract theory C.
+
+  op cz  : cenv.  (* complexity of Z   *)
+  op cf2 : cprot. (* complexity of F2  *)
+  op cs1 : csim.  (* complexity of S1  *)
+
+  axiom cz_pos   : cenv_pos cz.
+  axiom cf2_pos  : cprot_pos cf2.
+  axiom cs1_pos  : csim_pos cs1.
+
+  clone Pi2.CP as CPi2 with 
+    op cp <- cf2 
+    proof * by smt (cf2_pos).
+
+  clone RI.C as CRI with
+    op c <- cz,
+    (* complexity of the simulator for Para(F1,P2) *)
+    op csi = {|
+        cinit = cs1.`cinit;
+        cstep = max 2 (1 + cs1.`cstep + cs1.`cs_s + 4 * cs1.`cs_b);
+        cs_s  = max 1 cs1.`cs_s;
+        cs_b  = cs1.`cs_b; 
+        cbackdoor = max 7 (3 + cs1.`cbackdoor + cs1.`cb_s + 4 * cs1.`cb_b);
+        cb_s  = cs1.`cb_s;
+        cb_b  = max 1 cs1.`cb_b;
+      |}
+    proof *by smt(cz_pos cs1_pos).
+  
+  clone Pi1.C as CPi1 with
+    op c = {|
+        cd = cf2.`cpinit + cz.`cd + 
+             (1 + cf2.`cpinputs) * cz.`ci + (4 + cf2.`cpoutputs) * cz.`co + (1 + cf2.`cpstep) * cz.`cs + (4 + cf2.`cpbackdoor) * cz.`cb;
+        ci = cz.`ci;
+        co = cz.`co;
+        cs = cz.`cs;
+        cb = cz.`cb;
+      |},
+    op csi <- cs1
+    proof * by smt(cf2_pos cz_pos cs1_pos).
+
+  section.
+
+    declare module F2 <: CPi2.CPROTOCOL.
+    declare module P1 <: Pi1.REAL.PROTOCOL {-F2}.
+    declare module F1 <: Pi1.IDEAL.PROTOCOL {-F2, -P1}.
+    declare module S1 <: CPi1.CSIMULATOR {-F2, -P1}.
+
+    lemma ex_compose &m e : 
+      (forall (Z<:CPi1.CENV{-P1, -F1, -S1}), 
+         `|Pr[Pi1.REAL.UC_emul(Z, P1).main() @ &m : res] - 
+            Pr[Pi1.REAL.UC_emul(Z, Pi1.CompS(F1,S1)).main() @ &m : res]| <= e) =>
+      exists (S <: CRI.CSIMULATOR { +S1, -I.PPara(F1,F2) }), 
+        forall (Z <: CRI.CENV{-F2, -P1, -F1, -S1}), 
+         `|Pr[RI.REAL.UC_emul(Z, R.PPara(P1, F2)).main() @ &m : res] -
+            Pr[RI.REAL.UC_emul(Z, RI.CompS(I.PPara(F1,F2), S)).main() @ &m : res]| <= e.
+    proof.
+      move=> h.
+      exists (Sid(S1)); split.
+      + split.
+        + by move=> kbackdoor kstep FB hkb hks; proc true : time [].
+        split => kbackdoor kstep FB hkb hks.
+        + proc; exlim m => -[] mi. 
+          + match Left 1; [1: by auto; smt() | 2:done] .
+            call(:true; time [Sid(S1, FB).FBPi.step     : [ '1; FB.step : 1],
+                              Sid(S1, FB).FBPi.backdoor : [ N 4; FB.backdoor : 1]]).
+            + by move=> * /=; proc; call (:true; time []); auto.
+            + by move=> * /=; proc; call (:true; time []); auto.     
+            skip => />; rewrite !bigi_constz /=; smt(cs1_pos). 
+          match Right 1; [1: by auto; smt() | 2:done].
+          call(:true; time []); auto => />; smt(cs1_pos). 
+        proc; exlim m => -[] mi. 
+        + match Left 1; [1: by auto; smt() | 2:done].
+          wp; call(:true; time [Sid(S1, FB).FBPi.step     : [ '1; FB.step : 1],
+                                Sid(S1, FB).FBPi.backdoor : [ N 4; FB.backdoor : 1]]).
+          + by move=> * /=; proc; call (:true; time []); auto.
+          + by move=> * /=; proc; call (:true; time []); auto.     
+          skip => />; rewrite !bigi_constz /=; smt(cs1_pos).
+        match Right 1; [1: by auto; smt() | 2:done].
+        wp; call(:true; time []); auto => />; smt(cs1_pos).
+      move=> Z.
+      rewrite (compose F2 P1 F1 S1 Z).
+      apply (h (CompZR(Z, F2))) => kbackdoor kstep koutputs kinputs I hkb hks hko hki.
+      proc.
+      call (:true; time [R.EIPara(I, F2).inputs   : [N (1 + cf2.`cpinputs)  ; I.inputs   : 1],
+                         R.EIPara(I, F2).outputs  : [N (4 + cf2.`cpoutputs) ; I.outputs  : 1],
+                         R.EIPara(I, F2).step     : [N (1 + cf2.`cpstep)    ; I.step     : 1],
+                         R.EIPara(I, F2).backdoor : [N (4 + cf2.`cpbackdoor); I.backdoor : 1]]) => *.
+      + proc; exlim i => -[] ii.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by call(:true; time []); auto => />; smt (cf2_pos).
+        match Right 1; [1: by auto => /# | 2:done].
+        by call(:true; time []); auto => /> /#.
+      + proc; exlim o => -[] oi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by wp; call(:true; time []); auto => />; smt (cf2_pos).
+        match Right 1; [1: by auto => /# | 2:done].
+        by wp; call(:true; time []); auto => /> /#.
+      + proc; exlim m => -[] mi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by call(:true; time []); auto => />; smt (cf2_pos).
+        match Right 1; [1: by auto => /# | 2:done].
+        by call(:true; time []); auto => /> /#.
+      + proc; exlim m => -[] mi.
+        + match Left 1; [1: by auto => /# | 2:done]. 
+          by wp; call(:true; time []); auto => />; smt (cf2_pos).
+        match Right 1; [1: by auto => /# | 2:done].
+        by wp; call(:true; time []); auto => /> /#.
+      call(:true; time []); skip => />.
+      rewrite !bigi_constz /=; smt(cz_pos cf2_pos).
+    qed.
+  end section.
+  end C.
+
+end PARA_RI.

--- a/examples/UC/dh_enc_cost.ec
+++ b/examples/UC/dh_enc_cost.ec
@@ -1,0 +1,2373 @@
+require import AllCore SmtMap Distr RndO CHoareTactic.
+require import Composition_cost.
+
+import CoreMap Bigxint.
+
+(* Parties have some sort of identifier *)
+type party.
+
+(* 2 party Protocols have roles *)
+type role = [ | I | R ].
+
+(* Most protocols will pack data in packages *)
+type 'a pkg = party * party * 'a.
+
+op snd (p : 'a pkg) = p.`1.
+op rcv (p : 'a pkg) = p.`2.
+op pld (p : 'a pkg) = p.`3.
+
+lemma pkgid (p p' : unit pkg): p = (snd p',rcv p', ()) => p = p' by smt().
+
+schema cost_rcv ['a] `{P} {p : 'a pkg} : cost [P : rcv p] = '1 + cost [P : p].
+schema cost_snd ['a] `{P} {p : 'a pkg} : cost [P : snd p] = '1 + cost [P : p].
+schema cost_pld ['a] `{P} {p:'a pkg} : cost[P:pld p] = '1 + cost [P:p].
+schema cost_tt : cost [true : tt] = '0.
+
+hint simplify cost_pld, cost_rcv, cost_snd, cost_tt.
+
+schema cost_eqI `{P} {r:role} : cost [P : r = I] = '1 + cost [P : r].
+schema cost_eqR `{P} {r:role} : cost [P : r = R] = '1 + cost [P : r].
+hint simplify cost_eqI, cost_eqR.
+
+schema cost_eqNone ['a] `{P} {x:'a option} : cost [P: x = None] = '1 + cost [P : x].
+hint simplify cost_eqNone.
+
+schema cost_eqLefttt `{P} {r: (unit,unit) sum} : cost [P : r = Left tt] = '1 + cost [P : r].
+schema cost_eqRighttt `{P} {r: (unit,unit) sum} : cost [P : r = Right tt] = '1 + cost [P : r].
+hint simplify cost_eqLefttt, cost_eqRighttt.
+
+
+(****************************************************************)
+(*                    CHANNEL FUNCTIONALITIES                   *)
+(****************************************************************)
+
+type 'a stlkg = [
+   | Ch_Init
+   | Ch_Blocked1 of 'a
+   | Ch_Wait of 'a
+   | Ch_Blocked2 of 'a
+   | Ch_Available of 'a 
+].
+
+schema cost_eqSRI ['a] {r2: ('a stlkg, 'a stlkg) sum option} : cost[true : r2 = Some (Right Ch_Init)] = N 3 + cost [true : r2].
+hint simplify cost_eqSRI.
+
+theory FChan.
+
+type msg.
+
+type state = (msg pkg) stlkg.
+
+op leakpkg (p : msg pkg) : unit pkg = (snd p, rcv p, ()).
+
+op init_st : state = Ch_Init.
+
+op get_msg (st : state) (r : role) (p' : unit pkg)  = 
+    with st = Ch_Init => None
+    with st = Ch_Blocked1 _ => None
+    with st = Ch_Wait _ => None
+    with st = Ch_Blocked2 _ => None
+    with st = Ch_Available p => if leakpkg p = p' /\ r = R then Some (pld p) else None.
+ 
+op unblock (st : state) =
+    with st = Ch_Init => st
+    with st = Ch_Blocked1 p => Ch_Wait p
+    with st = Ch_Wait _ => st
+    with st = Ch_Blocked2 p => Ch_Available p
+    with st = Ch_Available _ => st.
+
+theory FAuth.
+
+op set_msg (st : state) (r : role) (p : msg pkg) = 
+    with st = Ch_Init => if r = I then Ch_Blocked2 p else st
+    with st = Ch_Blocked1 _ => st
+    with st = Ch_Wait _ => st
+    with st = Ch_Blocked2 _ => st
+    with st = Ch_Available _ => st.
+
+type leakage = (msg pkg) stlkg.
+
+op leak (st : state) = Some st.
+
+schema cost_witness_msgpkg : cost [true: witness <:msg pkg>] = '1.
+hint simplify cost_witness_msgpkg.
+
+schema cost_init_st : cost [true : init_st] = '1.
+schema cost_set_msg {r : role, p : msg pkg, st: state } : 
+  cost [true : set_msg st r p] = N 3 + cost[true : st] + cost [true : r] + cost [true : p].
+schema cost_get_msg {r : role, p : unit pkg, st: state } :
+   cost [true :  get_msg st r p] = N 9 + cost[true : st] + cost [true : r] + cost [true : p].
+schema cost_unblock {st:state} : cost [true : unblock st] = N 2 + cost[true : st].
+schema cost_leak    {st: state} : cost [true : leak st] = '1 + cost[true : st].
+hint simplify cost_init_st, cost_set_msg, cost_get_msg, cost_unblock, cost_leak.
+
+clone import REAL_IDEAL as FAuthWorlds with
+    type REAL.inputs <- role * msg pkg,
+    type REAL.ask_outputs <- role * unit pkg,
+    type REAL.outputs <- msg,
+    type IDEAL.step <- unit,
+    type IDEAL.ask_backdoor <- unit,
+    type IDEAL.backdoor <- leakage.
+
+import IDEAL.
+
+module FAuth : PROTOCOL = {
+   var st : state
+
+   proc init() : unit = { st <- init_st; }
+
+   proc inputs(r : role, p : msg pkg) : unit = {
+      st <- set_msg st r p;
+   }
+
+   proc outputs(r : role, p : unit pkg) : msg option = {
+      return get_msg st r p;
+   }
+
+   proc step() : unit = {
+      st <- unblock st;
+   }
+
+   proc backdoor() : leakage option = {
+      return leak st;
+   }
+
+}.
+
+end FAuth.
+
+(* We need to replace this with general parallel composition of
+   functionalitites *)
+theory F2Auth.
+
+clone FAuth as FAuthLR.
+
+clone FAuth as FAuthRL.
+
+clone import PARA with
+    type Pi1.inputs        <- role * msg pkg,
+    type Pi1.ask_outputs   <- role * unit pkg,
+    type Pi1.outputs       <- msg,
+    type Pi1.step          <- unit,
+    type Pi1.ask_backdoor  <- unit,
+    type Pi1.backdoor      <- (msg pkg) stlkg,
+    type Pi2.inputs        <- role * msg pkg,
+    type Pi2.ask_outputs   <- role * unit pkg,
+    type Pi2.outputs       <- msg,
+    type Pi2.step          <- unit,
+    type Pi2.ask_backdoor  <- unit,
+    type Pi2.backdoor      <- (msg pkg) stlkg.
+
+module F2Auth = PPara(FAuthLR.FAuth,FAuthRL.FAuth).
+
+end F2Auth.
+
+theory FSC.
+
+type leakage = (unit pkg) stlkg.
+
+op set_msg (st : state) (r : role) (p : msg pkg) = 
+    with st = Ch_Init => if r = I then Ch_Blocked1 p else st
+    with st = Ch_Blocked1 _ => st
+    with st = Ch_Wait p' => if r = R /\ snd p' = snd p /\ rcv p' = rcv p then Ch_Blocked2 p' else st
+    with st = Ch_Blocked2 _ => st
+    with st = Ch_Available _ => st.
+
+op leak (st : state) = 
+    with st = Ch_Init => Some Ch_Init
+    with st = Ch_Blocked1 p => Some (Ch_Blocked1 (leakpkg p))
+    with st = Ch_Wait p => Some (Ch_Wait (leakpkg p))
+    with st = Ch_Blocked2 p => Some (Ch_Blocked2 (leakpkg p))
+    with st = Ch_Available p => Some (Ch_Available (leakpkg p)).
+
+clone import REAL_IDEAL as FSCWorlds with
+    type REAL.inputs <- role * msg pkg,
+    type REAL.ask_outputs <- role * unit pkg,
+    type REAL.outputs <- msg,
+    type IDEAL.step <- unit,
+    type IDEAL.ask_backdoor <- unit,
+    type IDEAL.backdoor <- leakage.
+
+import IDEAL.
+
+module FSC : PROTOCOL = {
+   var st : state
+
+   proc init() : unit = { st <- init_st; }
+
+   proc inputs(r : role, p : msg pkg) : unit = {
+      st <- set_msg st r p;
+   }
+
+   proc outputs(r : role, p : unit pkg) : msg option = {
+      return get_msg st r p;
+   }
+
+   proc step() : unit = {
+      st <- unblock st;
+   }
+
+   proc backdoor() : leakage option = {
+      return leak st;
+   }
+
+}.
+
+end FSC.
+
+end FChan.
+
+(****************************************************************)
+(*                  KEY EXCHANGE FUNCTIONALITY                  *)
+(****************************************************************)
+
+
+theory FKE.
+
+type key.
+
+op gen : key distr.
+
+type kestate = [
+  | KE_Init
+  | KE_Blocked1 of unit pkg
+  | KE_Wait of unit pkg
+  | KE_Blocked2 of unit pkg
+  | KE_Available of unit pkg
+].
+
+type state = {
+  key : key;
+  kst : kestate;
+}.
+
+type leakage = kestate.
+
+op init key = {| key = key; kst = KE_Init |}.
+
+schema cost_init `{P} {k:key} : cost[P:init k] = N 2 + cost[P:k].
+hint simplify cost_init.
+
+(* This is a hack *)
+op kstp st = st.`kst.
+
+(* Both parties need to provide the same party ids and roles
+   for the protocol to start *)
+op party_start (st : state) (r : role)  (p' : unit pkg) = 
+ match (kstp st) with
+    |  KE_Init        => if r = I
+                         then {| st with kst = KE_Blocked1 p' |} 
+                         else st
+    |  KE_Blocked1 p  => st
+    |  KE_Wait p      => if r = R /\ p = p' 
+                         then {| st with kst = KE_Blocked2 p |} 
+                         else st
+    |  KE_Blocked2 p  => st
+    |  KE_Available p => st
+    end.
+
+op party_output (st : state) (r : role) = 
+    match (kstp st) with
+    |  KE_Init        => None
+    |  KE_Blocked1 p  =>  None
+    |  KE_Wait p      => None
+    |  KE_Blocked2 p  => if r = R
+                         then Some st.`key
+                         else None
+    |  KE_Available p => if r = I \/ r = R
+                         then Some st.`key
+                         else None
+    end.
+
+op unblock st = 
+    match (kstp st) with
+    |  KE_Init        => st
+    |  KE_Blocked1 p  => {| st with kst = KE_Wait p |} 
+    |  KE_Wait p      => st
+    |  KE_Blocked2 p  => {| st with kst = KE_Available p |} 
+    |  KE_Available p => st
+    end.
+
+op leak st = Some st.`kst.
+
+schema cost_leak `{P} {st:state} : cost [P:leak st] = '1 + cost[P:st].
+hint simplify cost_leak.
+
+schema cost_unblock `{P} {s:state} : cost[P : unblock s] = N 2 + cost[P : s].
+hint simplify cost_unblock.
+
+clone import REAL_IDEAL as FKEWorlds with
+    type REAL.inputs <- role * unit pkg,
+    type REAL.ask_outputs <- role,
+    type REAL.outputs <- key,
+    type IDEAL.step <- unit,
+    type IDEAL.ask_backdoor <- unit,
+    type IDEAL.backdoor <- leakage.
+
+import IDEAL.
+
+module FKE : PROTOCOL = {
+   var st : state
+
+   proc init() : unit = {
+      var k;
+      k <$ gen;
+      st <- init k;
+   }
+
+   proc inputs(r : role, p : unit pkg) : unit = {
+      st <- party_start st r p;
+   }
+
+   proc outputs(r : role) : key option = {
+      return party_output st r;
+   }
+
+   proc step() : unit = {
+      st <- unblock st;
+   }
+
+   proc backdoor() : leakage option = {
+      return leak st;
+   }
+
+}.
+
+(* The following subtheory defines a joint
+    ideal functionality that combines FKE with
+    FAuth in parallel. *)
+
+theory FKEAuth.
+
+clone import FChan.
+
+clone import PARA with
+    type Pi1.inputs        <- role * msg pkg,
+    type Pi1.ask_outputs   <- role * unit pkg,
+    type Pi1.outputs       <- msg,
+    type Pi1.step          <- unit,
+    type Pi1.ask_backdoor  <- unit,
+    type Pi1.backdoor      <- (msg pkg) stlkg,
+    type Pi2.inputs        <- role * unit pkg,
+    type Pi2.ask_outputs   <- role,
+    type Pi2.outputs       <- key,
+    type Pi2.step          <- unit,
+    type Pi2.ask_backdoor  <- unit,
+    type Pi2.backdoor      <- kestate.
+
+module FKEAuth = PPara(FAuth.FAuth,FKE).
+
+end FKEAuth.
+
+end FKE.
+
+(****************************************************************)
+(*                  DIFFIE - HELLMAN PROTOCOL                   *)
+(****************************************************************)
+
+
+require import DiffieHellman.
+
+schema cost_dapply : cost[true : dapply (fun (x : t) => g ^ x) FDistr.dt] = 
+                          N (FDistr.cdt + cgpow).
+
+op adv_ddh : int -> real.
+
+axiom adv_ddh_max cddh : 
+   forall (A <:DDH.Adversary [ guess : `{N cddh}]) &m, 
+     `| Pr[DDH.DDH0(A).main() @&m : res] - Pr[DDH.DDH1(A).main() @&m : res] | <= adv_ddh cddh.
+
+theory DHKE. 
+
+import DDH.
+
+clone import FChan as HybFChan with
+     type msg <- group.
+
+(* This allows us to define a hybrid protocol that uses F2Auth.
+   We don't intend to instantiate this functionality.  *)
+clone import COMPOSITION with
+   type Pi.REAL.inputs = (role * group pkg, role * group pkg) sum,
+   type Pi.REAL.ask_outputs = (role * unit pkg, role * unit pkg) sum,
+   type Pi.REAL.outputs = (group, group) sum,
+   type Pi.IDEAL.step =  (unit,unit) sum,
+   type Pi.IDEAL.ask_backdoor =  (unit,unit) sum,
+   type Pi.IDEAL.backdoor = (state,state) sum,
+   type R.inputs = role * unit pkg,
+   type R.ask_outputs = role,
+   type R.outputs = group,
+   type R.step = role,
+   type R.ask_backdoor = role,
+   type R.backdoor = unit.
+
+import RPi.
+
+type istate = [
+   | IInit
+   | ISent
+   | IDone
+].
+
+type rstate = [
+   | RWaiting
+   | RDone
+].
+
+schema cost_eqIInit `{P} {i:istate} : cost[P : i = IInit] = '1 + cost[P: i].
+schema cost_eqISent `{P} {i:istate} : cost[P : i = ISent] = '1 + cost[P: i].
+schema cost_eqRWaiting `{P} {i:rstate} : cost[P : i = RWaiting] = '1 + cost[P: i].
+hint simplify cost_eqIInit, cost_eqISent, cost_eqRWaiting.
+
+schema cost_witness_UPKG `{P} : cost[P : witness <:unit pkg>] = '1.
+hint simplify cost_witness_UPKG.
+
+module (DHKE : RHO) (Auth: Pi.REAL.IO) = {
+
+   module Initiator = {
+     var p : unit pkg
+     var st : istate
+     var _X : group
+     var _x : F.t
+     var _K  : group option
+
+     proc init() : unit = {
+        p <- witness;
+        st <- IInit;
+        _x <$ FDistr.dt;
+        _X <- g^_x;
+        _K <- None;
+     }
+  
+     proc inputs(_p : unit pkg) : unit = { 
+        if (st = IInit) {
+           p <- _p;
+           Auth.inputs(Left (I, (snd p, rcv p, _X))); 
+           st <- ISent;
+        }
+     }
+  
+     proc outputs() : group option = { 
+        return _K;
+     }
+
+     proc step() : unit = { 
+        var _Y;
+        if (st = ISent) {
+           _Y <@ Auth.outputs(Right (R, (rcv p, snd p, ())));
+           if (_Y <> None) {
+              _K <- Some (oget (getr (oget _Y)) ^ _x);
+              st <- IDone;
+           }
+        }
+     }
+  
+     proc backdoor() : unit option = { 
+         return None;
+     }
+   }
+
+   module Responder = {
+     var p : unit pkg
+     var st : rstate
+     var _Y : group
+     var _y : F.t
+     var _K  : group option
+
+     proc init() : unit = {
+        p <- witness;
+        st <- RWaiting;
+        _y <$ FDistr.dt;
+        _Y <- g^_y;
+        _K <- None;
+     }
+  
+     proc inputs(_p : unit pkg) : unit = { 
+        var _X;
+        if (st = RWaiting) {
+           _X <@ Auth.outputs(Left (R,_p));
+           if (_X <> None) {
+              p <- _p;
+              Auth.inputs(Right (I, (rcv p, snd p, _Y))); 
+              _K <- Some (oget (getl (oget _X)) ^ _y);
+              st <- RDone;
+           }
+        }
+     }
+  
+     proc outputs() : group option = { 
+        return _K;
+     }
+  
+     proc step() : unit = { 
+     }
+  
+     proc backdoor() : unit option = { 
+         return None;
+     }
+   }
+
+   (* Now the protocol *)
+
+   proc init() : unit = {
+     Initiator.init();
+     Responder.init();
+   }
+
+   proc inputs(r : role, p : unit pkg) : unit = {
+      if (r = I) {
+            Initiator.inputs(p);
+      } else {
+            Responder.inputs(p);
+      }  
+   }
+
+   proc outputs(r : role) : group option = {
+      var rr;
+      rr <- None;
+      if (r = I) {
+         rr <@ Initiator.outputs();
+      } else {
+         rr <@ Responder.outputs();
+      }
+      return rr;
+   }
+
+   proc step(r : role) : unit = {
+      if (r = I) {
+         Initiator.step();
+      } else {
+         Responder.step();
+      }
+   }
+
+   proc backdoor(r : role) : unit option = {
+      var rr;
+      if (r = I) {
+         rr <@ Initiator.backdoor();
+      } else {
+         rr <@ Responder.backdoor();
+      }
+      return rr;
+   }
+
+}.
+
+(* To have the type of the simulator we need now to clone FKE. *)
+
+clone import FKE with
+  type key <- group,
+  op gen <- dapply (fun x => g^x) FDistr.dt,
+  type FKEWorlds.REAL.step <- IDEAL.step,
+  type FKEWorlds.REAL.ask_backdoor <- IDEAL.ask_backdoor,
+  type FKEWorlds.REAL.backdoor <- IDEAL.backdoor,
+  type FKEAuth.FChan.msg <- group.
+
+clone import F2Auth as SimAuth.
+
+import FKEWorlds.
+
+module (DHKE_SIM : SIMULATOR) (FB : IDEAL.BACKDOORS) = {
+   var _Keager : group
+
+   var _X : group
+   var _Y : group
+
+   proc init() : unit = {
+     var x,y;
+
+     x <$ FDistr.dt;
+     y <$ FDistr.dt;
+
+     _X <- g^x;
+     _Y <- g^y;
+
+     SimAuth.F2Auth.init();
+   }
+
+   proc step(s : RPi.IDEAL.step) : unit = {
+      var lk ,__Y;
+      match (s) with
+      | Left r => { 
+         (* Stepping Rho *)
+         lk <@ FB.backdoor();
+         if (lk <> None) {
+            match (oget lk) with 
+            | KE_Init => {
+                 (* Nothing happened on the inputs side,
+                    so nothing to do *)
+              }
+            | KE_Blocked1 i => {
+                 (* Initiator was given first input, but
+                    this was not yet delivered. We do
+                    nothing *)
+              } 
+            | KE_Wait i => {
+                 (* Nothing happened on the receiver 
+                    side yet, we wait *)
+              }
+            | KE_Blocked2 i => {
+                 (* We got an input on the receiver 
+                    side for sure.
+                    The sender may now be terminating in the
+                    real world, easy to check because we will
+                    have a message to read also on the initiator
+                    end of things *)
+                    if (r = I) {    
+                         __Y <@ SimAuth.F2Auth.outputs(Right (R,(rcv i, snd i, ())));
+                        if (__Y <> None) {
+                           FB.step();
+                        }
+                    }
+              }
+            | KE_Available i => {
+                 (* Nothing to do *)
+              }
+            end;
+         }
+        }
+      | Right r => { 
+         (* Stepping F2Auth *)
+         lk <@ FB.backdoor();
+         if (lk <> None) {
+            match (oget lk) with 
+            | KE_Init => {
+                 (* Nothing happened on the inputs side,
+                    so nothing to do *)
+              }
+            | KE_Blocked1 i => {
+                    if (r = Left ()) {
+                        (* Initiator was given first input, and
+                           this is now being delivered. *)
+                        SimAuth.F2Auth.inputs(Left (I, (snd i, rcv i, _X))); 
+                        SimAuth.F2Auth.step(Left ()); 
+                        FB.step();
+                    }                 
+              } 
+            | KE_Wait i => {
+                        (* Nothing to do *)
+              }
+            | KE_Blocked2 i => {
+                    if (r = Right ()) {
+                      (* We got an input on the receiver 
+                      side for sure.
+                      This step to the channel is
+                      the moment in which the message 
+                      the receiver sent gets delivered. *)
+                       SimAuth.F2Auth.inputs(Right (I, (rcv i, snd i, _Y))); 
+                       SimAuth.F2Auth.step(Right ()); 
+                    }                 
+              }
+            | KE_Available i => {
+                 (* Nothing to do *)
+              }
+            end;
+         }
+        }
+      end;
+   }
+
+   proc backdoor(b : RPi.IDEAL.ask_backdoor) : RPi.IDEAL.backdoor option = {
+    var r2 : Pi.IDEAL.backdoor option;
+    var r : (R.backdoor, Pi.IDEAL.backdoor) sum option;
+    var lk; 
+    
+    match (b) with
+    | Left m1 => { 
+         r <- None;
+         }
+    | Right m2 => {
+         (* Since things are out of sync we may need to cheat *)
+         r <- None;
+         lk <@ FB.backdoor();
+         if (lk <> None) {
+            match (oget lk) with 
+            | KE_Init => {
+               (* All in sync *)
+               r2 <@ SimAuth.F2Auth.backdoor(m2);              
+               r <- omap Right r2;       
+              }
+            | KE_Blocked1 i => {
+               if (m2 = Left ()) { 
+                  (* Initiator channel *)          
+                  r <- Some (Right (Left (Ch_Blocked2 (snd i, rcv i,_X)))); 
+               }
+               else {
+                  (* Responder channel *)          
+                  r <- Some (Right (Right Ch_Init)); 
+               }
+              } 
+            | KE_Wait i => {
+               (* All in sync *)
+               r2 <@  SimAuth.F2Auth.backdoor(m2);              
+               r <- omap Right r2;       
+              }
+            | KE_Blocked2 i => {
+               if (m2 = Left ()) {  
+                  (* Initiator channel *)         
+                  r <- Some (Right (Left (Ch_Available (snd i, rcv i, _X)))); 
+               }
+               else {
+                  (* Responder channel *)
+                  r2 <@  SimAuth.F2Auth.backdoor(Right ()); 
+                  if (r2 = Some (Right Ch_Init)) {
+                     r <- Some (Right (Right (Ch_Blocked2 (rcv i, snd i, _Y)))); 
+                  } else {
+                     r <- Some (Right (Right (Ch_Available (rcv i, snd i, _Y)))); 
+                  }
+               }
+              }
+            | KE_Available i => {
+               (* All in sync *)
+               r2 <@  SimAuth.F2Auth.backdoor(m2);              
+               r <- omap Right r2;       
+              }
+            end;
+         }
+    }
+    end;
+    return r;
+   }
+
+}.
+
+(**************************)
+(* We now write the proof *)
+(**************************)
+
+(* EAGER SAMPLE IN RHO *)
+
+module type RHOEager (P : Pi.REAL.IO) = {
+  proc init(__X : group ,__Y : group, __Z : group) : unit {}
+  
+  proc inputs(i : R.inputs) : unit {P.inputs, P.outputs}
+  
+  proc outputs(o : R.ask_outputs) : R.outputs option {P.inputs, P.outputs}
+  
+  proc step(m : R.step) : unit {P.inputs, P.outputs}
+  
+  proc backdoor(m : R.ask_backdoor) : R.backdoor option {P.inputs, P.outputs}
+}.
+
+module (DHKE_Eager : RHOEager) (Auth: Pi.REAL.IO) = {
+
+   module Initiator = {
+
+     proc init(__X : group) : unit = {
+        DHKE.Initiator.p <- witness;
+        DHKE.Initiator.st <- IInit;
+        DHKE.Initiator._X <- __X;
+        DHKE.Initiator._K <- None;
+     }
+
+     proc step() : unit = { 
+        var _Y;
+        if (DHKE.Initiator.st = ISent) {
+           _Y <@ Auth.outputs(Right (R, (rcv DHKE.Initiator.p, snd DHKE.Initiator.p, ())));
+           if (_Y <> None) {
+              DHKE.Initiator._K <- Some DHKE_SIM._Keager;
+              DHKE.Initiator.st <- IDone;
+           }
+        }
+     }
+
+     include DHKE(Auth).Initiator [ -init, step]
+   }
+
+   module Responder = {
+
+     proc init(__Y) : unit = {
+        DHKE.Responder.p <- witness;
+        DHKE.Responder.st <- RWaiting;
+        DHKE.Responder._K <- None;
+        DHKE.Responder._Y <- __Y;
+     }
+  
+     proc inputs(p : unit pkg) : unit = { 
+        var _X;
+        if (DHKE.Responder.st = RWaiting) {
+           _X <@ Auth.outputs(Left (R, p));
+           if (_X <> None) {
+              DHKE.Responder.p <- p;
+              Auth.inputs(Right (I, (rcv DHKE.Responder.p, snd DHKE.Responder.p, DHKE.Responder._Y))); 
+              DHKE.Responder._K <- Some DHKE_SIM._Keager;
+              DHKE.Responder.st <- RDone;
+           }
+        }
+     }
+     include DHKE(Auth).Responder [ -init, inputs]
+   }
+
+   (* Now the protocol with eager sampling *)
+
+   proc init(__X, __Y, __K : group) : unit = {
+     DHKE_SIM._Keager <- __K;
+     Initiator.init(__X);
+     Responder.init(__Y);    
+   }
+
+   include DHKE(Auth) [ -init, inputs, step]
+
+   proc inputs(r : role, p : unit pkg) : unit = {
+      if (r = I) {
+           Initiator.inputs(p);
+      } else {
+           Responder.inputs(p); 
+     }
+   }
+
+   proc step(r : role) : unit = {
+      if (r = I) {
+         Initiator.step();
+      } else {
+         Responder.step();
+      }
+   }
+
+}.
+
+(* Now composition with eager sampling *)
+
+module CompRFEager (Rho : RHOEager, F : Pi.IDEAL.PROTOCOL) = {
+  proc init(__X : group, __Y : group, __K : group) : unit = {
+    F.init();
+    Rho(F).init(__X, __Y, __K);
+  }
+  
+  include Rho(F) [inputs, outputs]
+  
+  proc step(m : RPi.IDEAL.step) : unit = {
+    match (m) with
+    | Left m1 =>  Rho(F).step(m1);
+    | Right m2 =>  F.step(m2);
+    end;
+  }
+  
+  proc backdoor(m : RPi.IDEAL.ask_backdoor) : RPi.IDEAL.backdoor option = {
+    var r1 : R.backdoor option;
+    var r2 : Pi.IDEAL.backdoor option;
+    var r : (R.backdoor, Pi.IDEAL.backdoor) sum option;
+    
+    match (m) with
+    | Left m1 => { 
+         r1 <@ Rho(F).backdoor(m1);
+         r <- omap Left r1;
+         }
+    | Right m2 => {
+         r2 <@ F.backdoor(m2);
+         r <- omap Right r2;
+    }
+    end;
+    
+    return r;
+  }
+}.
+
+(* Finally the game with eager sampling and DDH attacker type *)
+
+module type EagerPROTOCOL = {
+   include REAL.PROTOCOL [-init]
+   proc init(__X : group, __Y : group, __K : group) : unit
+}.
+
+module UC_emul_DDH(E : REAL.ENV, P : EagerPROTOCOL) : Adversary = {
+  proc guess(__X : group, __Y : group, __K : group) : bool = {
+    var b : bool;
+    
+    P.init(__X,__Y,__K);
+    b <@ E(P).distinguish();
+    
+    return b;
+  }
+}.
+
+section.
+
+(* Security proof first uses DDH to replace the key with a random
+   group element in the real-world. Then it shows that the simulator
+   perfectly emulates this modified game *)
+
+declare module Z <: REAL.ENV {-DHKE_SIM, -FKE, 
+                              -HybFChan.F2Auth.FAuthLR.FAuth,
+                              -HybFChan.F2Auth.FAuthRL.FAuth,
+                              -DHKE}.
+
+lemma hop1 &m : 
+   Pr[ REAL.UC_emul(Z,CompRF(DHKE,HybFChan.F2Auth.F2Auth)).main() @ &m : res] =
+   Pr[ DDH0(UC_emul_DDH(Z,CompRFEager(DHKE_Eager,HybFChan.F2Auth.F2Auth))).main() @ &m : res].
+proof.
+byequiv => //.
+proc.
+inline *.
+swap {1} 5 -4.
+swap {1} 10 -8.
+seq 2 2 : (={glob Z} /\ DHKE.Initiator._x{1} = x{2} /\ DHKE.Responder._y{1} = y{2}).
+by sim />.
+wp;call (_: ={glob HybFChan.F2Auth.F2Auth,
+           DHKE.Initiator.p,DHKE.Initiator.st,DHKE.Initiator._X,
+           DHKE.Initiator._K,
+           DHKE.Responder.p,DHKE.Responder.st,DHKE.Responder._Y,
+           DHKE.Responder._K} /\
+           DHKE_SIM._Keager{2} = DHKE.Responder._Y{1}^DHKE.Initiator._x{1} /\
+           DHKE_SIM._Keager{2} = DHKE.Initiator._X{1}^DHKE.Responder._y{1} /\
+
+           (match DHKE.Initiator.st{1} with
+            | IInit => 
+                  HybFChan.F2Auth.FAuthLR.FAuth.st{1} = Ch_Init /\
+                  HybFChan.F2Auth.FAuthRL.FAuth.st{1} = Ch_Init 
+            | ISent => 
+                 match (HybFChan.F2Auth.FAuthLR.FAuth.st{1}) with
+                 | Ch_Init => true
+                 | Ch_Blocked1 p => true
+                 | Ch_Wait p => true
+                 | Ch_Blocked2 p   => p = (snd DHKE.Initiator.p{1}, rcv DHKE.Initiator.p{1}, DHKE.Initiator._X{1})
+                 | Ch_Available p => p = (snd DHKE.Initiator.p{1}, rcv DHKE.Initiator.p{1}, DHKE.Initiator._X{1})
+                 end /\
+
+                 match HybFChan.F2Auth.FAuthRL.FAuth.st{1} with
+                 | Ch_Init => true
+                 | Ch_Blocked1 p => true
+                 | Ch_Wait p => true
+                 | Ch_Blocked2 p   => p = (rcv DHKE.Responder.p{1}, snd DHKE.Responder.p{1}, DHKE.Responder._Y{1})
+                 | Ch_Available p => p = (rcv DHKE.Responder.p{1}, snd DHKE.Responder.p{1}, DHKE.Responder._Y{1})
+                 end
+            | IDone =>  DHKE.Responder.st{1} = RDone /\
+                        DHKE.Initiator._K{1} = Some (DHKE.Responder._Y{1}^DHKE.Initiator._x{1})
+            end) /\
+           (match DHKE.Responder.st{1} with
+            | RWaiting => DHKE.Initiator.st{1} = IInit \/ 
+                  (DHKE.Initiator.st{1} = ISent /\ HybFChan.F2Auth.FAuthRL.FAuth.st{1} = Ch_Init)
+            | RDone => 
+                 (DHKE.Initiator.st{1} = ISent \/ DHKE.Initiator.st{1} = IDone)  /\
+                  DHKE.Responder._K{1} = Some (DHKE.Initiator._X{1}^DHKE.Responder._y{1})
+               end)
+); last first.
+
+(* Init *)
+auto => />; smt(@G).
+
+(* Now the call *)
++ by proc;inline *; auto => /> /#.
++ by sim />.
++ proc; match; first 2 by auto.
+  + move => m1 m1_0; inline *.
+    sp 1 1; if => //=; if => //=.
+    by sp 1 1; match; auto => /#.
+  + move => m1 m1_0; inline *; auto => /#.
+by proc; inline *; match; auto => /#.
+qed.
+
+(* we'll need a complex relation on states *)
+op staterel (p1 : unit pkg) ist1 rst1 (kst2 : kestate) 
+            (fLR1 fRL1 fLR2 fRL2 : HybFChan.state) _Xp _Yp _KI _KR (_K : group) =
+    match kst2 with
+    (* KE INITIAL STATE: NOTHING HAPPENED YET *)
+    | KE_Init =>
+        (ist1 = IInit)   /\ (rst1 = RWaiting) /\ 
+        (fLR1 = Ch_Init) /\ (fRL1 = Ch_Init) /\ 
+        (fLR2 = Ch_Init) /\ (fRL2 = Ch_Init) /\ 
+        (_KI = None)     /\ (_KR = None)
+    (* KE BLOCKED1 STATE: ENV PROVIDED INPUT TO INITIATOR BUT X NOT YET DELIVERED *)
+    | KE_Blocked1 p => 
+        p1 = p /\ 
+        (ist1 = ISent)         /\ (rst1 = RWaiting) /\ 
+        (fLR1 = Ch_Blocked2 _Xp) /\ (fRL1 = Ch_Init)  /\ 
+        (fLR2 = Ch_Init)       /\ (fRL2 = Ch_Init)   /\ 
+        (_KI = None)           /\ (_KR = None)
+    (* KE WAITING STATE: ENV PROVIDED INPUT TO INITIATOR AND X DELIVERED. *)
+    | KE_Wait p => 
+        p1 = p /\ 
+        (ist1 = ISent)           /\ (rst1 = RWaiting) /\ 
+        (fLR1 = Ch_Available _Xp) /\ (fRL1 = Ch_Init) /\ 
+        (fLR2 = Ch_Available _Xp) /\ (fRL2 = Ch_Init) /\ 
+        (_KI = None)             /\ (_KR = None)
+    (* KE BLOCKED2 STATE: ENV PROVIDED INPUT TO BOTH PARTIES AND Y YES/NO DELIVERED *)
+    | KE_Blocked2 p => 
+        p1 = p /\ 
+        (ist1 = ISent) /\ (rst1 = RDone) /\ 
+        (fLR1 = Ch_Available _Xp)         /\ 
+        (fRL2 = Ch_Init \/ fRL2 = Ch_Available _Yp) /\
+              (fRL2 = Ch_Init          => fRL1 = Ch_Blocked2 _Yp)   /\
+              (fRL2 = Ch_Available _Yp => fRL1 = Ch_Available _Yp) /\
+        (fLR2 = Ch_Available _Xp) /\ 
+        (_KI = None) /\ (_KR = Some _K)
+    (* KE AVAILABLE STATE: ALeft DONE *)
+    | KE_Available p => 
+        p1 = p /\ 
+        (ist1 = IDone) /\ (rst1 = RDone) /\ 
+        (fLR1 = Ch_Available _Xp) /\ (fRL1 = Ch_Available _Yp) /\ 
+        (fLR2 = Ch_Available _Xp) /\ (fRL2 = Ch_Available _Yp) /\ 
+        (_KI = Some _K)  /\ (_KR = Some _K)
+    end.
+
+
+lemma hop2 &m : 
+   Pr[ DDH1(UC_emul_DDH(Z,CompRFEager(DHKE_Eager,HybFChan.F2Auth.F2Auth))).main() @ &m : res] =
+   Pr[ REAL.UC_emul(Z,CompS(FKE, DHKE_SIM)).main() @ &m : res].
+proof.
+byequiv => //.
+proc. 
+
+(* Initializations *)
+inline {1} UC_emul_DDH(Z, CompRFEager(DHKE_Eager, HybFChan.F2Auth.F2Auth)).guess.
+inline {2} CompS(FKE, DHKE_SIM).init. 
+seq 7 2 : (={glob Z} /\
+           HybFChan.F2Auth.FAuthLR.FAuth.st{1} = SimAuth.FAuthLR.FAuth.st{2} /\
+           HybFChan.F2Auth.FAuthRL.FAuth.st{1} = SimAuth.FAuthRL.FAuth.st{2} /\
+           FAuthLR.FAuth.st{2} = Ch_Init /\
+           FAuthRL.FAuth.st{2} = Ch_Init /\
+           DHKE.Initiator._K{1} = None /\
+           DHKE.Responder._K{1} = None /\
+           DHKE.Initiator._X{1} = DHKE_SIM._X{2} /\
+           DHKE.Responder._Y{1} = DHKE_SIM._Y{2}  /\
+           DHKE_SIM._Keager{1} = FKE.st.`key{2} /\
+           DHKE.Initiator.st{1} = IInit /\
+           DHKE.Responder.st{1} = RWaiting /\
+           FKE.st.`kst{2}  = KE_Init
+           ).
++ inline *.
+  wp; swap {1} 3 -2; rnd; rnd;  wp; rnd (fun x => g^x) (fun x => log x). 
+  auto => />; progress; 1,4:algebra. 
+  + by rewrite dmapE /(\o) /pred1; congr; apply fun_ext => z; algebra.
+  + by rewrite supp_dmap; exists zL; trivial.
+  + by rewrite /init.
+  + by rewrite /init.
+(* Calling the environment *)
+wp; call (_: 
+   DHKE.Initiator._X{1} = DHKE_SIM._X{2} /\
+   DHKE.Responder._Y{1} = DHKE_SIM._Y{2} /\
+   DHKE_SIM._Keager{1} = FKE.st{2}.`key /\
+   staterel DHKE.Initiator.p{1}
+            DHKE.Initiator.st{1} 
+            DHKE.Responder.st{1} 
+            FKE.st{2}.`kst 
+            HybFChan.F2Auth.FAuthLR.FAuth.st{1}
+            HybFChan.F2Auth.FAuthRL.FAuth.st{1}
+            FAuthLR.FAuth.st{2}
+            FAuthRL.FAuth.st{2}
+            (snd DHKE.Initiator.p{1}, rcv DHKE.Initiator.p{1}, DHKE.Initiator._X{1})
+            (rcv DHKE.Initiator.p{1}, snd DHKE.Initiator.p{1}, DHKE.Responder._Y{1})
+            DHKE.Initiator._K{1}
+            DHKE.Responder._K{1}
+            DHKE_SIM._Keager{1}).
+
+(* INPUTS *)
+(* PY: SMT doesn't catch this without rewrite *)
++ by proc; inline *;wp;skip; rewrite /staterel; smt(pkgid). 
+
+(* OUTPUTS *)
++ by proc;inline *;auto => />; rewrite /staterel => /#. 
+
+(* STEP *)
++ proc.
+  match; first 2 by smt().
+  (* We step Rho *)
+  + by move => m1 p; inline *;wp;skip; smt(). 
+  (* We step F2Auth *)
+
+    move => m2 p;inline *; auto => /> &1 &2.
+    rewrite /staterel /leak oget_some /unblock /kstp.
+    by case (FKE.st{2}.`kst) => /> /#. 
+
+(* BACKDOOR *)
++ proc.
+  match; first 2 by smt().
+  (* Backdoor Rho *)
+  + by move => *; inline *;auto => /#.   
+  (* Backdoor F2Auth *)
+  move=> m2 p; inline *; auto => /> &1 &2.
+  rewrite /staterel /leak oget_some /unblock /kstp /rcv. 
+  by case (FKE.st{2}.`kst) => /> /#. 
+
+(* WRAP-UP CALL *)
+by auto => /#.
+qed.
+
+(* THIS IS THE MAIN DH UC SECURITY THEOREM *)
+
+lemma KEAdv &m :
+      `| Pr[ REAL.UC_emul(Z,CompRF(DHKE,HybFChan.F2Auth.F2Auth)).main() @ &m : res] - 
+         Pr[ REAL.UC_emul(Z,CompS(FKE, DHKE_SIM)).main() @ &m : res] | = 
+      `| Pr[ DDH0(UC_emul_DDH(Z,CompRFEager(DHKE_Eager,HybFChan.F2Auth.F2Auth))).main() @ &m : res] - 
+         Pr[ DDH1(UC_emul_DDH(Z,CompRFEager(DHKE_Eager,HybFChan.F2Auth.F2Auth))).main() @ &m : res] |.
+proof. by rewrite (hop1 &m) (hop2 &m). qed.
+
+end section.
+
+abstract theory C.
+
+clone FKEWorlds.C as RC
+  with op csi = {|
+    cinit     = 2 * (1 + cgpow + FDistr.cdt);
+    cstep     = 26; 
+    cs_s      = 1; 
+    cs_b      = 1;
+    cbackdoor = 20;
+    cb_s      = 0;
+    cb_b      = 1; 
+  |}
+  proof csi_pos by smt (ge0_cg ge0_cf) .
+
+op cddh =  8 + RC.c.`cd + RC.c.`ci * 29 + RC.c.`co * 2 + RC.c.`cs * 23 + RC.c.`cb * 5.
+
+lemma KEAdv_ex &m :
+    exists (S <: RC.CSIMULATOR {+DHKE_SIM}), 
+      forall (Z <: RC.CENV { -HybFChan.F2Auth.FAuthLR.FAuth, -HybFChan.F2Auth.FAuthRL.FAuth, -DHKE, -FKE, -DHKE_SIM}),
+      `| Pr[ REAL.UC_emul(Z,CompRF(DHKE,HybFChan.F2Auth.F2Auth)).main() @ &m : res] - 
+         Pr[ REAL.UC_emul(Z,CompS(FKE, S)).main() @ &m : res] | <= adv_ddh cddh.
+proof. 
+  exists DHKE_SIM; split.
+  + split; [ | split] => kb ks FB hkb hks.
+    + proc; inline *; wp; do !rnd; skip => />.
+      rewrite FDistr.dt_ll /#.
+    + proc; exlim s => -[]r.
+      + match Left 1; [1: by auto; smt() | 2: done].
+        seq 1 : true time [ N 25; FB.backdoor : 0; FB.step : 1 ]; 1: done.
+        + by call (:true); auto => />. 
+        if => //.
+        + exlim (oget lk) => -[|i|i|i|i].
+          + by match KE_Init 1 => //=; auto => /> /#.
+          + by match KE_Blocked1 1 => //=; auto => /> /#. 
+          + by match KE_Wait 1 => //=; auto => /> /#.
+          + match KE_Blocked2 1 => //=; auto => />; 1: smt().
+            if => //.
+            + seq 1 : true time [N 2; FB.step : 1] => //.
+              + by inline *; sp 1 => //=; match Right 1 => //=; auto => /> /#.
+              by if => //; 1: call (:true); auto => />.
+            by auto => /> /#.          
+          by match KE_Available 1 => //=; auto => /> /#.
+        by auto=> /> /#.
+      match Right 1; [1: by auto; smt() | 2: done].
+      seq 1 : true time [ N 20; FB.backdoor : 0; FB.step : 1 ]; 1: done.
+      + by call (:true); auto => />. 
+      if => //.
+      + exlim (oget lk) => -[|i|i|i|i].
+        + by match KE_Init 1 => //=; auto => /> /#. 
+        + match KE_Blocked1 1 => //=; auto => />; 1: smt().
+          if => //.
+          + call(:true); inline *; sp 1 => //=.
+            by match Left 1 => //=; auto => /> /#. 
+          by auto => /> /#.
+        + by match KE_Wait 1 => //=; auto => /> /#. 
+        + match KE_Blocked2 1 => //=; auto => />; 1: smt().
+          if => //.
+          + inline *; sp 1 => //=.
+            by match Right 1 => //=; auto => /> /#. 
+          by auto => /> /#. 
+        match KE_Available 1 => //=; auto => /> /#.
+      by auto=> /> /#. 
+    proc.
+    exlim b => -[] mi. 
+    + match Left 1; [1: by auto; smt() | 2: done].
+      by auto => /> /#.
+    match Right 1; [1: by auto; smt() | 2: done].
+    seq 2 : true time [N 18] => //.
+    + by call (:true); auto => />.
+    by inline *; auto => /> /#.     
+
+  move=> Z. have ->:= KEAdv Z &m.
+  apply (adv_ddh_max cddh (UC_emul_DDH(Z, CompRFEager(DHKE_Eager, HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth))))).
+  proc; inline *.
+  call (:true; time [
+     CompRFEager(DHKE_Eager, HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth)).inputs : [N 29],
+     CompRFEager(DHKE_Eager, HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth)).outputs : [N 2],
+     CompRFEager(DHKE_Eager, HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth)).step : [N 23],
+     CompRFEager(DHKE_Eager, HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth)).backdoor : [N 5] ]) => /= *.
+  + by proc; inline *; auto => />.
+  + by proc; inline *; auto => />.
+  + by proc; inline *; auto => /> /#.
+  + by proc; inline *; auto => /> /#.
+  auto => />.
+  rewrite !bigi_constz; smt (RC.c_pos).
+qed.
+
+end C.
+
+end DHKE.
+
+(****************************************************************)
+(*                  SECURE CHANNEL BASED ON OTP                 *)
+(****************************************************************)
+
+theory OTP.
+
+type msg = group.
+type key = group.
+type cph = group.
+
+op gen = dapply (fun x => g^x) FDistr.dt.
+
+op enc(m : msg, k : key) = m * k.
+op dec(c : cph, k : key) = c / k.
+
+lemma correctness m k :
+   dec (enc m k) k = m.
+proof. rewrite /dec /enc -div_def log_mul -{2}(gpow_log m); congr; ring. qed.
+
+schema cost_dec `{P} {c : cph, k : key} : cost [P: dec c k] = N cgdiv + cost[P:c] + cost[P:k].
+schema cost_enc `{P} {c : cph, k : key} : cost [P: enc c k] = N cgmul + cost[P:c] + cost[P:k].
+hint simplify cost_dec, cost_enc.
+
+import DHKE.FKE.
+
+(* To have the type of the simulator we need now to clone ideal
+   secure channel functionality FSC. *)
+
+clone import FChan with
+  type msg <- group,
+  type FSC.FSCWorlds.REAL.step <- (role, (unit, unit) sum) sum,
+  type FSC.FSCWorlds.REAL.ask_backdoor <- (role, (unit, unit) sum) sum,
+  type FSC.FSCWorlds.REAL.backdoor <- (unit,  (FKEAuth.FChan.state, kestate) sum) sum.
+
+(* This allows us to define a hybrid protocol that uses FKEAuth. *)
+clone import COMPOSITION as C_OTP with
+   type Pi.REAL.inputs = (role * group pkg,role * unit pkg) sum,
+   type Pi.REAL.ask_outputs = (role * unit pkg, role) sum,
+   type Pi.REAL.outputs = (group,group) sum,
+   (**************************************************)
+   (* We look ahead to an instantiation based on DHKE *)
+   type Pi.REAL.step = (unit, (role, (unit, unit) sum) sum) sum,
+   type Pi.REAL.ask_backdoor = (unit, (role, (unit, unit) sum) sum) sum,
+   type Pi.REAL.backdoor = (FKEAuth.FChan.state, (unit, (DHKE.HybFChan.state,
+DHKE.HybFChan.state) sum) sum) sum,
+   (**************************************************)
+   type Pi.IDEAL.step = (unit,unit) sum,
+   type Pi.IDEAL.ask_backdoor = (unit, unit) sum,
+   type Pi.IDEAL.backdoor = (FKEAuth.FChan.state,kestate) sum,
+   type R.inputs = role * msg pkg,
+   type R.ask_outputs = role * unit pkg,
+   type R.outputs = msg,
+   type R.step = role,
+   type R.ask_backdoor = role,
+   type R.backdoor = unit,
+   (* We also set the stage for transitivity *)
+   type TRANS.H2.IDEAL.step = unit,
+   type TRANS.H2.IDEAL.ask_backdoor = unit,
+   type TRANS.H2.IDEAL.backdoor = FChan.FSC.leakage.
+
+import RPi.
+
+type iscstate = [
+   | ISCInit
+   | ISCSentKE
+   | ISCDone
+].
+
+schema cost_eqISCInit   `{P} {i:iscstate} : cost [P : i = ISCInit] = '1 + cost [P : i].
+schema cost_eqISCSentKE `{P} {i:iscstate} : cost [P : i = ISCSentKE] = '1 + cost [P : i].
+schema cost_eqISCDone   `{P} {i:iscstate} : cost [P : i = ISCDone] = '1 + cost [P : i].
+hint simplify cost_eqISCInit, cost_eqISCSentKE, cost_eqISCDone.
+
+module (OTP : RHO) (KEAuth: Pi.REAL.IO) = {
+
+   module Initiator = {
+     var p : msg pkg
+     var st : iscstate
+
+     proc init() : unit = {
+        p <- witness;
+        st <- ISCInit;
+     }
+  
+     (* To avoid confusion we only accept one input on initiator side *)
+     proc inputs(_p : msg pkg) : unit = { 
+        if (st = ISCInit) {
+           p <- _p;
+           KEAuth.inputs(Right (I, (snd p, rcv p, ()))); 
+           st <- ISCSentKE;
+        }
+     }
+  
+     proc outputs() : group option = { return None; }
+
+     (* Initiator needs to be stepped to be aware of KE completion *)
+     proc step() : unit = { 
+        var _K;
+        if (st = ISCSentKE) {
+           _K <@ KEAuth.outputs(Right I);
+           if (_K <> None) {
+              KEAuth.inputs(Left (I, (snd p, rcv p, enc (pld p) (oget (getr (oget _K))))));
+              st <- ISCDone;
+           }
+        }
+     }
+  
+     proc backdoor() : unit option = { return None; }
+   }
+
+   module Responder = {
+
+     proc init() : unit = { }
+  
+     (* We let KE functionality manage inputs, only one will
+        be accepted, and it must mach the one previously given
+        by initiator *)
+     proc inputs(_p : msg pkg) : unit = { 
+        KEAuth.inputs(Right (R, (snd _p, rcv _p, ())));
+     }
+
+     (* Output becomes available whenever the authentication
+        channel is unblocked *)  
+     proc outputs(_p : unit pkg) : group option = {
+        var rr,m,_K;
+        rr <- None; 
+        m <@ KEAuth.outputs(Left (R,  (snd _p, rcv _p, ())));
+        if (m <> None) {
+           _K <@ KEAuth.outputs(Right R);
+           rr <- Some (dec (oget (getl (oget m))) (oget (getr (oget _K))));
+        }
+        return rr;
+     }
+  
+     proc step() : unit = { }
+  
+     proc backdoor() : unit option = { return None; }
+   }
+
+   (* Now the protocol *)
+
+   proc init() : unit = {
+     Initiator.init();
+     Responder.init();
+   }
+
+   proc inputs(r : role, p : msg pkg) : unit = {
+      if (r = I) {
+            Initiator.inputs(p);
+      } else {
+            Responder.inputs(p);
+      }  
+   }
+
+   proc outputs(r : role, p : unit pkg) : group option = {
+      var rr;
+      rr <- None;
+      if (r = I) {
+         rr <@ Initiator.outputs();
+      } else {
+         rr <@ Responder.outputs(p);
+      }
+      return rr;
+   }
+
+   proc step(r : role) : unit = {
+      if (r = I) {
+         Initiator.step();
+      } else {
+         Responder.step();
+      }
+   }
+
+   proc backdoor(r : role) : unit option = {
+      var rr;
+      if (r = I) {
+         rr <@ Initiator.backdoor();
+      } else {
+         rr <@ Responder.backdoor();
+      }
+      return rr;
+   }
+}.
+
+
+(* The simulator uses it's own copy of the low level
+   ideal functionalities, which it uses in the simulation *)
+clone import FKEAuth as SimKEAuth.
+
+import FSC.
+import FSCWorlds.
+
+module (OTP_SIM : SIMULATOR) (FB : IDEAL.BACKDOORS) = {
+
+   proc init() : unit = {
+     SimKEAuth.FKEAuth.init();
+   }
+
+   proc step(s : RPi.IDEAL.step) : unit = {
+     var lsc ,lke, lfa,fresh;
+     match s with
+     | Left m1 => {
+           (* Stepping rho *)
+           lsc <@ FB.backdoor();
+           match (oget lsc) with
+           | Ch_Init => { (* Nothing happended yet *) }
+           | Ch_Blocked1 p => { (* Initiator has provided input, but responder still did not *) }
+           | Ch_Wait p => { (* Initiator has provided input, but responder still did not *) }
+           | Ch_Blocked2 p => {
+               if (m1 = I) {
+                   (* Stepping initiator when both already provided input.
+                      Step causes initiator to progress if KE just finished *)
+                   lfa <@ SimKEAuth.FKEAuth.backdoor(Left ());
+                   match (oget (getl (oget lfa))) with
+                   | Ch_Init => {
+                     lke <@ SimKEAuth.FKEAuth.backdoor(Right ());
+                      match  (oget (getr (oget lke))) with
+                      | KE_Init => {}
+                      | KE_Blocked1 p => {}
+                      | KE_Wait p => {}
+                      | KE_Blocked2 p => {}
+                      | KE_Available p => {
+                            fresh <$ dapply (fun x => g^x) FDistr.dt;
+                            SimKEAuth.FKEAuth.inputs(Left (I, (snd p, rcv p, enc  (g^F.zero) fresh)));
+                        }
+                      end; 
+                     }
+                   | Ch_Blocked1 p' => { }
+                   | Ch_Wait p' => { }
+                   | Ch_Blocked2 p' => { }
+                   | Ch_Available p' => { }
+                   end;
+               } else {
+                   (* Stepping responder has no effect *)
+               }
+             }
+           | Ch_Available p => { }
+           end;
+             
+       }
+     | Right m2 => {
+           match m2 with
+           | Left m21 => {
+              (* Stepping FAuth: pass it along but check if receiver done. *)
+                 SimKEAuth.FKEAuth.step(Left ());
+                 lfa <@ SimKEAuth.FKEAuth.backdoor(Left ());
+                 match (oget (getl (oget lfa))) with
+                 | Ch_Init => { }
+                 | Ch_Blocked1 p' => { }
+                 | Ch_Wait p' => { }
+                 | Ch_Blocked2 p' => { }
+                 | Ch_Available p' => { FB.step(); }
+                 end;
+             }
+           | Right m22 => {
+              (* Stepping FKE: Just pass it along, but check if inputs
+                 needs to be given first. *)
+                 lsc <@ FB.backdoor();
+                 match (oget lsc) with
+                 | Ch_Init => { }
+                 | Ch_Blocked1 p' => { 
+                    lke <@ SimKEAuth.FKEAuth.backdoor(Right ());
+                     match  (oget (getr (oget lke))) with
+                     | KE_Init => {  SimKEAuth.FKEAuth.inputs(Right (I,(snd p', rcv p', ()))); FB.step(); }
+                     | KE_Blocked1 p => {}
+                     | KE_Wait p => { }
+                     | KE_Blocked2 p => {}
+                     | KE_Available p => { }
+                     end; 
+                   }
+                 | Ch_Wait p' => { }
+                 | Ch_Blocked2 p' => {
+                    lke <@ SimKEAuth.FKEAuth.backdoor(Right ());
+                     match  (oget (getr (oget lke))) with
+                     | KE_Init => {}
+                     | KE_Blocked1 p => {}
+                     | KE_Wait p => { SimKEAuth.FKEAuth.inputs(Right (R,p));  }
+                     | KE_Blocked2 p => {}
+                     | KE_Available p => { }
+                     end; 
+                    }
+                 | Ch_Available p' => { }
+                 end;
+                 SimKEAuth.FKEAuth.step(Right ());
+             }
+           end;
+       }
+     end;
+   }
+
+   proc backdoor(b : RPi.IDEAL.ask_backdoor) : RPi.IDEAL.backdoor option = {
+       var rr,lsc,lfa,lke;
+       rr <- None;
+       match b with 
+       | Left b1 => {
+             (* Rho has no leakage *)
+         } 
+       | Right b2 => {
+            match b2 with
+            | Left c1 => {
+               (* Auth backdoor: just type conversions *)
+                 lfa <@ SimKEAuth.FKEAuth.backdoor(Left ());
+                 match (oget (getl (oget lfa))) with
+                 | Ch_Init => { 
+                     rr <- Some (Right (Left (Ch_Init))); 
+                   }
+                 | Ch_Blocked1 p' => { 
+                     rr <- Some (Right (Left (Ch_Blocked1 p'))); 
+                   }
+                 | Ch_Wait p' => {  
+                     rr <- Some (Right (Left (Ch_Wait p')));  
+                   }
+                 | Ch_Blocked2 p' => { 
+                     rr <- Some (Right (Left (Ch_Blocked2 p')));  
+                   }
+                 | Ch_Available p' => {  
+                     rr <- Some (Right (Left (Ch_Available p')));  
+                   }
+                 end;
+          }
+          | Right c2 => {
+               (* Key exchange leakage: sim sometimes lags behind, but we don't 
+                  step FKE here. *)
+               lsc <@ FB.backdoor();
+               match (oget lsc) with
+               | Ch_Init => { rr <- Some (Right (Right KE_Init)); }
+               | Ch_Blocked1 p => { rr <- Some (Right (Right (KE_Blocked1 p))); }
+               | Ch_Wait p => { rr <- Some (Right (Right (KE_Wait p))); }
+               | Ch_Blocked2 p => {
+                  lfa <@ SimKEAuth.FKEAuth.backdoor(Left ());
+                  match (oget (getl (oget lfa))) with
+                  | Ch_Init => {
+                    lke <@ SimKEAuth.FKEAuth.backdoor(Right ());
+                     match  (oget (getr (oget lke))) with
+                     | KE_Init => { rr <- Some (Right (Right (KE_Blocked2 p))); }
+                     | KE_Blocked1 p' => { rr <- Some (Right (Right (KE_Blocked2 p))); }
+                     | KE_Wait p' => { rr <- Some (Right (Right (KE_Blocked2 p))); }
+                     | KE_Blocked2 p' => { rr <- Some (Right (Right (KE_Blocked2 p))); }
+                     | KE_Available p' => { rr <- Some (Right (Right (KE_Available p))); }
+                     end; 
+                    }
+                  | Ch_Blocked1 p' => { }
+                  | Ch_Wait p' => { }
+                  | Ch_Blocked2 p' => { 
+                       rr <- Some (Right (Right (KE_Available p))); 
+                    }
+                  | Ch_Available p' => { 
+                       rr <- Some (Right (Right (KE_Available p))); 
+                    }
+                  end;
+                }
+             | Ch_Available p => { rr <- Some (Right (Right (KE_Available p))); }
+             end;
+             }
+          end;
+         } 
+       end;
+       return rr;
+   }
+
+}.
+
+section.
+
+(* AS A PROOF INSTRUMENT WE NEED TO MOVE THE SAMPLING OF THE AGREED KEY TO WHERE THE 
+   SIMULATOR DOES IT *)
+module (OTPLazy : RHO) (KEAuth: Pi.REAL.IO) = {
+   module Initiator = {
+     include OTP(KEAuth).Initiator [- step]
+
+     proc step() : unit = { 
+        var _K,fresh;
+        if (OTP.Initiator.st = ISCSentKE) {
+           _K <@ DHKE.FKE.FKEAuth.FKEAuth.outputs(Right I);
+           if (_K <> None) {
+              fresh <$  dapply (fun x => g^x) FDistr.dt;
+              (* WE PUNCH THROUGH THE INTERFACE TO HARDWIRE A FRESH KEY *)
+              DHKE.FKE.FKE.st <- {| DHKE.FKE.FKE.st with key = fresh |};
+              DHKE.FKE.FKEAuth.FKEAuth.inputs(Left (I, 
+                 (snd OTP.Initiator.p, rcv OTP.Initiator.p, enc (pld OTP.Initiator.p) fresh)));
+              OTP.Initiator.st <- ISCDone;
+           }
+        }
+     }
+   }
+
+
+   (* Now the protocol *)
+
+   include OTP(KEAuth) [- init,step]
+
+   proc init() : unit = {
+     Initiator.init();
+     OTP(KEAuth).Responder.init();
+   }
+
+   proc step(r : role) : unit = {
+      if (r = I) {
+         Initiator.step();
+      } else {
+         OTP(KEAuth).Responder.step();
+      }
+   }
+}.
+
+declare module Z <: REAL.ENV {-FKE, -FSC, -FChan.FAuth.FAuth, -OTP_SIM, 
+                             -OTP, -DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, -OTPLazy}.
+
+(* To prove that our change of sampling in OTP is sound we use a generic
+   eager sampling module *)
+local clone import GenEager with
+  type from <- unit, 
+  type to   <- group, 
+  op sampleto <- fun (x:unit) => dapply (fun (x : t) => g ^ x) FDistr.dt
+  proof *.
+realize sampleto_ll.
+proof. by move => _; rewrite /= weight_dmap FDistr.dt_ll. qed.
+
+(* We rewrite our new version of OTP using this module *)
+local module OTP_AUX (O:RO) (KEAuth: Pi.REAL.IO) = {
+   module Initiator = {
+     include OTP(KEAuth).Initiator [- step]
+
+     proc step() : unit = { 
+        var _K,fresh;
+        if (OTP.Initiator.st = ISCSentKE) {
+           _K <@ DHKE.FKE.FKEAuth.FKEAuth.outputs(Right I);
+           if (_K <> None) {
+              fresh <@ O.get();
+              (* WE PUNCH THROUGH THE INTERFACE TO HARDWIRE A FRESH KEY *)
+              DHKE.FKE.FKE.st <- {| DHKE.FKE.FKE.st with key = fresh |};
+              DHKE.FKE.FKEAuth.FKEAuth.inputs(Left (I, 
+                 (snd OTP.Initiator.p, rcv OTP.Initiator.p, enc (pld OTP.Initiator.p) fresh)));
+              OTP.Initiator.st <- ISCDone;
+           }
+        }
+     }
+  }
+
+
+   (* Now the protocol *)
+
+   include OTP(KEAuth) [- init,step]
+
+   proc init() : unit = {
+     O.init();
+     O.sample();
+     Initiator.init();
+     OTP(KEAuth).Responder.init();
+   }
+
+   proc step(r : role) : unit = {
+      if (r = I) {
+         Initiator.step();
+      } else {
+         OTP(KEAuth).Responder.step();
+      }
+   }
+}.
+
+local module D (O:RO) = {
+   proc distinguish = REAL.UC_emul(Z,CompRF(OTP_AUX(O),DHKE.FKE.FKEAuth.FKEAuth)).main
+}.
+
+lemma OTPAdv1 &m :
+      Pr[ REAL.UC_emul(Z,CompRF(OTP,DHKE.FKE.FKEAuth.FKEAuth)).main() @ &m : res] =
+      Pr[ REAL.UC_emul(Z,CompRF(OTPLazy,DHKE.FKE.FKEAuth.FKEAuth)).main() @ &m : res].
+proof.
+  have -> : 
+    Pr[ REAL.UC_emul(Z,CompRF(OTP,DHKE.FKE.FKEAuth.FKEAuth)).main() @ &m : res] =
+    Pr[ D(RO).distinguish() @ &m : res].
+  + byequiv (_: ={glob Z} ==> ={res}) => //.
+    proc.
+    call (_: ={glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob OTP} /\ 
+            FKE.st{1}.`kst = FKE.st{2}.`kst /\
+            () \in RO.m{2} /\
+            FKE.st{1}.`key = oget RO.m{2}.[()] /\
+            (DHKE.FKE.FKEAuth.FChan.FAuth.FAuth.st{2} <> Ch_Init => 
+                   FKE.st{2}.`key = oget RO.m{2}.[()])
+             ); conseq />.
+    + proc => /=; inline *; wp; skip => /> &1 &2; rewrite /party_start /kstp /=. 
+      progress; smt (). 
+
+    + proc => /=; inline *; wp; skip => /> &1 &2; rewrite /party_output /kstp /= /#.    
+    + proc; match; 1,2 : smt().
+      + move=> m1 m2.      
+        inline OTP(DHKE.FKE.FKEAuth.FKEAuth).step OTP_AUX(RO, DHKE.FKE.FKEAuth.FKEAuth).step.
+        sp 1 1; if => //; conseq />; last by sim.
+        inline *.
+        if => //.
+        match Right {1} 2; 1: by auto => /#.
+        match Right {2} 2; 1: by auto => /#.
+        sp; if; last done.
+        + move => /> &1 &2.
+          rewrite /get_as_Right /= /party_output /kstp => <-.
+          by case: (FKE.st{1}.`kst) => />.
+        rcondf{2} 3; 1: by auto.
+        match Left {1} 2; 1: auto => /#.
+        match Left {2} 6; 1: auto => /#.
+        auto => /> &1 &2 ?? heq.
+        rewrite /party_output /kstp /get_as_Left /get_as_Right /= heq.
+        case : (FKE.st{1}.`kst) => />; rewrite //=. 
+        rewrite /= dmap_ll //=.
+        by apply  FDistr.dt_ll.
+      move => m1 m2. 
+      inline DHKE.FKE.FKEAuth.FKEAuth.step.
+      sp 1 1; match; 1,2: smt().
+      + by move=> *; inline *; auto => /#.
+      move=> tt1 tt2; inline *; auto => /> &1 &2 heq ??.
+      by rewrite /unblock /kstp heq; case: (FKE.st{2}.`kst) => />.
+    + proc.
+      match; 1,2 : smt().
+      + by move=> m1 m2; inline *; sim; auto.
+      by move=> m1 m2; inline *; auto => /> /#.
+    inline *; auto => />; rewrite /is_lossless weight_dmap FDistr.dt_ll /= => *.
+    by rewrite get_setE /init /= mem_empty /= mem_set.
+  have -> : Pr[D(RO).distinguish() @ &m : res] = Pr[D(LRO).distinguish() @ &m : res].
+  + byequiv (RO_LRO_D(D)) => //.
+  byequiv (_: ={glob Z} ==> ={res}) => //.
+  proc.
+  call (_: ={glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob OTP, glob FKE} /\ 
+            () \in RO.m{1} = (OTP.Initiator.st{1} = ISCDone)); conseq />; 2,4: by sim.
+  + proc; if => //; conseq />; 2: by sim.
+    by inline *; auto => />.
+  + proc; match; 1,2 : smt().
+    + move=> m1 m2; inline *; sp 1 1; if => //.
+      if => //.
+      match Right {1} 2; 1: by auto => /#.
+      match Right {2} 2; 1: by auto => /#.
+      sp; if => //; auto => /> &1 &2 -> /= ??.
+      by rewrite get_setE /= mem_set.
+    by move=> m1 m2;conseq />; inline *; sim; auto.
+  by inline *; auto => /> ?; rewrite mem_empty.
+qed.
+
+(* THE INVARIANT RELATES THE STATES OF THE REAL AND SIMULATED
+   FUNCTIONALITIES *)
+
+op invotp ip1 kst1 kst2 (cst2 : group pkg stlkg) ast2 ast1 ist1 =
+   match cst2 with
+   | Ch_Init => (* We just started, no inputs, all funcs in init *)
+                kst1.`kst = kst2.`kst /\
+                kst2.`kst = KE_Init /\
+                ast2 = FChan.init_st /\
+                ast1 = DHKE.FKE.FKEAuth.FChan.init_st /\ 
+                ist1 = ISCInit
+   | Ch_Blocked1 p => 
+                (* There has been a initiator input, but nothing else,
+                   so things only moved in the real world key exchance *)
+                ip1 = p /\ 
+                kst1.`kst = KE_Blocked1 (snd p,rcv p, ()) /\
+                kst2.`kst = KE_Init /\
+                ast2 = FChan.init_st /\ 
+                ast1 = Ch_Init /\ 
+                ist1 = ISCSentKE 
+   | Ch_Wait p => 
+                (* KE has been stepped to wait in the real world and simulator
+                   picks it up to make everything match again at waiting state *)
+                ip1 = p /\ 
+                kst1.`kst = kst2.`kst /\
+                kst1.`kst = KE_Wait (snd p,rcv p, ()) /\
+                ast2 = FChan.init_st /\ 
+                ast1 = Ch_Init /\ 
+                ist1 = ISCSentKE
+   | Ch_Blocked2 p => 
+                ip1 = p  /\
+                (* We create a disjunction in the invariant based on the state of various 
+                    functionalities *)
+
+                (
+                (* We may have just come from wait state *)
+                   (kst1.`kst = KE_Blocked2 (snd p,rcv p, ()) /\ 
+                     kst2.`kst = KE_Wait (snd p,rcv p, ()) /\ 
+                      ast1 = Ch_Init /\
+                       ist1 = ISCSentKE /\ ast2 = Ch_Init) \/
+                (* Key Exchange finished but nobody knows: we get here through steps to ke *)
+                   (kst1.`kst = KE_Available (snd p,rcv p, ()) /\ 
+                     kst2.`kst = KE_Available (snd p,rcv p, ()) /\ 
+                      ast1 = Ch_Init /\
+                       ist1 = ISCSentKE /\ ast2 = Ch_Init) \/
+                (* Key Exchange finished and initiator did its part but still undelivered *)
+                   (kst1.`kst = KE_Available (snd p,rcv p, ()) /\ 
+                     kst2.`kst = KE_Available (snd p,rcv p, ()) /\
+                      ast1 = Ch_Blocked2 
+                                     (snd p, rcv p, enc (pld p) kst1.`key) /\
+                      ast2 = Ch_Blocked2 (snd p, rcv p, enc (pld p) kst1.`key) /\
+                       ist1 = ISCDone)
+                 ) 
+   | Ch_Available p => 
+                ip1 = p /\ 
+                kst1.`kst = KE_Available (snd p,rcv p, ()) /\
+                kst2.`kst = KE_Available (snd p,rcv p, ()) /\
+                ast1 = Ch_Available 
+                                    (snd p, rcv p, enc (pld p) kst1.`key) /\
+                ist1 = ISCDone /\ 
+                ast2 = Ch_Available (snd p, rcv p, enc (pld p) kst1.`key)
+   end.
+
+lemma alg_lem1 (a b c : group):
+   a = a * inv b * c * b * inv c.
+proof. rewrite log_bij !(Ring.rw_algebra, inv_def); ring. qed.
+
+lemma alg_lem2 (a b c : group):
+   a = a * b * inv c * inv b * c.
+proof. rewrite log_bij !(Ring.rw_algebra, inv_def); ring. qed.
+
+lemma sup_lem1 (a b c : group):
+   a \in gen =>
+     mu1 gen a = mu1 gen (a * inv b * c).
+have genu : (is_uniform gen); first by apply dmap_uni;smt(@DiffieHellman).
+have genl : (is_lossless gen); first by apply dmap_ll;smt(@DiffieHellman).
+rewrite !(mu1_uni_ll _ _ genu genl). 
+move => agen; rewrite agen //=.
+have -> // : (a * inv b * c \in gen).
+rewrite /gen supp_dmap.
+by exists ((log a) - (log b) + (log c));smt(@DiffieHellman).
+qed.
+
+lemma sup_lem2 (a b c : group):
+    a \in gen =>
+      a * b * inv c \in gen.
+proof.
+rewrite /gen //=  => *; rewrite supp_dmap. 
+by exists (log a + log b + (log (inv c)));smt(@DiffieHellman).
+qed.
+
+lemma enc_lem (a b c : group):
+    enc b a = enc c (a * b * inv c).
+proof.
+rewrite /enc; rewrite log_bij !(Ring.rw_algebra, inv_def); ring. 
+qed.
+
+
+lemma aux ['a] (b : bool) (u v : 'a) :
+  b => (if b then u else v) = u
+by case b. 
+lemma aux2 ['a] (b : bool) (u v : 'a) :
+  !b => (if b then u else v) = v
+by case b.
+
+lemma OTPAdv2 &m :
+      Pr[ REAL.UC_emul(Z,CompRF(OTPLazy,DHKE.FKE.FKEAuth.FKEAuth)).main() @ &m : res] =
+         Pr[ REAL.UC_emul(Z,CompS(FSC, OTP_SIM)).main() @ &m : res].
+byequiv => //.
+proc.
+inline *.
+swap {1} [2..3] -1.
+swap {2} [3..4] -2.
+seq 2 2 : (={glob Z,glob FKE} /\ FKE.st.`kst{2} = KE_Init); first by auto => /#.
+call (_: invotp OTP.Initiator.p{1}
+                FKE.st{1}
+                FKE.st{2} 
+                FSC.st{2}
+                FChan.FAuth.FAuth.st{2} 
+                DHKE.FKE.FKEAuth.FChan.FAuth.FAuth.st{1} 
+                OTP.Initiator.st{1}); last by auto => />.
+
+(* INPUTS *)
++ by proc;inline *;wp;skip;rewrite /invotp; smt().
+
+(* OUTPUTS *)
++ proc;inline *.
+  wp; skip => /> &1 &2; rewrite /rcv /= /party_output /invotp /kstp /=.
+
+  (* MERGE-COST: old proof *)
+  (* smt (correctness). *)
+
+  (* MERGE-COST: new proof *)
+  progress; 1,3: smt ().
+  move :H; case (FSC.st{2}); case (FKE.st{1}.`kst) => />.
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).
+  smt (correctness).  
+  smt (correctness).
+  move :H0 H1.
+  case (OTP.Initiator.p{1}); case (p{2}) => />. 
+  rewrite /leakpkg /pld /rcv /snd /=. 
+  smt(correctness).
+  (* MERGE-COST: end *)
+
+
+(* Step *)
++ proc;inline *.
+  match; first 2 by smt().
+  (* STEP RHO *)
+  + move => m1 m1_0.
+    sp 1 0; if{1}.
+    (* STEP INITIATOR *)
+    + sp 0 1; match{2}.
+      + by rcondf {1} 1; move => *; wp;skip;smt().
+      + move => p. 
+        rcondt {1} 1; first by move => *; wp;skip;smt().
+        by sp 1 0; match{1};  by move => *;rcondf {1} 5; move => *;wp;skip;smt().
+      + move => p.
+        rcondt {1} 1; first by move => *; wp;skip;smt().
+        by sp 1 0; match{1};  by move => *;rcondf {1} 5; move => *;wp;skip;smt().
+      + move => p.
+        rcondt {2} 1; first by move => *; wp;skip;smt().
+        if{1}.
+        + seq 0 3 : (#pre /\  (oget (getl (oget lfa{2}))) = Ch_Init); 
+            first by wp;skip;smt().
+          match {2}; last 4 by move => p'; exfalso; smt().
+          seq 3 3 : (#pre /\ 
+              (_K{1} <> None => 
+                 FKE.st{1}.`kst = KE_Available (snd OTP.Initiator.p{1}, 
+                                                rcv OTP.Initiator.p{1},()) /\
+                (oget (getr (oget lke{2}))) = FKE.st{1}.`kst) /\
+              (_K{1} = None => 
+                FKE.st{1}.`kst <> KE_Available (snd OTP.Initiator.p{1}, 
+                                                rcv OTP.Initiator.p{1},()) /\
+                (oget (getr (oget lke{2}))) = KE_Wait (snd OTP.Initiator.p{1}, 
+                                                        rcv OTP.Initiator.p{1},()))); 
+            first by wp;skip;rewrite /invotp /#.
+          case (_K{1} = None).
+          + rcondf {1} 1; first by auto => /#.
+            by match {2}; auto => /#.
+          rcondt {1} 1; first by auto => />.
+          match {2}; first 4 by auto => /#.
+          move => p0.
+          swap {1} 2 1.
+          seq 2 2 : (#pre /\ ={i} /\ 
+                    i{1} = Left (I,  (snd OTP.Initiator.p{1},  
+                                        rcv OTP.Initiator.p{1}, 
+                                        enc (pld OTP.Initiator.p{1}) fresh{1}))).
+          + wp; rnd (fun (fresh1 : group) => 
+                       fresh1 * (pld OTP.Initiator.p{1}) * (inv (g ^ F.zero))) 
+                    (fun (fresh2 : group) => 
+                       fresh2 * (inv (pld OTP.Initiator.p{1})) * (g ^ F.zero)).
+
+            (* MERGE-COST: old proof *)
+            (* by wp;skip;smt(alg_lem1 sup_lem1 sup_lem2 alg_lem2 enc_lem). *)
+
+            (* MERGE-COST: new proof *)
+            wp;skip. 
+            move => />. 
+            progress.
+            smt(alg_lem1 alg_lem2 enc_lem). 
+            by apply sup_lem1.
+            by apply sup_lem2.
+            smt(alg_lem1 alg_lem2 enc_lem).
+            smt(alg_lem1 alg_lem2 enc_lem).
+            smt(alg_lem1 alg_lem2 enc_lem).
+            smt(alg_lem1 alg_lem2 enc_lem).
+            (* MERGE-COST: end *)
+
+          by wp;skip;rewrite /invotp;smt().
+        seq 0 3 : (#pre /\ (oget (getl (oget lfa{2}))) <> Ch_Init); 
+          first by wp;skip;smt().
+        by match {2}; 1: (by exfalso => /#); auto => /#.
+      by move => p; rcondf{1} 1; [ by move => *;auto => /#| by auto=> />].
+    (* STEP RESPONDER *)
+    sp 0 1; match{2}; first 3 by auto;rewrite /invotp /#.
+    + by move => p;rcondf{2} 1; auto; rewrite /invotp /#.
+    by auto; rewrite /invotp /#.
+
+  (* STEP HYBRID FUNC *)
+  move => m2 m2_0.
+  sp 1 0;match; 1,2: (by smt()). 
+  (* FAuth *)
+  + auto; rewrite /invotp /#.
+  (* KE *)
+  move => *;wp;skip;rewrite /invotp => /> &1 &2.
+  by case: (FSC.st{2}) => /> /#. 
+
+(* BACKDOOR *)
+proc.
+sp 0 1; match; first 2 by smt().
+
+(* Backdooring the protocol *)
++ by move => m1 b1; inline *; wp;skip;rewrite /invotp; smt().
+
+(* Backdooring the hybrid functionalities *)
+move => m2 b2; inline *.
+by sp 1 0; match; 1,2: (by smt()); auto; rewrite /invotp /#.
+qed.
+
+(* Main theorem for secure channel based on OTP using ideal functionalities
+   for key exchange and authenticated message transfer. Simulation is perfect. *)
+lemma OTPAdv &m :
+      Pr[ REAL.UC_emul(Z,CompRF(OTP,DHKE.FKE.FKEAuth.FKEAuth)).main() @ &m : res] =
+         Pr[ REAL.UC_emul(Z,CompS(FSC, OTP_SIM)).main() @ &m : res].
+proof. by rewrite (OTPAdv1 &m) -(OTPAdv2 &m). qed.
+
+end section.
+
+(* NOW WE MOVE TO INSTANTIATING FKE WITH DHKE *)
+
+clone import PARA_IR with
+    type Pi1.inputs        <- role * group pkg,
+    type Pi1.ask_outputs   <- role * unit pkg,
+    type Pi1.outputs       <- group,
+    type Pi1.step          <- unit,
+    type Pi1.ask_backdoor  <- unit,
+    type Pi1.backdoor      <- DHKE.FKE.FKEAuth.FChan.state,
+    type Pi2.REAL.inputs        <- role * unit pkg,
+    type Pi2.REAL.ask_outputs   <- role,
+    type Pi2.REAL.outputs       <- group,
+    type Pi2.REAL.step          <- (role,(unit,unit) sum) sum,
+    type Pi2.REAL.ask_backdoor  <- (role,(unit,unit) sum) sum,
+    type Pi2.REAL.backdoor      <- (unit, (DHKE.HybFChan.state, DHKE.HybFChan.state) sum) sum,
+    type Pi2.IDEAL.step          <- unit,
+    type Pi2.IDEAL.ask_backdoor  <- unit,
+    type Pi2.IDEAL.backdoor      <- DHKE.FKE.kestate. 
+
+
+(* We re-express OTP as an instance of PARA_IR. *)
+module I_PARA = I.PPara(DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, DHKE.FKE.FKE).
+module I_OTP = C_OTP.CompRF(OTP,I_PARA).
+
+(* This also allows us to express an instantiated KE *)
+module DHKE_ = DHKE.COMPOSITION.CompRF(DHKE.DHKE,DHKE.HybFChan.F2Auth.F2Auth).
+module R_PARA = R.PPara(DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, DHKE_).
+(* And also to express parametrizing OTP with this *)
+module R_OTP = C_OTP.CompRP(OTP,R_PARA).
+
+op cz : cenv.
+axiom cz_pos : cenv_pos cz.
+
+clone PARA_IR.C as PIC with
+  op cz = {|
+    cd = 2 + cz.`cd + 9 * cz.`ci + (22 + cgdiv) * cz.`co + (19 + cgmul) * cz.`cs + 5 * cz.`cb;
+    ci = cz.`cs + cz.`ci;
+    co = cz.`cs + 2 * cz.`co;
+    cs = cz.`cs;
+    cb = cz.`cb;
+  |},
+  op cf1 = {|
+    cpinit     = 1;
+    cpinputs   = 3;
+    cpoutputs  = 9;
+    cpstep     = 2;
+    cpbackdoor = 1;
+  |},
+  op cs2 = {|
+    cinit     = 2 * (1 + cgpow + FDistr.cdt);
+    cstep     = 26; 
+    cs_s      = 1; 
+    cs_b      = 1;
+    cbackdoor = 20;
+    cb_s      = 0;
+    cb_b      = 1; 
+  |}
+  proof cz_pos by smt (cz_pos ge0_cg)
+  proof cf1_pos by done
+  proof cs2_pos by smt (ge0_cg ge0_cf).
+
+clone DHKE.C as DHKEC with
+  op RC.c <- PIC.CPi2.c
+  proof RC.c_pos by apply PIC.CPi2.c_pos. 
+
+(* THIS PROOF IS ALL BOILER PLATE: WE APPLY THE REFINEMENT OF UC THEOREM FOR INSTANTIATING
+   ONE OF THE FUNCTIONALITIES IN A PARALLEL COMPOSITION OF FUNCTIONALITIES, AND THEN PROVE THAT
+   EVERYTHING MATCHES SYNTACTICALLY. THE THEOREM STATES THAT THE DHKE SIMULATOR CAN BE USED TO
+   CONSTRUCT A SIMULATOR FOR THE INSTANTIATED PROTOCOL, WHICH UC REALIZES THE PROTOCOL WITH
+   AN IDEAL FKE. BELOW WE APPLY TRANSITIVITY TO DERIVE THE MAIN THEOREM. *)
+
+op csi = {|
+   cinit = PIC.CRI.csi.`cinit;
+   cstep = max 2 (1 + PIC.CRI.csi.`cstep + PIC.CRI.csi.`cs_s + PIC.CRI.csi.`cs_b * 4);
+   cs_s  = max 1 PIC.CRI.csi.`cs_s;
+   cs_b  = PIC.CRI.csi.`cs_s;
+   cbackdoor = max 7 (3 + PIC.CRI.csi.`cbackdoor + PIC.CRI.csi.`cb_s + PIC.CRI.csi.`cb_b * 4);
+   cb_s      = PIC.CRI.csi.`cb_s;
+   cb_b      = max 1 PIC.CRI.csi.`cb_b;
+|}.
+
+lemma InstOTPAdv &m :    
+  exists (S <: RPi.SIMULATOR {+DHKE.DHKE_SIM}
+               [init : {} `{N csi.`cinit},
+                step : `{N csi.`cstep, #FB.step : csi.`cs_s, #FB.backdoor : csi.`cs_b},
+                backdoor : `{N csi.`cbackdoor, #FB.step : csi.`cb_s, #FB.backdoor : csi.`cb_b}]) , 
+      forall (Z <:  C_OTP.RPi.REAL.ENV {-OTP, -FKE, -DHKE.FKE.FKEAuth.FChan.FAuth.FAuth,
+                              -DHKE.DHKE_SIM, -DHKE_, -FSC, -FChan.FAuth.FAuth}
+                  [distinguish : {#I.inputs, #I.outputs, #I.step, #I.backdoor}
+                               `{N cz.`cd,
+                                 #I.inputs : cz.`ci,
+                                 #I.outputs : cz.`co,
+                                 #I.step : cz.`cs,
+                                 #I.backdoor : cz.`cb}
+              ]), 
+      `| Pr[ C_OTP.RPi.REAL.UC_emul(Z,R_OTP).main() @ &m : res] -
+         Pr[ C_OTP.RPi.REAL.UC_emul(Z,C_OTP.RPi.CompS(I_OTP, S)) .main() @ &m : res] | <= adv_ddh DHKEC.cddh.
+proof.
+have [S h] := DHKEC.KEAdv_ex &m.
+have := PIC.ex_compose DHKE.FKE.FKEAuth.FChan.FAuth.FAuth _ _ _ _ _ DHKE_ DHKE.FKE.FKE S &m (adv_ddh DHKEC.cddh) _;
+  1..5: by proc; auto => />.
+move=> /= Z; have := h Z.
+have -> : 
+    Pr[FKEWorlds.REAL.UC_emul(Z, DHKE.COMPOSITION.CompRF(DHKE.DHKE, DHKE.HybFChan.F2Auth.PARA.PPara(DHKE.HybFChan.F2Auth.FAuthLR.FAuth, DHKE.HybFChan.F2Auth.FAuthRL.FAuth))).main
+     () @ &m : res] =
+   Pr[Pi2.REAL.UC_emul(Z, DHKE.COMPOSITION.CompRF(DHKE.DHKE, DHKE.HybFChan.F2Auth.PARA.PPara(DHKE.HybFChan.F2Auth.FAuthLR.FAuth, DHKE.HybFChan.F2Auth.FAuthRL.FAuth))).main () @ &m : res].
++ by byequiv => //; sim.
+have -> //: Pr[FKEWorlds.REAL.UC_emul(Z, FKEWorlds.CompS(FKE, S)).main() @ &m : res] = Pr[Pi2.REAL.UC_emul(Z, Pi2.CompS(FKE, S)).main() @ &m : res].
++ by byequiv => //; sim.
+move=> [S1 hS1].
+exists (C_OTP.Sid(S1)); split.
++ split; [|split] => kb ks FB *.
+  + by proc true : time []. 
+  + proc; exlim m => -[] mi.
+    + match Left 1; [auto; smt() | done |].
+      by call (:true); auto => /> /#. 
+    match Right 1;[auto; smt() | done |].
+    call (:true; time [C_OTP.Sid(S1, FB).FBPi.step : [N 1; FB.step : 1], 
+                       C_OTP.Sid(S1, FB).FBPi.backdoor : [N 4; FB.backdoor : 1]]).
+    + by move=> *; proc; call(:true); auto.
+    + by move=> *; proc; call(:true); auto.
+    auto => />.
+    rewrite !bigi_constz; 1..2 : smt (PIC.CRI.csi_pos).
+    by rewrite /= !StdBigop.Bigint.bigi_constz; smt (PIC.CRI.csi_pos).
+  proc; exlim m => -[] mi.
+  + match Left 1; [auto; smt() | done |].
+    by wp; call (:true); auto => />. 
+  match Right 1;[auto; smt() | done |].
+  wp;call (:true; time [C_OTP.Sid(S1, FB).FBPi.step : [N 1; FB.step : 1], 
+                        C_OTP.Sid(S1, FB).FBPi.backdoor : [N 4; FB.backdoor : 1]]).
+  + by move=> *; proc; call(:true); auto.
+  + by move=> *; proc; call(:true); auto.
+  auto => />.
+  rewrite !bigi_constz; 1..2 : smt (PIC.CRI.csi_pos).
+  by rewrite /= !StdBigop.Bigint.bigi_constz; smt (PIC.CRI.csi_pos).
+move => Z.
+have -> : Pr[ C_OTP.RPi.REAL.UC_emul(Z,R_OTP).main() @ &m : res] = 
+          Pr[ RI.REAL.UC_emul(C_OTP.CompZR(Z, OTP), R.PPara(DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, DHKE_)).main () 
+               @ &m : res].
++ byequiv => //.
+  proc;inline *.
+  wp;call(_: ={glob OTP, glob DHKE.DHKE, glob DHKE.HybFChan.F2Auth.F2Auth, 
+               glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth}); first 4 by sim.
+  by auto.
+have -> : Pr[RPi.REAL.UC_emul(Z, RPi.CompS(I_OTP, C_OTP.Sid(S1))).main() @ &m : res] = 
+          Pr[RI.REAL.UC_emul(C_OTP.CompZR(Z, OTP), RI.CompS(I.PPara(DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, FKE), S1)).main() @ &m : res]. 
++ byequiv => //. 
+  proc;inline *.
+  wp;call(_: ={glob S1, glob OTP, glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob FKE}); 
+     first 2 by sim.
+  + proc; match; [1,2: by smt()]; move=> *;inline *; auto.
+    call (: ={glob S1, glob OTP, glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob FKE}).
+    + by proc; inline *; match Right {1} 2; auto => /#.
+    + by proc; inline *; match Right {1} 2; auto => /#.
+    by auto => />.
+  + proc; match; 1,2: by smt().
+    + by move => *; inline *;auto => /> /#.
+    move => *; inline *.
+    wp; call (: ={glob S1, glob OTP, glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob FKE}).
+    + by proc; inline *; match Right {1} 2; auto => /#.
+    + by proc; inline *; match Right {1} 2; auto => /#.
+    by auto => />.
+  wp; call (:true); auto => />.
+apply (hS1 (C_OTP.CompZR(Z, OTP))). 
+move=> kb ks ko ki I0 * {S h S1 hS1}.
+proc.
+call (:true; time [ CompR_I(OTP, I0).inputs  : [N 9; I0.inputs : 1], 
+                    CompR_I(OTP, I0).outputs : [N (22 + cgdiv); I0.outputs : 2], 
+                    CompR_I(OTP, I0).step    : [N (19 + cgmul); I0.inputs : 1; I0.outputs : 1; I0.step : 1], 
+                    CompR_I(OTP, I0).backdoor : [N 5; I0.backdoor : 1]]) => /= *.
++ proc; inline *;if => //.
+  + sp => //; if => //; auto; last by smt().
+    by call (:true); auto => />.
+  by call(:true);auto => />. 
++ proc; inline *; sp => //; if => //; auto => />; 1: smt(ge0_cg).
+  seq 3 : true time [N (13 + cgdiv); I0.outputs : 1] => //.
+  + by call (:true); auto => /> /#.
+  if => //=; auto => />; last smt(ge0_cg).
+  by call(:true); auto => /> /#.
++ proc; exlim m => -[] mi.
+  + match Left 1; [auto; smt() | done |].
+    inline *; sp => //; if => //; last by auto; smt (ge0_cg).
+    if => //; last by auto; smt (ge0_cg).
+    seq 1 : true time [N (14 + cgmul); I0.inputs : 1] => //.
+    + by call(:true); auto => /> /#.
+    if => //; auto; 2: smt(ge0_cg).
+    call (:true); auto => /> /#.
+  match Right 1; [auto; smt() | done |].
+  call(:true); auto => />; smt (ge0_cg).
++ proc. exlim m => -[] mi.
+  + match Left 1; [auto; smt() | done |].
+    by inline *; auto => /#.
+  match Right 1; [auto; smt() | done |].
+  by wp; call (:true); auto.  
+inline *; auto => />.
+rewrite !bigi_constz; 1..4:smt(cz_pos). 
+rewrite /= !StdBigop.Bigint.bigi_constz; smt (cz_pos).
+qed.
+
+import DHKE.
+(* import COMPOSITION. *)
+import FKE.
+import FKEAuth. 
+
+(****************************************************************)
+(*  MAIN THEOREM: ASSUMING 3 AUTHENTICATED COMMUNICATIONS       *)
+(*  DHKE + OTP UC REALIZES A ONE-SHOT SECURE CHANNEL.           *)
+(****************************************************************)
+
+(* Again, the steps in this proof are all boiler plate; we just apply transitivity.
+   We could have equality here, but we need to have a strengthened transitivity lemma for perfect simulators. *)
+
+clone C_OTP.TRANS.C as COTPTC with
+  op cz   <- cz,
+  op cs12 <- csi,
+  op cs23 <- {|
+    cinit     = 3 + FDistr.cdt + cgpow;
+    cstep     = 34 + cgmul + 2 * cgpow + FDistr.cdt;
+    cs_s      = 1;
+    cs_b      = 1;
+    cbackdoor = 25;
+    cb_s      = 0;
+    cb_b      = 1;
+    |}
+  proof cz_pos by apply cz_pos
+  proof cs12_pos by smt (PIC.CRI.csi_pos)
+  proof cs23_pos by smt (ge0_cf ge0_cg).
+ 
+(* add proof *)
+
+(* hint simplify cost_dapply. *)
+
+
+schema cost_party_start `{P} {s:state, r:role, p : unit pkg}: cost[P: party_start s r p] = N 5 + cost[P:s] + cost[P:r] + cost[P:p].
+hint simplify cost_party_start.
+
+lemma MainTheorem &m : 
+  exists (S <: TRANS.GOAL.SIMULATOR),
+    forall (Z <: RPi.REAL.ENV {-S, -FSC, -CompRP(OTP,R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE,HybFChan.F2Auth.F2Auth)))}
+      [distinguish : 
+        `{N cz.`cd,
+          #I.inputs : cz.`ci,
+          #I.outputs : cz.`co,
+          #I.step : cz.`cs,
+          #I.backdoor : cz.`cb}]
+    ),   
+      `| Pr[ RPi.REAL.UC_emul(Z,CompRP(OTP,R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE,HybFChan.F2Auth.F2Auth)))).main() @ &m : res] -
+         Pr[ RPi.REAL.UC_emul(Z,TRANS.GOAL.CompS(FSC, S)).main() @ &m : res] | <=
+       adv_ddh (11 + cz.`cd + 42 * cz.`ci + (52 + cgdiv) * cz.`co + (93 + cgmul) * cz.`cs + 15 * cz.`cb).
+proof.
+have -> : 11 + cz.`cd + 42 * cz.`ci + (52 + cgdiv) * cz.`co + (93 + cgmul) * cz.`cs + 15 * cz.`cb = DHKEC.cddh by smt().
+have [S hS]:= InstOTPAdv &m.
+have [S1 hS1]:= COTPTC.ex_uc_transitivity
+      (CompRP(OTP, R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE, HybFChan.F2Auth.F2Auth)))) 
+      (CompRF(OTP,FKEAuth)) FSC S OTP_SIM _ _ _ &m (adv_ddh DHKEC.cddh) 0%r _ _.
++ move=> kb ks FB *.
+  instantiate h := (cost_dapply {k : group}).
+  proc; inline *; wp; rnd; 1: by rewrite h.
+  by auto => />; rewrite h dmap_ll 1:FDistr.dt_ll /= /#.
++ move=> kb ks FB *.                  
+  proc. 
+  exlim (s) => -[]mi.
+  + match Left 1;[auto; smt() | done |].
+    seq 1 : true time [N (33 + cgmul + 2 * cgpow + FDistr.cdt)] => //.
+    + by call (:true); auto => /> /#. 
+    inline *; wp.
+    exlim (oget lsc) => -[|p|p|p|p].
+    + match Ch_Init 1; [auto; smt() | done |].
+      by auto => />; smt(ge0_cf ge0_cg).
+    + match Ch_Blocked1 1; [auto; smt() | done |].
+      by auto => />; smt(ge0_cf ge0_cg).
+    + match Ch_Wait 1; [auto; smt() | done |].
+      auto => />; smt(ge0_cf ge0_cg).
+    + match Ch_Blocked2 1; [auto; smt() | done |].
+      if => //.
+      + sp => //.
+        match Left 1; [auto; smt() | done |].
+        sp => //.
+        exlim (oget (getl (oget lfa))) => -[|p'|p'|p'|p'].
+        + match Ch_Init 1; [auto; smt() | done |].
+          sp => //.
+          match Right 1; [auto; smt() | done |].
+          sp => //.
+          exlim (oget (getr (oget lke))) => -[|p1|p1|p1|p1].
+          + match KE_Init 1; [auto; smt() | done |].
+            auto; smt(ge0_cf ge0_cg).
+          + match KE_Blocked1 1; [auto; smt() | done |].
+            auto => />; smt(ge0_cf ge0_cg).
+          + match KE_Wait 1; [auto; smt() | done |].
+            auto => />; smt(ge0_cf ge0_cg).
+          + match KE_Blocked2 1; [auto; smt() | done |].
+            auto => />; smt(ge0_cf ge0_cg).
+          match KE_Available 1; [auto; smt() | done |].
+          seq 2 : (i =  Left (I, (snd p2, rcv p2, enc (g ^ F.zero) fresh))) time [N 4] => //.
+          + instantiate h := (cost_dapply {m2, m3 : unit, r3, r4 : role, p0, p1, p2 : unit pkg, fresh : group, 
+                                           p : group pkg, r1, r10 : group pkg stlkg option, r2, r20 : kestate option,
+                                           r, r0 : (group pkg stlkg, kestate) sum option, lsc : Top.OTP.FChan.FSC.leakage option, 
+                                           m1 : C_OTP.R.step, s : RPi.IDEAL.step, i : SimKEAuth.PARA.Pi12.inputs,
+                                           m, m0 : SimKEAuth.PARA.Pi12.ask_backdoor, lke, lfa : SimKEAuth.PARA.Pi12.backdoor option}).
+             wp; rnd => />; 1: by rewrite h.
+             auto => /> *; rewrite h dmap_ll 1:FDistr.dt_ll /=; smt(ge0_cf ge0_cg).
+          by match Left 1; [auto; smt() | done | auto => />].
+        + match Ch_Blocked1 1; [auto; smt() | done |].
+          auto; smt(ge0_cf ge0_cg).
+        + match Ch_Wait 1; [auto; smt() | done |].
+          auto; smt(ge0_cf ge0_cg).
+        + match Ch_Blocked2 1; [auto; smt() | done |].
+          auto; smt(ge0_cf ge0_cg).
+        match Ch_Available 1; [auto; smt() | done |].
+        auto; smt(ge0_cf ge0_cg).
+      auto; smt(ge0_cf ge0_cg).
+    match Ch_Available 1; [auto; smt() | done |].
+    auto; smt(ge0_cf ge0_cg).
+  match Right 1;[auto; smt() | done |].
+  inline *.
+  exlim m2 => -[] m2i.
+  + match Left 1; [auto; smt() | done |].
+    sp 1 => //.
+    match Left 1; [auto; smt() | done |].
+    sp 3 => //.
+    match Left 1; [auto; smt() | done|].
+    sp => //.
+    exlim (oget (getl (oget lfa))) => -[|p'|p'|p'|p'].
+    + match Ch_Init 1; [auto; smt() | done |].
+      by auto => /=; smt(ge0_cf ge0_cg).
+    + by match Ch_Blocked1 1; auto; smt(ge0_cf ge0_cg).
+    + by match Ch_Wait 1; auto; smt(ge0_cf ge0_cg).
+    + by match Ch_Blocked2 1; auto; smt(ge0_cf ge0_cg).
+    match Ch_Available 1; [auto; smt() | done |].
+    by call (:true); auto; smt(ge0_cf ge0_cg).
+  match Right 1; [auto; smt() | done |].
+  seq 1 : true time [N 28; FB.step : 1] => //.
+  + by call(:true); auto => />; smt(ge0_cf ge0_cg).
+  seq 1 : true time [N 4] => //; last by sp 1 => //; match Right 1; auto.
+  exlim (oget lsc) => -[|p'|p'|p'|p'].
+  + match Ch_Init 1; auto; smt(ge0_cf ge0_cg).
+  + match Ch_Blocked1 1;[auto; smt() | done |].
+    sp 1 => //; match Right 1; [auto; smt() | done |].
+    sp 4 => //.
+    exlim  (oget (getr (oget lke))) =>  -[|p|p|p|p].
+    + match KE_Init 1; [auto; smt() | done |].
+      sp 1 => //; match Right 1; [auto; smt() | done |].
+      by call (:true); auto => />. 
+    + by match KE_Blocked1 1; auto; smt(ge0_cf ge0_cg).
+    + by match KE_Wait 1; auto; smt(ge0_cf ge0_cg).
+    + by match KE_Blocked2 1; auto; smt(ge0_cf ge0_cg).
+    by match KE_Available 1; auto; smt(ge0_cf ge0_cg).
+  + by match Ch_Wait 1; auto; smt(ge0_cf ge0_cg).
+  + match Ch_Blocked2 1; [auto; smt() | done |].
+    by sp 1 => //; match Right 1; auto; smt(ge0_cf ge0_cg).
+  by match Ch_Available 1; auto; smt(ge0_cf ge0_cg).
++ move=> kb ks FB *.                  
+  proc.
+  inline *.
+  exlim (b) => -[bl|br].     
+  + by match Left 2; auto; smt().
+  match Right 2; [1: by auto; smt() | 2: done].
+  exlim (b2) => -[b2l|b2r].     
+  + by match Left 2; auto; smt().
+  match Right 2; [1: by auto; smt() | 2: done].
+  sp => //.
+  seq 1 : true time [ N 22]; 1: done.
+  call (:true); auto => * /=; by smt (). 
+  by auto => /> /#.
++ move=> Z.
+  have -> : 
+    Pr[TRANS.H1.REAL.UC_emul(Z, CompRP(OTP, R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE, HybFChan.F2Auth.F2Auth)))).main() @ &m : res] = 
+     Pr[RPi.REAL.UC_emul(Z, CompRP(OTP, R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE,HybFChan.F2Auth.PARA.PPara(HybFChan.F2Auth.FAuthLR.FAuth, HybFChan.F2Auth.FAuthRL.FAuth))))).main() @ &m : res].
+  + by byequiv => //;sim.
+  have -> : 
+    Pr[TRANS.H1.REAL.UC_emul(Z, TRANS.H1.CompS(CompRF(OTP, FKEAuth), S)).main() @ &m : res] = 
+    Pr[RPi.REAL.UC_emul(Z, RPi.CompS(CompRF(OTP, I.PPara(FChan.FAuth.FAuth, FKE)), S)).main() @ &m : res].
+  + by byequiv => //; sim.
+  by apply (hS Z).
++ move=> Z.
+  have -> :
+    Pr[TRANS.H2.REAL.UC_emul(Z, CompRF(OTP, FKEAuth)).main() @ &m : res] = 
+    Pr[REAL.UC_emul(Z, CompRF(OTP, PARA.PPara(FChan.FAuth.FAuth, FKE))).main() @ &m : res].
+  + by byequiv => //; sim.
+  have -> : 
+    Pr[TRANS.H2.REAL.UC_emul(Z, TRANS.H2.CompS(FSC, OTP_SIM)).main() @ &m : res] = 
+    Pr[REAL.UC_emul(Z, CompS(FSC, OTP_SIM)).main() @ &m : res].
+  + by byequiv => //; sim.
+  by rewrite  -(OTPAdv Z &m).
+exists S1 => Z.
+have <- : 
+  Pr[TRANS.GOAL.REAL.UC_emul(Z, CompRP(OTP, R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE, HybFChan.F2Auth.F2Auth)))).main() @ &m : res] = 
+  Pr[RPi.REAL.UC_emul(Z, CompRP(OTP, R.PPara(FChan.FAuth.FAuth, COMPOSITION.CompRF(DHKE, HybFChan.F2Auth.F2Auth)))).main() @ &m : res].
++ by byequiv=> //; sim.
+have <- :
+  Pr[TRANS.GOAL.REAL.UC_emul(Z, TRANS.GOAL.CompS(FSC, S1)).main() @ &m : res] =
+  Pr[RPi.REAL.UC_emul(Z, TRANS.GOAL.CompS(FSC, S1)).main () @ &m : res].
++ by byequiv => //;sim.
+apply (hS1 Z).
+qed.
+
+end OTP.

--- a/examples/Upto.ec
+++ b/examples/Upto.ec
@@ -70,8 +70,8 @@ module Experiment (O : Oracle) (AdvF : A) = {
 
 (* TODO: wut? Document this. *)
 lemma Conclusion &m p
-                 (O1 <: Oracle{Experiment})(O2 <: Oracle{Experiment})
-                 (Adv <: A{Experiment, O1, O2})
+                 (O1 <: Oracle{-Experiment})(O2 <: Oracle{-Experiment})
+                 (Adv <: A{-Experiment, -O1, -O2})
                  I P (m : glob O2 -> int) (g : int -> real):
   (forall x, 0%r <= g x <= 1%r) =>
   bigi predT g 0 qO <= qO%r * p =>
@@ -93,7 +93,7 @@ lemma Conclusion &m p
      phoare [O2.f : m (glob O2) = k ==> snd res] <= (g k )) =>
   islossless O1.f =>
   islossless O2.f =>
-  (forall (O <: Oracle{Adv}), islossless O.f => islossless Adv(O).run) =>
+  (forall (O <: Oracle{-Adv}), islossless O.f => islossless Adv(O).run) =>
   I (glob O1){m} (glob O2){m} =>
   Pr [Experiment(O1, Adv).main() @ &m : P res]
   <= Pr [Experiment(O2, Adv).main() @ &m : P res]  + qO%r * p.

--- a/examples/async-while.ec
+++ b/examples/async-while.ec
@@ -56,7 +56,7 @@ async while
 + by move=> &1 &2 />; smt(gt0_k).
 + by move=> &1 &2 />; smt(gt0_k).
 + by move=> &2; exfalso=> &1; smt(gt0_k).
-+ by move=> &2; exfalso=> &1; smt(gt0_k).
++ by move=> &2; exfalso=> &1 ?; smt(gt0_k).
 + move=> v1 v2.
   rcondt {2} 1; 1: by auto => /> /#.
   rcondf{2} 4; 1: by auto; conseq (_: true);auto.

--- a/examples/br93.ec
+++ b/examples/br93.ec
@@ -245,10 +245,10 @@ module I(A:Adv): Inverter = {
 (* We now prove the result using a sequence of games                    *)
 section.
 (* All lemmas in this section hold for all (valid) CPA adversary A      *)
-declare module A <: Adv { LRO, Log }.
+declare module A <: Adv { -LRO, -Log }.
 
-declare axiom A_a1_ll (O <: POracle {A}): islossless O.o => islossless A(O).a1.
-declare axiom A_a2_ll (O <: POracle {A}): islossless O.o => islossless A(O).a2.
+declare axiom A_a1_ll (O <: POracle {-A}): islossless O.o => islossless A(O).a1.
+declare axiom A_a2_ll (O <: POracle {-A}): islossless O.o => islossless A(O).a2.
 
 (* Step 1: replace RO call with random sampling                         *)
 local module Game1 = {
@@ -401,7 +401,7 @@ local module OWr (I : Inverter) = {
 }.
 
 (* We can easily prove that it is strictly equivalent to OW              *)
-local lemma OW_OWr &m (I <: Inverter {OWr}):
+local lemma OW_OWr &m (I <: Inverter {-OWr}):
   Pr[OW(I).main() @ &m: res]
   = Pr[OWr(I).main() @ &m: res].
 proof. by byequiv=> //=; sim. qed.
@@ -621,10 +621,10 @@ module A_CPA (A : Adv) (H : POracle) = {
 }.
 
 section.
-declare module A <: Adv { LRO, I }.
+declare module A <: Adv { -LRO, -I }.
 
-declare axiom A_a1_ll (O <: POracle {A}): islossless O.o => islossless A(O).a1.
-declare axiom A_a2_ll (O <: POracle {A}): islossless O.o => islossless A(O).a2.
+declare axiom A_a1_ll (O <: POracle {-A}): islossless O.o => islossless A(O).a1.
+declare axiom A_a2_ll (O <: POracle {-A}): islossless O.o => islossless A(O).a2.
 
 local clone import BR93 as Instance with
   type pkey  <- pkey,

--- a/examples/cost/apply_example.ec
+++ b/examples/cost/apply_example.ec
@@ -1,0 +1,67 @@
+require import AllCore Int CHoareTactic StdBigop.
+import Bigint.
+
+schema cost_plus `{P} {e e' : int}: 
+  cost[P : e + e'] = cost[P : e] + cost[P : e'] + N 1.
+
+schema cost_times `{P} {e e' : int}: 
+  cost[P : e * e'] = cost[P : e] + cost[P : e'] + N 1.
+
+hint simplify cost_plus.
+hint simplify cost_times.
+
+(*********************)
+(* Lemma application *)
+(*********************)
+
+module type H = { 
+  proc o1 () : unit
+  proc o2 () : unit  
+}.
+
+module type Adv (H0 : H) (H1 : H) = { proc a () : unit }.
+
+module (MyAdv : Adv) (H0 : H) (H1 : H) = {
+  proc a () = {
+    var y;
+    y <- 1 + 1 + 1 + 1;
+    H0.o1();
+    H1.o2();
+    H0.o2();
+  }
+}.
+
+lemma MyAdv_compl (k01 k02 k11 k12 : int)
+    (H0 <: H [o1 : `{N k01}, o2 : `{N k02}])
+    (H1 <: H [o1 : `{N k11}, o2 : `{N k12}]) : 
+    choare[MyAdv(H0, H1).a] 
+      time [N 3; H0.o1 : 1; H0.o2 : 1; H1.o2 : 1].
+proof.
+  proc; do !(call(_: true)); auto => /=.
+qed.
+
+print MyAdv_compl.
+
+module (MyH : H) = { 
+  proc o1 () = {
+    var z;
+    z <- 1 + 1;
+  }
+
+  proc o2 () = {
+    var z;
+    z <- 1 + 1 + 1;
+  }
+}.
+
+lemma MyH_compl1 : choare[MyH.o1] time [N 1] by proc; auto.
+lemma MyH_compl2 : choare[MyH.o2] time [N 2] by proc; auto.
+lemma MyH_compl : choare[MyH.o1] time [N 1] /\ choare[MyH.o2] time [N 2] 
+    by split; [apply MyH_compl1 | apply MyH_compl2].
+
+lemma advcompl_inst : choare[MyAdv(MyH, MyH).a] time [N 8].
+proof.
+  apply (MyAdv_compl _ _ _ _ 
+              MyH MyH_compl1 MyH_compl2
+              MyH MyH_compl1 MyH_compl2). 
+qed.

--- a/examples/cost/small_tutorial.ec
+++ b/examples/cost/small_tutorial.ec
@@ -1,0 +1,331 @@
+require import AllCore Xint Int List CHoareTactic StdBigop.
+import Bigint.
+
+module V = { var v : int }.
+
+(*********************)
+(* Expression's cost *)
+(*********************)
+
+(* Integer constants are free. *)
+lemma free_int : cost(_:{})[true : 1] = N 0 by auto.
+
+(* Variable lookups are free. *)
+lemma free_var : cost(_:{x : int})[true : x] = N 0 by auto.
+
+(* Same for global variables. *)
+module A = { var x : int }.
+lemma free_var_g : cost(_:{})[true : A.x] = N 0 by auto.
+
+(* And logical variables. *)
+lemma free_var_logical (a : int) : cost(_:{})[true : a] = N 0 by auto.
+
+
+(* Everything else has a cost, that must be given by the user through 
+   schemata. A schema allow to quantify over *expressions*, as in: *)
+schema cost_plus `{P} {e e' : int}: 
+  cost[P : e + e'] = cost[P : e] + cost[P : e'] + N 1.
+
+schema cost_plus_true {e e' : int}: 
+  cost[true : e + e'] = cost[true : e] + cost[true : e'] + N 1.
+
+schema cost_times `{P} {e e' : int}: 
+  cost[P : e * e'] = cost[P : e] + cost[P : e'] + N 1.
+
+(* It can be instantiated manually with the [instantiate] tactic. *)
+(* Syntax, where for every i, Pi can use memory mhm:
+   instantiate intro_pat := 
+   (sc_name memtype '(P1) ... '(Pn) expr1 ... exprm) *)
+lemma foo_cost : cost(_:{})[true : 1 + 2] = N 1.
+proof.
+instantiate H  := (cost_plus_true {} 1 2).
+instantiate H0 := (cost_plus      {} `(true) 1 2).
+instantiate H2 := (cost_plus      {} `(_:true) 1 2).
+
+(* We can also explicitely give the memory name, as follows: *)
+instantiate H3 := (cost_plus      {} `(&mem: V.v = 2) 1 2). 
+instantiate H4 := (cost_plus      {} `(&mem: V.v{mem} = 2) 1 2).
+
+instantiate -> := (cost_plus      {} `(_:true) 1 2).
+auto.
+qed.
+
+(* Instantiating manually can be avoided using simplification hints.  *)
+hint simplify cost_plus.
+hint simplify cost_times.
+
+lemma foo_cost2 : cost(_:{})[true : 1 + 2] = N 1 by auto.
+
+(* Schemata can have type variables, e.g. for lists. *)
+require import List.
+schema cost_cons ['a] {e : 'a} {l : 'a list} : 
+    cost[true : e :: l] =   
+    cost[true : e] + cost[true : l] + N 1.
+
+schema cost_nil ['a] : cost[true : [<:'a>]] = N 1.
+
+hint simplify cost_cons.
+hint simplify cost_nil.
+lemma foo_list : cost(_:{})[true: [1;2;3;4]] = N 5 by auto.
+
+
+(****************************)
+(* Modules and restrictions *)
+(****************************)
+
+
+module B = { 
+  proc g (x : int, y : int) : int = {
+    var r : int;
+    r <- x + y;
+    r <- r * x;
+    return r * r;
+  }
+
+  proc f (x : int) : int = {
+    var a : int;
+    a <- x + 1;
+    a <@ g(a,x);
+  return a;
+  }
+}.
+
+(* Assignements are free, only the variable evaluation has a cost. *)
+lemma foo : choare[B.g : true ==> true] time [N 3].
+proof. by proc; auto. qed.
+
+(* Procedure calls are also free. *)
+lemma foo3 : choare[B.f : true ==> true] time [N 4].
+proof.
+  proc; call foo; auto.
+qed.
+
+module C = { 
+  proc f (x : int, y : int) : int = {
+    var r : int;
+    if (y < x) {
+      r <- 1 + 1;
+      r <- 1 + 1;
+     } else {
+      r <- 2 + 1;
+      r <- 2 + 1;
+    }
+    return r;
+  }
+}.
+
+schema cost_lt `{P} {e e' : int}: 
+  cost[P : e < e'] = cost[P : e] + cost[P : e'] + N 1.
+hint simplify cost_lt.
+
+(* For if statements, to keep cost expressions simpler, we do not use
+    a max. Instead, we add the cost of both branches. *)
+lemma foo4 : choare[C.f] time [N 5].
+proof.
+proc; auto.
+qed.
+
+module D = { 
+  var g : int
+
+  proc f (x : int, y : int) : int = {
+    while (x < y) {
+      x <- x + 1;
+    }
+    return x;
+  }
+}.
+
+lemma foo5 : forall (a : int) (b : int), 
+0 <= a <= b =>
+choare[D.f : x = a /\ y = b /\ x < y ==> true] time [N (2 * (b - a) + 1)].
+proof.
+move => a b [Ha Hb].
+proc => /=.
+(* The [while] tactic takes the following parameters:
+   - invariant, 
+   - deacreasing quantity qdec
+   - number of loop iterations
+   - cost of one loop body, when (qdec = k), given using a lambda. *)
+while (x <= y /\ y = b) (b - x) (b - a) time [fun _ => N 1].
+
+(* prove that the loop body preserves the invariant, and cost what was stated. *)
+move => z; auto => * /=; by smt ().
+
+(* prove that the if the invariant holds, and if the decreasing quantity is less 
+   or equal to zero, then we exit the loop. *)
+move => &hr; by smt ().
+
+(* prove that either the wanted upper-bound is infinite, or the final cost is 
+  not infinite. *)
+right; auto.
+
+(* prove that the invariant implies the post, that the decreasing quantity
+   is initially smaller than the number of loop iterations, and that the cost
+   of all iterations is smaller than the final cost. *)
+skip => * => /=; split; 1: by smt().
+by rewrite big_constNz /= !size_range /= /#.
+qed.
+
+(* Match example *)
+
+module ExMatch = {
+  proc gethead (l : int list) = {
+    var x : int;
+    match 1 :: 2 :: l with
+    | [] => x <- 0;
+    | a :: tail => x <- a + 1;
+    end;
+  }
+}.
+
+lemma test_match : choare[ExMatch.gethead] time [N 4].
+proof.
+proc; match (::) 0 => //=.
++ by skip=> /#.
++ by auto.
+qed.
+
+(*********************)
+(* Lemma application *)
+(*********************)
+
+module type H = { proc o () : unit }.
+
+module type Adv (H0 : H) = { proc a () : unit }.
+
+module (MyAdv : Adv) (H0 : H) = {
+  proc a () = {
+    var y;
+    y <- 1 + 1 + 1 + 1;
+    H0.o();
+    H0.o();
+  }
+}.
+
+
+lemma MyAdv_compl (k : int) (H0   <: H [o : `{N k}]) : 
+  0 <= k => choare[MyAdv(H0).a] time [N 3; H0.o : 2].
+proof.
+by move=> _; proc; do !(call(_: true; time [])); auto => /=.
+qed.
+
+(* The same lemma, but in a section. *)
+section.
+op mk : int.
+declare module H0 <: H [ o : `{N mk}].
+
+lemma MyAdv_compl_loc : choare[MyAdv(H0).a] time [N 3; H0.o : 2].
+proof. by proc; do !(call(_: true; time [])); auto. qed.
+end section.
+
+module (MyH : H) = { 
+  proc o () = {
+    var z;
+    z <- 1+1;
+  }
+}.
+
+lemma MyH_compl : choare[MyH.o] time [N 1] by proc; auto.
+
+lemma advcompl_inst : choare[MyAdv(MyH).a] time [N 5].
+proof.
+by apply (MyAdv_compl 1 MyH MyH_compl).
+qed.
+
+module Inv (Adv0 : Adv) (HI : H) = {
+  module Adv1 = Adv0(HI)
+
+  proc i () = {
+    var z;
+    z <- 1 + 1;
+    Adv1.a();
+  }
+}.
+
+lemma Inv_compl
+    (j k h : int)
+    (Adv0 <: Adv [a : `{N j, #H0.o : k}]) 
+    (H0   <: H [o : `{N h}]) : 
+    0 <= k =>
+    choare[Inv(Adv0, H0).i] time [N 1; Adv0.a : 1; H0.o : k ].
+proof.    
+move => hk; proc.
+call (_: true; time [H0.o : [N 0; H0.o : 1]]).
+move => i Hi /=; proc*; call(_: true; time []); auto => /=.
+by auto => /=; rewrite big_constz count_predT big_constNz !size_range /#.
+qed.
+
+lemma Inv_compl_inst (h : int) (H1   <: H [o : `{N h}]) : 
+  choare[Inv(MyAdv, H1).i] time [N 4; H1.o : 2 ].
+proof.
+by apply (Inv_compl _ _ h MyAdv MyAdv_compl H1 _).
+qed.
+
+(**************************************************)
+op kab : int.
+
+module type AB (H0 : H) = {
+  proc a () : unit `{ N kab, H0.o : 1 }
+}.
+
+section.
+ declare module H0 <: H.
+ declare module AB0 <: AB.
+
+ local module AB1 = AB0(H0).
+
+ local module E = { 
+   proc e () = {
+     AB1.a();
+   }
+ }.
+
+(**************************************************)
+ module type MAB (H1 : H) (H2 : H)  = {
+   proc a () : unit {H2.o}
+ }.
+
+ local module (MAB0 : MAB) (H1 : H) (H2 : H) = {
+   proc a () = {
+     H2.o();
+     H0.o();
+   }
+ }.
+
+ local module MAB1 = MAB0(H0).
+
+ local module MAB2 = MAB0(H0, H0).
+
+end section.
+
+(**************************************************)
+(* Bonus: expression's cost using a free operator *)
+(**************************************************)
+
+op free ['a] (x : 'a) : 'a.
+
+axiom free_id ['a] (x : 'a) : free(x) = x.
+
+schema free_id ['a] {e : 'a} : cost[true : free(e)] = N 0.
+
+schema plus_cost_f {e e' : int}: cost[true : free(e) + free(e')] = N 1.
+
+(* The schema below is valid for any operator with a call-by-value semantics. *)
+schema plus_cost_e {e e' : int}: 
+  cost[true : e + e'] = 
+  cost[true : free(e) + free(e')] +
+  cost[true : e] + cost[true : e'].
+
+schema free_beta ['a, 'b] {f : 'a -> 'b} {k : 'a} :
+  cost[true : (fun x => f x) k] = 
+  cost[true : f (free k)] + cost[true : k] + N 1.
+
+lemma foo_p_f : cost(_:{})[true : 1 + 2] = N 1.
+proof.
+instantiate -> := (plus_cost_e {} 1 2).
+instantiate -> := (plus_cost_f {} 1 2) => //.
+qed.
+
+(* Remark: we cannot use hints there, because plus_cost_e is not terminating. *)
+

--- a/examples/cramer-shoup/cramer_shoup.ec
+++ b/examples/cramer-shoup/cramer_shoup.ec
@@ -277,9 +277,9 @@ proof. islossless. qed.
 
 section Security_Aux.
 
-  declare module A <: CCA_ADV {CCA, B_TCR}.
-  declare axiom guess_ll : forall (O <: CCA_ORC{A}), islossless O.dec => islossless A(O).guess.
-  declare axiom choose_ll : forall (O <: CCA_ORC{A}), islossless O.dec => islossless A(O).choose.
+  declare module A <: CCA_ADV {-CCA, -B_TCR}.
+  declare axiom guess_ll : forall (O <: CCA_ORC{-A}), islossless O.dec => islossless A(O).guess.
+  declare axiom choose_ll : forall (O <: CCA_ORC{-A}), islossless O.dec => islossless A(O).choose.
 
   equiv CCA_DDH0 : CCA(CramerShoup, A).main ~ DDH0_ex(B_DDH(A)).main : ={glob A} ==> ={res}.
   proof.   
@@ -453,7 +453,7 @@ section Security_Aux.
     have H2 : forall x1L x2L, x1L + xL * x2L = x1L + xL * x2L - xL * x2L + xL * x2L.
     +  by move=> ??;ring.
     rewrite -!H2 /=;split=> [ | _].
-    + by split ;ring.
+    + by split => *;ring.
     move=> ??????? Hbad ? ? /=.
     have <- /= : g ^ zL = g ^ xL ^ (zL / xL).
     + by rewrite log_bij !(log_g, log_pow, log_mul);field.
@@ -690,12 +690,12 @@ section Security_Aux.
        G1.x2 = G2.alpha - G2.v * G1.y2){2} /\
       (G1.bad{1} => G1.y2{2} \in G3.y2log{2})).
   proof.
-    proc;auto => &m1 &m2 />.
+    proc; auto => &m1 &m2 />.
     case: (ci{m2}) => a a_ c d /=.
     pose v := H _ _. rewrite !negb_or => [[]] Hg3 Hcilog Hstareq.
     rewrite Hg3 /=. 
     case: (G1.bad{m1}) => [_ -> | ] //=. 
-    move=> Hbad Hsize Hstar;rewrite !negb_and /= 2!negb_or /= -!andaE.
+    move=> Hbad Hsize Hstar;rewrite !andaE !negb_and /= 2!negb_or /= -!andaE.
     case (v = G2.v{m2}) => />.
     + by case: (G1.cstar{m2}) Hstareq Hstar => />.
     move=> Hv Ha _;left.
@@ -969,9 +969,9 @@ end section Security_Aux.
 
 section Security.
 
-  declare module A <: CCA_ADV {CCA, B_TCR}.
-  declare axiom guess_ll : forall (O <: CCA_ORC{A}), islossless O.dec => islossless A(O).guess.
-  declare axiom choose_ll : forall (O <: CCA_ORC{A}), islossless O.dec => islossless A(O).choose.
+  declare module A <: CCA_ADV {-CCA, -B_TCR}.
+  declare axiom guess_ll : forall (O <: CCA_ORC{-A}), islossless O.dec => islossless A(O).guess.
+  declare axiom choose_ll : forall (O <: CCA_ORC{-A}), islossless O.dec => islossless A(O).choose.
 
   local module NA (O:CCA_ORC) = {
     module A = A(O)

--- a/examples/hashed_elgamal_generic.ec
+++ b/examples/hashed_elgamal_generic.ec
@@ -1,6 +1,6 @@
-require import AllCore Int Real FSet StdOrder.
+require import AllCore FSet List SmtMap CHoareTactic StdOrder.
 require (*--*) BitWord Distr DInterval.
-(*---*) import RealOrder RField.
+(*---*) import RealOrder RField StdBigop.Bigint BIA.
 require (*--*) DiffieHellman ROM PKE_CPA.
 
 (* The type of plaintexts: bitstrings of length k *)
@@ -14,13 +14,32 @@ rename
   "dunifin" as "dbits".
 import DWord.
 
-(* Upper bound on the number of calls to H *)
-op qH: { int | 0 < qH } as gt0_qH.
+op cdbits : { int | 0 <= cdbits } as ge0_cdbits.
+
+schema cost_cdbits `{P} : cost [P: dbits] = N cdbits.
+hint simplify cost_cdbits.
+
+(* Upper bound on complexity of the adversary *)
+type adv_cost = {
+  cchoose : int; (* cost *)
+  ochoose : int; (* number of call to o *)
+  cguess  : int; (* cost *)
+  oguess  : int; (* number of call to o *)
+}.
+
+op cA : adv_cost.
+axiom cA_pos : 0 <= cA.`cchoose /\ 0 <= cA.`ochoose /\ 0 <= cA.`cguess /\ 0 <= cA.`oguess /\ 0 < cA.`ochoose + cA.`oguess.
+
+op qH = cA.`ochoose + cA.`oguess.
+lemma gt0_qH :  0 < qH by smt (cA_pos).
 
 (* Assumption: Set CDH *)
-clone import DiffieHellman.Set_CDH as SCDH with
-  op n <- qH.
+clone import DiffieHellman.List_CDH as LCDHT with
+  op n <- qH
+  proof gt0_n by apply gt0_qH.
 import DiffieHellman G FDistr.
+
+clone import LCDHT.C as C1.
 
 type pkey = group.
 type skey = t.
@@ -72,9 +91,14 @@ clone import ROM as RO with
   type d_in_t  <- unit,
   type d_out_t <- bool,
   op   dout _  <- dbits.
+
 import Lazy.
+
 clone import ROM_BadCall as ROC with
   op qH <- qH.
+
+clone import FMapCost as FMC with
+  type from  <- group.
 
 (* Adversary Definitions *)
 module type Adversary (O : POracle) = {
@@ -83,38 +107,25 @@ module type Adversary (O : POracle) = {
 }.
 
 (* Specializing and merging the hash function *)
-module H : Hash = {
-  proc init(): unit = { LRO.init(); Log.qs <- fset0; }
-  proc hash(x:group): bits = { var y; y <@ LRO.o(x); return y; }
+
+module H = {
+  var qs : group list
+  proc init(): unit = { LRO.init(); qs <- []; }
+  proc o(x:group): bits = { var y; qs <- x::qs; y <@ LRO.o(x); return y; }
+  proc hash = LRO.o
 }.
 
 (* The initial scheme *)
 module S = Hashed_ElGamal(H).
 
-(* The reduction *)
-module SCDH_from_CPA(A:Adversary,O:Oracle): Top.SCDH.Adversary = {
-  module BA = A(Bound(O))
-
-  proc solve(gx:group, gy:group): group fset = {
-    var m0, m1, h, b';
-
-    H.init();
-    (m0,m1)  <@ BA.choose(gx);
-    h        <$ dbits;
-    b'       <@ BA.guess(gy, h);
-    return Log.qs;
-  }
-}.
-
 (* We want to bound the probability of A winning CPA(Bounder(A,RO),S) in terms of
    the probability of B = CDH_from_CPA(SCDH_from_CPA(A,RO)) winning CDH(B) *)
+
 section.
-  declare module A <: Adversary { LRO, Log, OnBound.G1, OnBound.G_bad }.
+  declare module A <: Adversary [choose : `{N cA.`cchoose, #O.o : cA.`ochoose},
+                                 guess  : `{N cA.`cguess,  #O.o : cA.`oguess}] {-H}.
 
-  declare axiom choose_ll (O <: POracle {A}): islossless O.o => islossless A(O).choose.
-  declare axiom guess_ll (O <: POracle {A}) : islossless O.o => islossless A(O).guess.
-
-  local module BA = A(Bound(LRO)).
+  declare axiom guess_ll (O <: POracle {-A}) : islossless O.o => islossless A(O).guess.
 
   local module G0 = {
     var gxy:group
@@ -128,259 +139,130 @@ section.
       y       <$ dt;
       gx      <- g ^ x;
       gxy     <- gx ^ y;
-      (m0,m1) <@ BA.choose(gx);
-      b       <$ {0,1};
-      h       <@ H.hash(gxy);
-      c       <- (g ^ y, h +^ (b ? m1 : m0));
-      b'      <@ BA.guess(c);
-      return (b' = b);
-    }
-  }.
-
-  local equiv CPA_G0: CPA(S,BA).main ~ G0.main: ={glob A} ==> ={res}.
-  proof.
-    proc.
-    inline Hashed_ElGamal(H).kg Hashed_ElGamal(H).enc.
-    swap{1} 8 -5.
-    call (_: ={glob H, Log.qs}); first by sim.
-    wp; call (_: ={glob H}); first by sim.
-    wp; rnd.
-    call (_: ={glob H, Log.qs}); first by sim.
-    wp; do !rnd.
-    by call (_: true ==> ={glob H}); first by sim.
-  qed.
-
-  local lemma Pr_CPA_G0 &m:
-    Pr[CPA(S,BA).main() @ &m: res] = Pr[G0.main() @ &m: res]
-  by byequiv CPA_G0.
-
-  local module G1 = {
-    proc main() : bool = {
-      var m0, m1, c, b, b';
-      var x, y, h, gx, gxy;
-
-      H.init();
-      x       <$ dt;
-      y       <$ dt;
-      gx      <- g ^ x;
-      gxy     <- gx ^ y;
-      (m0,m1) <@ BA.choose(gx);
-      b       <$ {0,1};
-      h       <$ dbits;
-      c       <- (g ^ y, h +^ (b ? m1 : m0));
-      b'      <@ BA.guess(c);
-      return (b' = b);
-    }
-  }.
-
-  local module G2 = {
-    var gxy : group
-
-    proc main() : bool = {
-      var m0, m1, c, b, b';
-      var x, y, h, gx;
-
-      H.init();
-      x       <$ dt;
-      y       <$ dt;
-      gx      <- g ^ x;
-      gxy     <- gx ^ y;
-      (m0,m1) <@ BA.choose(gx);
-      b       <$ {0,1};
-      h       <$ dbits;
-      c       <- (g ^ y, h +^ (b ? m1 : m0));
-      b'      <@ BA.guess(c);
-      return G2.gxy \in Log.qs;
-    }
-  }.
-
-  local module (D : ROC.Dist) (H : POracle) = {
-    module A = A(H)
-
-    var y:t
-    var b:bool
-    var m0, m1:ptxt
-
-    proc a1(): group = {
-      var x, gxy, gx;
-
-      x       <$ dt;
-      y       <$ dt;
-      gx      <- g ^ x;
-      gxy     <- gx ^ y;
-      (m0,m1) <@ A.choose(gx);
-      b       <$ {0,1};
-      return gxy;
-    }
-
-    proc a2(x:bits): bool = {
-      var c, b';
-
-      c  <- (g ^ y, x +^ (b ? m1 : m0));
-      b' <@ A.guess(c);
-      return (b' = b);
-    }
-  }.
-
-  local lemma G0_D &m: Pr[G0.main() @ &m: res] = Pr[OnBound.G0(D,LRO).main() @ &m: res].
-  proof.
-    byequiv (_: ={glob A} ==> ={res})=> //.
-    proc.
-    inline D(Bound(LRO)).a1 D(Bound(LRO)).a2; wp.
-    conseq (_: _ ==> ={b'} /\ b{1} = D.b{2})=> //.
-    by inline H.hash; sim.
-  qed.
-
-  local lemma G1_D &m: Pr[G1.main() @ &m: res] = Pr[OnBound.G1(D,LRO).main() @ &m: res].
-  proof.
-    byequiv (_: ={glob A} ==> ={res})=> //.
-    proc.
-    inline D(Bound(LRO)).a1 D(Bound(LRO)).a2; wp.
-    conseq (_: _ ==> ={b'} /\ b{1} = D.b{2})=> //.
-    by inline H.hash; sim.
-  qed.
-
-  local lemma G2_D &m: Pr[G2.main() @ &m: res] = Pr[OnBound.G_bad(D,LRO).main() @ &m: res].
-  proof.
-    byequiv (_: ={glob A} ==> ={res})=> //.
-    proc.
-    inline D(Bound(LRO)).a1 D(Bound(LRO)).a2; wp.
-    conseq (_: _ ==> ={glob Log, b'} /\ b{1} = D.b{2} /\ G2.gxy{1} = x{2})=> //.
-    by inline H.hash; sim.
-  qed.
-
-  local lemma G0_G1_G2 &m:
-    Pr[G0.main() @ &m: res] <= Pr[G1.main() @ &m: res] + Pr[G2.main() @ &m: res].
-  proof.
-  rewrite (G0_D &m) (G1_D &m) (G2_D &m).
-  move: (OnBound.ROM_BadCall D _ _ _ &m tt true).
-  + move=> H H_o_ll; proc; auto; call (choose_ll H _)=> //; auto=> />.
-    by rewrite dt_ll DBool.dbool_ll.
-  + by move=> H H_o_ll; proc; auto; call (guess_ll H _)=> //; auto=> />.
-  + by move=> _; apply: dbits_ll.
-  by rewrite !eqT.
-  qed.
-
-  local module G1' = {
-    proc main() : bool = {
-      var m0, m1, c, b, b';
-      var x, y, h, gx, gxy;
-
-      H.init();
-      x       <$ dt;
-      y       <$ dt;
-      gx      <- g ^ x;
-      gxy     <- gx ^ y;
-      (m0,m1) <@ BA.choose(gx);
-      b       <$ {0,1};
-      h       <$ dbits;
+      (m0,m1) <@ A(H).choose(gx);
+      h       <$ dbits; 
       c       <- (g ^ y, h);
-      b'      <@ BA.guess(c);
+      b'      <@ A(H).guess(c);
+      b       <$ {0,1};
       return (b' = b);
     }
   }.
 
-  local lemma G1_G1' &m: Pr[G1.main() @ &m: res] = Pr[G1'.main() @ &m: res].
+  local lemma Pr_CPA_G0 &m :
+    Pr[CPA(S,A(LRO)).main() @ &m: res] <= 
+      Pr[G0.main() @ &m: res] + Pr[G0.main() @ &m: G0.gxy \in H.qs].
   proof.
-    byequiv (_: ={glob A} ==> ={res})=> //.
+    byequiv => //.
     proc.
-    call (_: ={glob LRO, glob Log}); first by sim.
-    wp; rnd (fun h, h +^ if b then m1 else m0){1}; rnd.
-    call (_: ={glob LRO, glob Log}); first by sim.
-    by inline H.init LRO.init; auto=> /> *; split => *; algebra.
+    inline Hashed_ElGamal(H).kg Hashed_ElGamal(H).enc H.hash.
+    swap{1} 8 -5; swap{2} 10 -3.
+    call (_: G0.gxy \in H.qs, 
+            (forall x, x \in H.qs{2} = x \in LRO.m{2}) /\
+            eq_except (pred1 G0.gxy{2}) LRO.m{1} LRO.m{2}).
+    + by apply guess_ll.
+    + proc; inline *; auto => /> &1 &2 hb; smt (eq_except_set_eq get_setE).
+    + by move=> *; islossless.
+    + by move=> /=; proc; call (_: true); 1: islossless; auto => />.
+    wp; rnd (fun y0 => y0 +^ m{1}) => /=.
+    wp; rnd; call (_: ={LRO.m} /\ (forall x, x \in H.qs{2} = x \in LRO.m{2})).
+    + by proc; inline *; auto => />; smt (get_setE).
+    inline *; auto => /> *; split; 1: by move=> *; rewrite mem_empty.
+    move=> _ ??? hdom ??; split; 1: by move=> *;ring.
+    smt(eq_except_setl get_setE).
   qed.
 
-  local lemma Pr_G1' &m: Pr[G1'.main() @ &m: res] = 1%r/2%r.
+  local lemma Pr_G0_res &m : 
+     Pr[G0.main() @ &m: res] <= 1%r/2%r.
   proof.
-    have LRO_o_ll := LRO_o_ll _; first by move=> /=; apply: dbits_ll.
-    byphoare (_: true ==> res)=> //.
-    proc.
-    swap 7 3.
-    rnd (pred1 b').
-    conseq (_: true) => />.
-    + by move=> b'; rewrite DBool.dbool1E /pred1 => />.
-    islossless.
-    + by apply (guess_ll (Bound(LRO))); islossless.
-    by apply (choose_ll (Bound(LRO))); islossless.
+    byphoare => //; proc. 
+    rnd (pred1 b'); conseq (_:true) => //.
+    by move=> /> *; rewrite DBool.dbool1E.
   qed.
 
-  local module G2' = {
-    var gxy : group
-
-    proc main() : bool = {
-      var m0, m1, c, b, b';
-      var x, y, h, gx;
-
+  local module ALCDH = {
+    proc solve (gx:group, gy:group) : group list = {
+      var m0, m1, c, b';
+      var h;
       H.init();
-      x        <$ dt;
-      y        <$ dt;
-      gx       <- g ^ x;
-      gxy      <- gx ^ y;
-      (m0,m1)  <@ BA.choose(gx);
-      b        <$ {0,1};
-      h        <$ dbits;
-      c        <- (g ^ y, h);
-      b'       <@ BA.guess(c);
-      return gxy \in Log.qs;
+      (m0,m1) <@ A(H).choose(gx);
+      h       <$ dbits; 
+      c       <- (gy, h);
+      b'      <@ A(H).guess(c);
+      if (H.qs = []) H.qs <- [g];  
+      return H.qs;
     }
-  }.
+  }. 
 
-  local lemma G2_G2' &m: Pr[G2.main() @ &m: res] = Pr[G2'.main() @ &m: res].
+  local lemma cost_ALCDH : 
+    choare [ALCDH.solve : true ==> 0 < size res <= cA.`ochoose + cA.`oguess] 
+    time [N (6 + cdbits + (3 + cdbits + cget qH + cset qH + cin qH) * (cA.`oguess + cA.`ochoose) + cA.`cguess + cA.`cchoose)].
   proof.
-    byequiv (_: ={glob A} ==> ={res})=> //.
+    proc; wp.
+    call (_: size H.qs- cA.`ochoose <= k /\ bounded LRO.m (size H.qs);
+           time
+           [H.o k : [N(3 + cdbits + cget qH + cset qH + cin qH)]]).
+    + move=> zo hzo; proc; inline *.
+      wp := (bounded LRO.m qH).
+      rnd; auto => &hr />; rewrite dbits_ll /=.
+      progress; 1,2,4,6,7,8,9: smt (cset_pos bounded_set).
+      * have -> : (qH = qH - 1 + 1) by smt ().
+        apply bounded_set. 
+        smt ().
+
+      * rewrite addzC.
+        apply bounded_set. 
+        smt ().
+
+    wp; rnd; call (_: size H.qs = k /\ bounded LRO.m (size H.qs);
+           time [H.o k : [N(3 + cdbits + cget qH + cset qH + cin qH)]]).
+    + move=> zo hzo; proc; inline *.
+      wp := (bounded LRO.m qH).
+      rnd;auto => &hr />; rewrite dbits_ll /=.
+      progress; 1,2,4,6,7,8,9: 
+      smt(cset_pos bounded_set cA_pos).
+      * have -> : (qH = qH - 1 + 1) by smt ().
+        apply bounded_set. 
+        smt (cA_pos).
+
+      * rewrite addzC.
+        apply bounded_set. 
+        smt ().
+    inline *; auto => />.
+    split => *.
+    + smt (bounded_empty dbits_ll size_ge0 size_eq0 cA_pos).
+    rewrite !bigi_constz /=; smt(cA_pos).
+  qed.
+
+  local lemma Pr_G0_LCDHPr_G0_res &m: 
+    Pr[G0.main() @ &m: G0.gxy \in H.qs] <= Pr[LCDH(ALCDH).main() @ &m : res].
+  proof.
+    byequiv => //.
     proc.
-    call (_: ={glob LRO, glob Log}); first by sim.
-    wp; rnd (fun h, h +^ if b then m1 else m0){1}; rnd.
-    call (_: ={glob LRO, glob Log}); first by sim.
-    by inline H.init LRO.init; auto=> /> *; split => *; algebra.
+    conseq (_ : _ ==> G0.gxy{1} \in H.qs{1} => g ^ (x{2} * y{2}) \in s{2}) _ (_: true ==> size s <= qH) => //.
+    + by move=> />.
+    + call (_: true ==> 0 < size res <= qH); last by auto.
+      by conseq cost_ALCDH; smt (cA_pos).
+    inline *.
+    rnd{1}; auto; call (_: ={glob H}); 1: by sim.
+    auto; call (_: ={glob H}); 1: by sim.
+    by auto => /> *; rewrite -pow_pow.
   qed.
 
-  local equiv G2'_SCDH: G2'.main ~ SCDH(SCDH_from_CPA(A,LRO)).main:
-    ={glob A} ==> res{1} = res{2} /\ card Log.qs{1} <= qH.
+  lemma ex_reduction &m : 
+    exists (B<:CDH.Adversary 
+      [solve : `{ N(C1.cduniform_n + 
+                  6 + cdbits + 
+                  (3 + cdbits + cget qH + cset qH + cin qH) * (cA.`oguess + cA.`ochoose) + cA.`cguess + cA.`cchoose)}]
+               {+A, +H}),
+    Pr[CPA(S,A(LRO)).main() @ &m: res] - 1%r/2%r <= 
+    qH%r * Pr[CDH.CDH(B).main() @ &m: res].
   proof.
-    proc.
-    inline SCDH_from_CPA(A,LRO).solve.
-    swap{2} 5 -4; swap{1} 7 3.
-    rnd{1}; wp.
-    seq  8  7: (={glob BA} /\
-                c{1} = (gy, h){2} /\
-                G2'.gxy{1} = g ^ (x * y){2} /\
-                card Log.qs{1} <= qH).
-      wp; rnd; call (_: ={glob H} /\ card Log.qs{1} <= qH).
-        proc; sp; if=> //; inline Log(LRO).o LRO.o; auto=> />.
-        by move=> &2 _ szqs_lt_qH _ _; rewrite fcardU fcard1; smt(fcard_ge0).
-      by inline H.init LRO.init; auto=> />; rewrite fcards0; smt(gt0_qH pow_pow).
-    call (_: ={glob H} /\ card Log.qs{1} <= qH).
-      proc; sp; if=> //; inline Log(LRO).o LRO.o; auto=> /> &2 _ szqs_lt_qH _ _.
-      by rewrite fcardU fcard1; smt(fcard_ge0).
-    by auto => />.
+    have [B hB]:= C1.ex_reduction _ ALCDH &m cost_ALCDH.
+    exists B; split.
+    + proc true : time [] => // /#.
+    move: (Pr_CPA_G0 &m) (Pr_G0_res &m) (Pr_G0_LCDHPr_G0_res) => /#.
   qed.
 
-  local lemma Pr_G2'_SCDH &m :
-    Pr[G2'.main() @ &m: res]
-    = Pr[SCDH(SCDH_from_CPA(A,LRO)).main() @ &m : res]
-  by byequiv G2'_SCDH.
-
-  local lemma Reduction &m :
-    Pr[CPA(S,BA).main() @ &m : res] <=
-    1%r / 2%r + Pr[SCDH(SCDH_from_CPA(A,LRO)).main() @ &m : res].
-  proof.
-    rewrite (Pr_CPA_G0 &m).
-    rewrite -(Pr_G1' &m) -(G1_G1' &m).
-    rewrite -(Pr_G2'_SCDH &m) -(G2_G2' &m).
-    by apply (G0_G1_G2 &m).
-  qed.
-
-  (** Composing reduction from CPA to SCDH with reduction from SCDH to CDH *)
-  lemma Security &m:
-      Pr[CPA(S,A(Bound(LRO))).main() @ &m: res] - 1%r / 2%r <=
-      qH%r * Pr[CDH.CDH(CDH_from_SCDH(SCDH_from_CPA(A,LRO))).main() @ &m: res].
-  proof.
-    apply (ler_trans (Pr[SCDH(SCDH_from_CPA(A,LRO)).main() @ &m: res])).
-    + smt(Reduction).
-    have:= Self.SCDH.Reduction (SCDH_from_CPA(A,LRO)) &m gt0_qH.    
-    by rewrite -mulrA mul1r mulrC ler_pdivr_mulr 1:lt_fromint 1:gt0_qH mulrC.
-  qed.
 end section.
 
-print axiom Security.
+print ex_reduction.

--- a/examples/plug-and-pray/Plug_and_Pray_example.ec
+++ b/examples/plug-and-pray/Plug_and_Pray_example.ec
@@ -68,7 +68,7 @@ proof indices_not_nil by smt(@List gt0_q).
    ``Guess'' functor and we use an if-then-else to ensure that
    G0.k is in [0..q-1].
 *)
-lemma Bound_aux &m (A <: Adv {G0}):
+lemma Bound_aux &m (A <: Adv {-G0}):
   (1%r/q%r) * Pr[ G0(A).main() @ &m : G0.b ]
   = Pr[ Guess(G0(A)).main() @ &m :  G0.b /\ res.`1 = G0.k ].
 proof.
@@ -94,7 +94,7 @@ qed.
   We now transfer the previous lemma to G0 and G1 by relating
   Guess(G0) with G1.
 *)
-lemma Bound &m (A <: Adv{G1,G0}):
+lemma Bound &m (A <: Adv{-G1,-G0}):
     (1%r/q%r) * Pr[ G0(A).main() @ &m : G0.b ]
   = Pr[ G1(A).main() @ &m :  G1.b /\ G1.k = G1.i].
 proof.

--- a/examples/prg-tutorial/PRGc.ec
+++ b/examples/prg-tutorial/PRGc.ec
@@ -151,7 +151,7 @@ module D_PRF (D:PRGa.Distinguisher,F:PRFA) = {
 section Fact1.
   (* Lemmas in this section are true forall PRG distinguisher D
      that do not share memory with SRG, PRFr, PRFi, or D_PRF. *)
-  declare module D <: PRGa.Distinguisher {SRG,PRFr,PRFi,D_PRF}.
+  declare module D <: PRGa.Distinguisher {-SRG,-PRFr,-PRFi,-D_PRF}.
 
   local lemma SRG_PRGp &m:
     Pr[IND_PRG(SRG,D).main() @ &m: res] = Pr[IND_PRF(PRFc,D_PRF(D)).main() @ &m: res].
@@ -245,16 +245,16 @@ module C_D_PRG(D:PRGa.Distinguisher,G:PRGa.RGA) = {
   }
 }.
 
-equiv Count_PRG_equiv (G <: PRGa.RG {C_PRG}) (D <: PRGa.Distinguisher {G,C_PRG}):
+equiv Count_PRG_equiv (G <: PRGa.RG {-C_PRG}) (D <: PRGa.Distinguisher {-G,-C_PRG}):
   IND_PRG(C_PRG(G),D).main ~ IND_PRG(G,C_D_PRG(D)).main:
     ={glob D, glob G} ==> ={glob D, glob C_PRG(G), res}.
 proof. by proc; inline *; swap{2} 2 -1; sim. qed.
 
-lemma Count_PRG (G <: PRGa.RG {C_PRG}) (D <: PRGa.Distinguisher {G,C_PRG}) &m:
+lemma Count_PRG (G <: PRGa.RG {-C_PRG}) (D <: PRGa.Distinguisher {-G,-C_PRG}) &m:
   Pr[IND_PRG(C_PRG(G),D).main() @ &m: res] = Pr[IND_PRG(G,C_D_PRG(D)).main() @ &m: res]
 by byequiv (Count_PRG_equiv G D).
 
-lemma Count_PRG_noop (G <: PRGa.RG {C_PRG}) (D <: PRGa.Distinguisher {G,C_PRG}) &m:
+lemma Count_PRG_noop (G <: PRGa.RG {-C_PRG}) (D <: PRGa.Distinguisher {-G,-C_PRG}) &m:
   Pr[IND_PRG(G,D).main() @ &m: res] = Pr[IND_PRG(C_PRG(G),D).main() @ &m: res].
 proof.
 byequiv=> //=; proc; inline *; sim (: ={glob G}): (={b}).
@@ -300,16 +300,16 @@ module C_D_PRF(D:PRFa.Distinguisher,F:PRFa.PRFA) = {
   }  
 }.
 
-equiv Count_PRF_equiv (F <: PRFa.PRF {C_PRF}) (D <: PRFa.Distinguisher {F,C_PRF}):
+equiv Count_PRF_equiv (F <: PRFa.PRF {-C_PRF}) (D <: PRFa.Distinguisher {-F,-C_PRF}):
   IND_PRF(C_PRF(F),D).main ~ IND_PRF(F,C_D_PRF(D)).main:
     ={glob D, glob F} ==> ={glob D, glob C_PRF(F), res}.
 proof. by proc; inline *; swap{2} 2 -1; sim. qed.
 
-lemma Count_PRF (F <: PRFa.PRF {C_PRF}) (D <: PRFa.Distinguisher {F,C_PRF}) &m:
+lemma Count_PRF (F <: PRFa.PRF {-C_PRF}) (D <: PRFa.Distinguisher {-F,-C_PRF}) &m:
   Pr[IND_PRF(C_PRF(F),D).main() @ &m: res] = Pr[IND_PRF(F,C_D_PRF(D)).main() @ &m: res]
 by byequiv (Count_PRF_equiv F D).
 
-lemma Count_PRF_noop (F <: PRFa.PRF {C_PRF}) (D <: PRFa.Distinguisher {F,C_PRF}) &m:
+lemma Count_PRF_noop (F <: PRFa.PRF {-C_PRF}) (D <: PRFa.Distinguisher {-F,-C_PRF}) &m:
   Pr[IND_PRF(F,D).main() @ &m: res] = Pr[IND_PRF(C_PRF(F),D).main() @ &m: res].
 proof.
 byequiv=> //=; proc; inline *; sim (: ={glob F}): (={b}).
@@ -317,8 +317,8 @@ by proc *; inline *; sim.
 qed.
 
 (* -------------------------------------------------------------------- *)
-equiv Count_AdvQueries_PRF (F <: PRFa.PRF {SRG,D_PRF,C_PRF,C_PRG})
-                           (D <: PRGa.Distinguisher {SRG,D_PRF,F,C_PRF,C_PRG}):
+equiv Count_AdvQueries_PRF (F <: PRFa.PRF {-SRG,-D_PRF,-C_PRF,-C_PRG})
+                           (D <: PRGa.Distinguisher {-SRG,-D_PRF,-F,-C_PRF,-C_PRG}):
   IND_PRF(F,D_PRF(C_D_PRG(D))).main ~ IND_PRF(C_PRF(F),D_PRF(D)).main:
     ={glob F, glob D} ==> ={glob F, glob D, res} /\ ={c}(C_PRG,C_PRF).
 proof.
@@ -333,8 +333,8 @@ qed.
   *   Pr[IND^PRF_PRFi(D^PRF_D): res] - Pr[IND^PRF_PRGi(D): res]
   *   <= Pr[IND^PRF_PRFi(D^PRF_D): !uniq D^PRF_D.log]                  **)
 section Fact2.
-  declare module D <: PRGa.Distinguisher {SRG,PRFr,PRFi,D_PRF}.
-  declare axiom D_distinguish_ll (G <: RGA {D}): islossless G.next => islossless D(G).distinguish.
+  declare module D <: PRGa.Distinguisher {-SRG,-PRFr,-PRFi,-D_PRF}.
+  declare axiom D_distinguish_ll (G <: RGA {-D}): islossless G.next => islossless D(G).distinguish.
 
   inductive inv (m : ('a,'b) fmap) (logP : 'a list) =
     | EqQueries of (dom m = mem logP).
@@ -411,8 +411,8 @@ section Fact2.
 end section Fact2.
   
 (* This concludes the proof of Theorem 1. *)
-lemma Theorem1 (D <: PRGa.Distinguisher {SRG,PRFc,PRFi,D_PRF}) &m:
-  (forall (G <: RGA {D}), islossless G.next => islossless D(G).distinguish) =>
+lemma Theorem1 (D <: PRGa.Distinguisher {-SRG,-PRFc,-PRFi,-D_PRF}) &m:
+  (forall (G <: RGA {-D}), islossless G.next => islossless D(G).distinguish) =>
   Pr[IND_PRG(SRG,D).main() @ &m: res] - Pr[IND_PRG(PRGi,D).main() @ &m: res]
   <= (Pr[IND_PRF(PRFc,D_PRF(D)).main() @ &m: res]
       - Pr[IND_PRF(PRFi,D_PRF(D)).main() @ &m: res])
@@ -426,8 +426,8 @@ qed.
 (* -------------------------------------------------------------------- *)
 (** Lemma 2: Forall q \geq 0, and forall D that calls next at most q
              times, D_PRF(D) calls f at most q times. **)
-lemma Lemma2 q (D <: PRGa.Distinguisher {SRG,PRFc,C_PRG,C_PRF,D_PRF}):
-  (forall (G <: PRGa.RG {D,C_PRG}) &m,
+lemma Lemma2 q (D <: PRGa.Distinguisher {-SRG,-PRFc,-C_PRG,-C_PRF,-D_PRF}):
+  (forall (G <: PRGa.RG {-D,-C_PRG}) &m,
     islossless G.init =>
     islossless G.next =>
     Pr[IND_PRG(C_PRG(G),D).main() @ &m: C_PRG.c <= q] = 1%r) =>
@@ -451,18 +451,18 @@ qed.
 op     qN : { int | 0 <= qN } as ge0_qN.
 
 section Lemma1.
-  declare module D <: PRGa.Distinguisher {SRG,PRFc,PRFi,C_PRG,C_PRF,D_PRF}.
+  declare module D <: PRGa.Distinguisher {-SRG,-PRFc,-PRFi,-C_PRG,-C_PRF,-D_PRF}.
 
-  declare axiom D_distinguish_ll (G <: PRGa.RGA {D}):
+  declare axiom D_distinguish_ll (G <: PRGa.RGA {-D}):
     islossless G.next => islossless D(G).distinguish.
 
-  declare axiom D_bounded (G <: PRGa.RG {D,C_PRG}) &m:
+  declare axiom D_bounded (G <: PRGa.RG {-D,-C_PRG}) &m:
     islossless G.init => islossless G.next =>
     Pr[IND_PRG(C_PRG(G),D).main() @ &m: C_PRG.c <= qN] = 1%r.
 
   (* We express the adversary assumption in Hoare form for use with
      conseq. This requires some gymnastics. *)
-  lemma D_bounded_hoare (G <: RG {D,C_PRG}):
+  lemma D_bounded_hoare (G <: RG {-D,-C_PRG}):
     islossless G.init =>
     islossless G.next =>
     hoare [IND_PRG(C_PRG(G),D).main: true ==> C_PRG.c <= qN].
@@ -532,9 +532,9 @@ end section Lemma1.
       ii) D makes at most qN calls to its next oracle,
     we have:
       Adv^PRG_SRG(D) <= Adv^PRF_PRFc(D_PRF(D)) + qN^2/|state|.        **)
-lemma Security (D <: PRGa.Distinguisher {SRG,PRFc,PRFi,C_PRG,C_PRF,D_PRF}) &m:
-  (forall (G <: PRGa.RGA {D}), islossless G.next => islossless D(G).distinguish) =>
-  (forall (G <: PRGa.RG {D,C_PRG}) &m,
+lemma Security (D <: PRGa.Distinguisher {-SRG,-PRFc,-PRFi,-C_PRG,-C_PRF,-D_PRF}) &m:
+  (forall (G <: PRGa.RGA {-D}), islossless G.next => islossless D(G).distinguish) =>
+  (forall (G <: PRGa.RG {-D,-C_PRG}) &m,
     islossless G.init => islossless G.next =>
     Pr[IND_PRG(C_PRG(G),D).main() @ &m: C_PRG.c <= qN] = 1%r) =>
   Pr[IND_PRG(SRG,D).main() @ &m: res] - Pr[IND_PRG(PRGi,D).main() @ &m: res]
@@ -549,7 +549,7 @@ move=> D_distinguish_ll D_bounded.
 rewrite (Count_PRG_noop SRG D &m) (Count_PRG_noop PRGi D &m).
 rewrite (Count_PRF_noop PRFc (D_PRF(D)) &m) (Count_PRF_noop PRFi (D_PRF(D)) &m).
 have:= PRGsi_Bad_bound D _ _ &m=> //.
-have C_D_PRG_ll: forall (G <: PRGa.RGA {C_D_PRG(D)}),
+have C_D_PRG_ll: forall (G <: PRGa.RGA {-C_D_PRG(D)}),
                    islossless G.next => islossless C_D_PRG(D,G).distinguish.
   move=> G G_next_ll; proc.
   call (_: true)=> //; first by proc; wp; call G_next_ll; wp.

--- a/scripts/testing/run-on-projects
+++ b/scripts/testing/run-on-projects
@@ -1,0 +1,108 @@
+#! /usr/bin/env python3
+
+# --------------------------------------------------------------------
+import sys, os, docker, multiprocessing as mp
+import coloredlogs, logging
+
+# --------------------------------------------------------------------
+ROOT    = os.path.dirname(__file__)
+ECBUILD = 'easycryptpa/ec-build-box'
+
+# --------------------------------------------------------------------
+class Object(object):
+    def __init__(self, **kw):
+        super(Object, self).__init__()
+        self.__dict__.update(kw)
+
+# --------------------------------------------------------------------
+def _main():
+    coloredlogs.install()
+    logging.basicConfig(level = logging.INFO)
+
+    if len(sys.argv)-1 != 2:
+        print('Usage: %s [ECROOT] [CONFIG]' % (sys.argv[0],))
+        exit(1)
+
+    ecpath, pfilename = sys.argv[1:]
+
+    with open(pfilename, 'r') as stream:
+        projects = [x.strip() for x in stream.readlines()]
+        projects = [x for x in projects if x]
+        projects = [x.split(None, 2) for x in projects]
+        projects = [x for x in projects if len(x) == 2]
+        projects = [Object(name = x[0], url = x[1]) for x in projects]
+
+    core = mp.cpu_count()
+    core = max(core-2, 1)
+    dck  = docker.from_env()
+
+    logging.info('pulling EasyCrypt build-box...')
+    img = dck.images.pull(ECBUILD)[0]
+    logging.info('...done')
+
+    logging.info('running container...')
+    config = dict(
+        init        = True,
+        detach      = True,
+        stdin_open  = True,
+        auto_remove = False,
+        cpu_count   = core,
+        working_dir = '/home/ci',
+        volumes     = {
+            os.path.realpath(ecpath): dict(bind='/home/ci/ecgit', mode='ro'),
+        },
+    )
+    ctn = dck.containers.run(img, **config)
+    logging.info('...done (%s)', ctn.name)
+
+    def _run(command, **kw):
+        logging.info('docker: %s' % (command,))
+
+        handle = dck.api.exec_create(ctn.id, command, tty=True, **kw)
+        stream = dck.api.exec_start(handle, stream=True)
+
+        for output in stream:
+            sys.stdout.write(output.decode('ascii'))
+
+        return dck.api.exec_inspect(handle['Id']).get('ExitCode') 
+
+    errors = 0
+
+    try:
+        logging.info('compiling EasyCrypt...')
+        _run('git clone --depth=1 file:///home/ci/ecgit easycrypt')
+        _run('opam config exec -- make -C easycrypt')
+        _run('ln -s ec.native easycrypt/easycrypt')
+        logging.info('...done')
+
+        _run('mkdir -p projects/_outputs')
+
+        for project in projects:
+            logging.info('checking project [%s]...' % (project.name,))
+            env = dict(
+                ECROOT   = '/home/ci/easycrypt',
+                ECJOBS   = core,
+                XUNITOUT = '/home/ci/projects/_output/%s.yml' % (project.name,))
+            _run('git clone --depth=1 --recurse-submodules %s projects/%s' % \
+                 (project.url, project.name))
+            status = _run(
+                'make -C projects/%s check' % (project.name,), environment = env)
+            if status != 0:
+                logging.error('project %s failed' % (project.name,))
+                errors += 1
+            logging.info('...done')
+
+    finally:
+        ctn.stop()
+        if errors == 0:
+            ctn.remove()
+
+    if errors != 0:
+        logging.error('# of failed projects: %d' % (errors,))
+        logging.error('run the following commands to inspect:')
+        logging.error('  - docker start %s' % (ctn.name,))
+        logging.error('  - docker exec -ti %s /bin/bash' % (ctn.name,))
+
+# --------------------------------------------------------------------
+if __name__ == '__main__':
+    _main()

--- a/src/dune
+++ b/src/dune
@@ -15,4 +15,4 @@
 
 (menhir
  (modules ecParser)
- (flags --table))
+ (flags --table --explain))

--- a/src/ecBaseLogic.ml
+++ b/src/ecBaseLogic.ml
@@ -14,7 +14,7 @@ open EcCoreFol
 type local_kind =
 | LD_var    of ty * form option
 | LD_mem    of EcMemory.memtype
-| LD_modty  of EcModules.module_type * EcModules.mod_restr
+| LD_modty  of EcModules.module_type
 | LD_hyp    of form
 | LD_abs_st of EcModules.abs_uses
 

--- a/src/ecCHoare.ml
+++ b/src/ecCHoare.ml
@@ -1,0 +1,199 @@
+(* --------------------------------------------------------------------
+ * Copyright (c) - 2012--2016 - IMDEA Software Institute
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
+ *
+ * Distributed under the terms of the CeCILL-C-V1 license
+ * -------------------------------------------------------------------- *)
+
+
+(* -------------------------------------------------------------------- *)
+(* Function for cost                                                    *)
+open EcUtils
+open EcTypes
+open EcFol
+open EcEnv
+
+let f_subcond f1 f2 =
+  f_or (f_is_inf f1) (f_is_int f2)
+
+let f_xsub f1 f2 =
+  f_subcond f1 f2, f_xadd f1 (f_xopp f2)
+
+let cost_sub_self c a =
+  let cond, c_self = f_xsub c.c_self a in
+  cond, cost_r c_self c.c_calls
+
+let cost_add_self c a =
+  let c_self = f_xadd c.c_self a in
+  cost_r c_self c.c_calls
+
+(* Add an entry for a oracle to [c.c_calls], if necessary. *)
+let cost_add_oracle env c f =
+  if EcPath.Mx.mem f c.c_calls
+  then c
+  else begin
+    let m = f.EcPath.x_top in
+    assert ( m.m_args = [] &&
+             match m.EcPath.m_top with `Local _ -> true | _ -> false);
+
+    let restr = EcEnv.NormMp.get_restr env m in
+    let oi = EcSymbols.Msym.find f.EcPath.x_sub restr.mr_oinfos in
+
+    let self = match EcCoreModules.PreOI.cost_self oi with
+      | `Unbounded -> assert false
+      | `Bounded self -> self in
+
+    let cb = call_bound_r self f_i0 in
+
+    cost_r c.c_self (EcPath.Mx.add f cb c.c_calls)
+  end
+
+let cost_sub_call env c f a =
+  let c = cost_add_oracle env c f in
+
+  let c_calls = EcPath.Mx.change (fun cb ->
+      let cb = oget cb in
+      call_bound_r cb.cb_cost (f_int_sub_simpl cb.cb_called a)
+      |> some
+    ) f c.c_calls in
+
+  cost_r c.c_self c_calls
+
+let cost_add_call env c f a =
+  let c = cost_add_oracle env c f in
+
+  let c_calls = EcPath.Mx.change (fun cb ->
+      let cb = oget cb in
+      call_bound_r cb.cb_cost (f_int_add_simpl cb.cb_called a)
+      |> some
+    ) f c.c_calls in
+
+  cost_r c.c_self c_calls
+
+let cost_op env op c1 c2 =
+  (* Ensure that [c1] and [c2] have the same support. *)
+  let c2 = List.fold_left (cost_add_oracle env) c2 (EcPath.Mx.keys c1.c_calls)
+  and c1 = List.fold_left (cost_add_oracle env) c1 (EcPath.Mx.keys c2.c_calls) in
+
+  EcPath.Mx.union (fun _ cb1 cb2 ->
+    assert (f_equal cb1.cb_cost cb2.cb_cost);
+    Some (call_bound_r cb1.cb_cost (op cb1.cb_called cb2.cb_called)))
+  c1.c_calls c2.c_calls
+
+let cost_add env c1 c2 =
+  let c_calls = cost_op env EcFol.f_int_add_simpl c1 c2 in
+  cost_r (f_xadd c1.c_self c2.c_self) c_calls
+
+let cost_sub env c1 c2 =
+  let c_calls = cost_op env EcFol.f_int_sub_simpl c1 c2 in
+  let cond, self = f_xsub c1.c_self c2.c_self in
+  cond, cost_r self c_calls
+
+let cost_map f_xmap f_map c =
+  EcPath.Mx.fold (fun f cb res ->
+      let c_calls =
+        EcPath.Mx.add f
+          (call_bound_r (cb.cb_cost) (f_map cb.cb_called))
+          res.c_calls in
+      cost_r res.c_self c_calls
+    ) c.c_calls
+    (cost_r (f_xmap c.c_self) EcPath.Mx.empty)
+
+let cost_app c args =
+  cost_map (fun c -> f_app_simpl c args txint)
+           (fun c -> f_app_simpl c args tint) c
+
+let cost_flatten cost =
+  EcPath.Mx.fold (fun _ cb cflat ->
+      f_xadd cflat (f_xmuli cb.cb_called cb.cb_cost))
+    cost.c_calls cost.c_self
+
+let loaded (env : env) =
+  is_some (EcEnv.Theory.by_path_opt EcCoreLib.CI_xint.p_Xint env) &&
+  is_some (EcEnv.Theory.by_path_opt EcCoreLib.CI_xint.p_choaretac env)
+
+exception LoadChoareFirst
+
+let check_loaded (env : env) =
+  if not (loaded env) then raise LoadChoareFirst
+
+let pp_exn fmt exn =
+  match exn with
+  | LoadChoareFirst -> Format.fprintf fmt "load the `CHoareTactic' theory first"
+  | _ -> raise exn
+
+let _ = EcPException.register pp_exn
+
+
+(*
+module ICHOARE : sig
+  val loaded : EcEnv.env -> bool
+  val choare_sum : cost -> (form * form) -> cost
+  val choare_max : form -> form -> form
+end = struct
+  open EcCoreLib
+  open EcEnv
+*)
+
+let q_List    = [EcCoreLib.i_top; "List"]
+
+let tlist =
+  let tlist = EcPath.fromqsymbol (q_List, "list") in
+  fun ty -> EcTypes.tconstr tlist [ty]
+
+let range =
+  let rg = EcPath.fromqsymbol (q_List @ ["Range"], "range") in
+  let rg = f_op rg [] (toarrow [tint; tint] (tlist tint)) in
+  fun m n -> f_app rg [m; n] (tlist tint)
+
+let f_predT = f_op EcCoreLib.CI_Pred.p_predT [tint] (tpred tint)
+
+let f_op_xbig =
+  f_op EcCoreLib.CI_xint.p_big [tint]
+    (toarrow [tpred tint; tfun tint txint; tlist tint] txint)
+
+let f_op_big =
+  let p_big = EcPath.fromqsymbol ([EcCoreLib.i_top;"StdBigop";"Bigint";"BIA"], "big") in
+
+  f_op p_big [tint]
+    (toarrow [tpred tint; tfun tint tint; tlist tint] tint)
+
+let f_xbig f m n =
+  f_app f_op_xbig [f_predT; f; range m n] txint
+
+let f_big f m n =
+  f_app f_op_big [f_predT; f; range m n] tint
+
+let choare_sum cost (m, n) =
+  cost_map (fun f -> f_xbig f m n)
+           (fun f -> f_big f m n) cost
+
+(* -------------------------------------------------------------------- *)
+(*
+(* -------------------------------------------------------------------- *)
+(* The cost of an expression evaluation in any memory of a given type
+   satisfying some pre-condition. *)
+val cost_of_expr : form -> EcMemory.memenv -> EcTypes.expr -> form
+
+(* The cost of an expression evaluation in any memory of a given type. *)
+val cost_of_expr_any : EcMemory.memenv -> EcTypes.expr -> form
+
+val free_expr : EcTypes.expr -> bool
+ *)
+let free_expr e = match e.e_node with
+  | Elocal _ | Evar _ | Eint _ -> true
+
+  | Eop _
+  | Eproj _ | Etuple _ | Eapp _
+  | Equant _ | Elet _ | Eif _ | Ematch _ -> false
+
+
+(* The cost of an expression evaluation in any memory of type [menv]
+   satisfying [pre]. *)
+let cost_of_expr pre menv e =
+  if free_expr e then f_x0 else f_coe pre menv e
+
+(* The cost of an expression evaluation in any memory of type [menv]. *)
+let cost_of_expr_any menv e =
+  if free_expr e then f_x0 else f_coe f_true menv e

--- a/src/ecCommands.ml
+++ b/src/ecCommands.ml
@@ -226,7 +226,7 @@ module HiPrinting = struct
       let ty = EcEnv.Var.by_xpath xp env in
       Format.fprintf fmt "  @[%a : %a@]@."
         (EcPrinting.pp_pv ppe) pv
-        (EcPrinting.pp_type ppe) ty.EcEnv.vb_type)
+        (EcPrinting.pp_type ppe) ty)
       (List.rev (Mx.bindings us.EcEnv.us_pv))
 
 
@@ -271,6 +271,7 @@ let process_pr fmt scope p =
   | Pr_pr   qs -> EcPrinting.ObjectInfo.pr_op   fmt env   (unloc qs)
   | Pr_th   qs -> EcPrinting.ObjectInfo.pr_th   fmt env   (unloc qs)
   | Pr_ax   qs -> EcPrinting.ObjectInfo.pr_ax   fmt env   (unloc qs)
+  | Pr_sc   qs -> EcPrinting.ObjectInfo.pr_sc   fmt env   (unloc qs)
   | Pr_mod  qs -> EcPrinting.ObjectInfo.pr_mod  fmt env   (unloc qs)
   | Pr_mty  qs -> EcPrinting.ObjectInfo.pr_mty  fmt env   (unloc qs)
   | Pr_any  qs -> EcPrinting.ObjectInfo.pr_any  fmt env   (unloc qs)
@@ -376,12 +377,14 @@ and process_abbrev (scope : EcScope.scope) (a : pabbrev located) =
 (* -------------------------------------------------------------------- *)
 and process_axiom (scope : EcScope.scope) (ax : paxiom located) =
   EcScope.check_state `InTop "axiom" scope;
+  (* TODO: A: aybe rename, as this now also adds schemata. *)
   let (name, scope) = EcScope.Ax.add scope (Pragma.get ()).pm_check ax in
     name |> EcUtils.oiter
       (fun x ->
          match (unloc ax).pa_kind with
          | PAxiom _ -> EcScope.notify scope `Info "added axiom: `%s'" x
-         | _        -> EcScope.notify scope `Info "added lemma: `%s'" x);
+         | PLemma _ -> EcScope.notify scope `Info "added lemma: `%s'" x
+         | PSchema  -> EcScope.notify scope `Info "added schema: `%s'" x);
     scope
 
 (* -------------------------------------------------------------------- *)
@@ -454,8 +457,8 @@ and process_th_require1 ld scope (nm, (sysname, thname), io) =
       let scope = EcScope.Theory.require scope (name, kind) loader in
           match io with
           | None         -> scope
-          | Some `Export -> EcScope.Theory.export scope ([], name.rqd_name)
-          | Some `Import -> EcScope.Theory.import scope ([], name.rqd_name)
+          | Some `Export -> EcScope.Theory.export scope ([], name.EcScope.rqd_name)
+          | Some `Import -> EcScope.Theory.import scope ([], name.EcScope.rqd_name)
 
 (* -------------------------------------------------------------------- *)
 and process_th_require ld scope (nm, xs, io) =
@@ -552,15 +555,19 @@ and process_pragma (scope : EcScope.scope) opt =
 (* -------------------------------------------------------------------- *)
 and process_option (scope : EcScope.scope) (name, value) =
   match value with
+  | `Bool value when EcLocation.unloc name = EcGState.old_mem_restr ->
+    let gs = EcEnv.gstate (EcScope.env scope) in
+    EcGState.setflag (unloc name) value gs; scope
+
+  | (`Int _) as value ->
+      let gs = EcEnv.gstate (EcScope.env scope) in
+      EcGState.setvalue (unloc name) value gs; scope
+
   | `Bool value -> begin
       try  EcScope.Options.set scope (unloc name) value
       with EcScope.UnknownFlag _ ->
         EcScope.hierror "unknown option: %s" (unloc name)
     end
-
-  | (`Int _) as value ->
-      let gs = EcEnv.gstate (EcScope.env scope) in
-      EcGState.setvalue (unloc name) value gs; scope
 
 (* -------------------------------------------------------------------- *)
 and process_addrw scope (local, base, names) =

--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -11,7 +11,7 @@ open EcUtils
 open EcIdent
 open EcTypes
 
-open EcModules
+open EcCoreModules
 
 type memory = EcMemory.memory
 
@@ -24,26 +24,22 @@ module Sx = EcPath.Sx
 open EcBigInt.Notations
 
 (* -------------------------------------------------------------------- *)
-type gty =
-  | GTty    of EcTypes.ty
-  | GTmodty of module_type * mod_restr
-  | GTmem   of EcMemory.memtype
-
 type quantif =
   | Lforall
   | Lexists
   | Llambda
 
-type binding  = (EcIdent.t * gty)
-type bindings = binding list
-
-let mhr    = EcIdent.create "&hr"
-let mleft  = EcIdent.create "&1"
-let mright = EcIdent.create "&2"
-
 type hoarecmp = FHle | FHeq | FHge
 
-type form = {
+type gty =
+  | GTty    of EcTypes.ty
+  | GTmodty of module_type
+  | GTmem   of EcMemory.memtype
+
+and binding  = (EcIdent.t * gty)
+and bindings = binding list
+
+and form = {
   f_node : f_node;
   f_ty   : ty;
   f_fv   : int EcIdent.Mid.t; (* local, memory, module ident *)
@@ -63,8 +59,12 @@ and f_node =
   | Fapp    of form * form list
   | Ftuple  of form list
   | Fproj   of form * int
-  | FhoareF of hoareF (* $hr / $hr *)
-  | FhoareS of hoareS
+
+  | FhoareF of sHoareF (* $hr / $hr *)
+  | FhoareS of sHoareS
+
+  | FcHoareF of cHoareF (* $hr / $hr *)
+  | FcHoareS of cHoareS
 
   | FbdHoareF of bdHoareF (* $hr / $hr *)
   | FbdHoareS of bdHoareS
@@ -73,6 +73,8 @@ and f_node =
   | FequivS of equivS
 
   | FeagerF of eagerF
+
+  | Fcoe of coe
 
   | Fpr of pr (* hr *)
 
@@ -100,16 +102,31 @@ and equivS = {
   es_sr  : stmt;
   es_po  : form; }
 
-and hoareF = {
+and sHoareF = {
   hf_pr : form;
   hf_f  : EcPath.xpath;
   hf_po : form;
 }
-and hoareS = {
+
+and sHoareS = {
   hs_m  : EcMemory.memenv;
   hs_pr : form;
   hs_s  : stmt;
   hs_po : form; }
+
+and cHoareF = {
+  chf_pr : form;
+  chf_f  : EcPath.xpath;
+  chf_po : form;
+  chf_co : cost;
+}
+
+and cHoareS = {
+  chs_m  : EcMemory.memenv;
+  chs_pr : form;
+  chs_s  : stmt;
+  chs_po : form;
+  chs_co : cost; }
 
 and bdHoareF = {
   bhf_pr  : form;
@@ -118,6 +135,7 @@ and bdHoareF = {
   bhf_cmp : hoarecmp;
   bhf_bd  : form;
 }
+
 and bdHoareS = {
   bhs_m   : EcMemory.memenv;
   bhs_pr  : form;
@@ -134,9 +152,53 @@ and pr = {
   pr_event : form;
 }
 
+and coe = {
+  coe_pre : form;
+  coe_mem : EcMemory.memenv;
+  coe_e   : expr;
+}
+
+(* Invariant: keys of c_calls are functions of local modules,
+   with no arguments. *)
+and cost = {
+  c_self  : form;    (* of type xint *)
+  c_calls : call_bound EcPath.Mx.t;
+}
+
+(* Call with cost at most [cb_cost], called at mist [cb_called].
+   [cb_cost] is here to properly handle substsitution when instantiating an
+   abstract module by a concrete one. *)
+and call_bound = {
+  cb_cost  : form;   (* of type xint *)
+  cb_called : form;  (* of type int  *)
+}
+
+and module_type = form p_module_type
+
+type mod_restr = form p_mod_restr
+
+(*-------------------------------------------------------------------- *)
+let mhr    = EcIdent.create "&hr"
+let mleft  = EcIdent.create "&1"
+let mright = EcIdent.create "&2"
+
+
 (*-------------------------------------------------------------------- *)
 let qt_equal : quantif -> quantif -> bool = (==)
 let qt_hash  : quantif -> int = Hashtbl.hash
+
+(*-------------------------------------------------------------------- *)
+let f_equal : form -> form -> bool = (==)
+let f_compare f1 f2 = f2.f_tag - f1.f_tag
+let f_hash f = f.f_tag
+let f_fv f = f.f_fv
+let f_ty f = f.f_ty
+
+let mty_equal = EcCoreModules.p_mty_equal f_equal
+let mty_hash  = EcCoreModules.p_mty_hash f_hash
+
+let mr_equal = EcCoreModules.p_mr_equal f_equal
+let mr_hash  = EcCoreModules.p_mr_hash f_hash
 
 (*-------------------------------------------------------------------- *)
 let gty_equal ty1 ty2 =
@@ -144,8 +206,8 @@ let gty_equal ty1 ty2 =
   | GTty ty1, GTty ty2 ->
       EcTypes.ty_equal ty1 ty2
 
-  | GTmodty (p1, r1), GTmodty (p2, r2)  ->
-    EcModules.mty_equal p1 p2 && mr_equal r1 r2
+  | GTmodty p1, GTmodty p2  ->
+    mty_equal p1 p2
 
   | GTmem mt1, GTmem mt2 ->
       EcMemory.mt_equal mt1 mt2
@@ -154,37 +216,50 @@ let gty_equal ty1 ty2 =
 
 let gty_hash = function
   | GTty ty -> EcTypes.ty_hash ty
-  | GTmodty (p, _)  ->  EcModules.mty_hash p
+  | GTmodty p  ->  mty_hash p
   | GTmem _ -> 1
 
+(* -------------------------------------------------------------------- *)
+let mr_fv (mr : form p_mod_restr) : int Mid.t =
+  (* mr_oinfos *)
+  let fv =
+    EcSymbols.Msym.fold (fun _ oi fv ->
+        let fv = List.fold_left EcPath.x_fv fv (PreOI.allowed oi) in
+        match PreOI.costs oi with
+        | `Unbounded -> fv
+        | `Bounded (self,calls) ->
+          EcPath.Mx.fold (fun xp call fv ->
+              let fv = EcPath.x_fv fv xp in
+              fv_union fv (f_fv call)
+            ) calls (fv_union fv (f_fv self))
+      ) mr.mr_oinfos Mid.empty
+  in
+
+  fv_union fv
+    (fv_union
+       (mr_xpaths_fv mr.mr_xpaths)
+       (mr_mpaths_fv mr.mr_mpaths))
+
+(* -------------------------------------------------------------------- *)
 let gty_fv = function
   | GTty ty -> ty.ty_fv
-  | GTmodty(_, (rx,r)) ->
-    let fv =
-      EcPath.Sm.fold (fun mp fv -> EcPath.m_fv fv mp) r EcIdent.Mid.empty in
-    EcPath.Sx.fold (fun xp fv -> EcPath.x_fv fv xp) rx fv
+  | GTmodty mty -> mr_fv mty.mt_restr
   | GTmem mt -> EcMemory.mt_fv mt
 
-let gty_fv_and_tvar = function
-  | GTty ty -> EcTypes.ty_fv_and_tvar ty
-  | GTmodty(_, (rx,r)) ->
-    let fv =
-      EcPath.Sm.fold (fun mp fv -> EcPath.m_fv fv mp) r EcIdent.Mid.empty in
-    EcPath.Sx.fold (fun xp fv -> EcPath.x_fv fv xp) rx fv
-  | GTmem mt -> EcMemory.mt_fv mt
 
+(* -------------------------------------------------------------------- *)
 let gtty (ty : EcTypes.ty) =
   GTty ty
 
-let gtmodty (mt : module_type) (mr : mod_restr) =
-  GTmodty (mt, mr)
+let gtmodty (mt : module_type) =
+  GTmodty mt
 
 let gtmem (mt : EcMemory.memtype) =
   GTmem mt
 
 (* -------------------------------------------------------------------- *)
 let as_gtty  = function GTty ty  -> ty  | _ -> assert false
-let as_modty = function GTmodty (mty, r) -> (mty, r) | _ -> assert false
+let as_modty = function GTmodty mty -> mty | _ -> assert false
 let as_mem   = function GTmem m -> m | _ -> assert false
 
 (*-------------------------------------------------------------------- *)
@@ -204,12 +279,6 @@ let b_hash (bs : bindings) =
 let hcmp_hash : hoarecmp -> int = Hashtbl.hash
 
 (*-------------------------------------------------------------------- *)
-let f_equal : form -> form -> bool = (==)
-let f_compare f1 f2 = f2.f_tag - f1.f_tag
-let f_hash f = f.f_tag
-let f_fv f = f.f_fv
-let f_ty f = f.f_ty
-
 module MSHf = EcMaps.MakeMSH(struct
   type t = form
   let tag f = f.f_tag
@@ -218,6 +287,14 @@ end)
 module Mf = MSHf.M
 module Sf = MSHf.S
 module Hf = MSHf.H
+
+let call_bound_equal cb1 cb2 =
+     f_equal cb1.cb_cost cb2.cb_cost
+  && f_equal cb1.cb_called cb2.cb_called
+
+let cost_equal c1 c2 =
+     f_equal c1.c_self c2.c_self
+  && EcPath.Mx.equal call_bound_equal c1.c_calls c2.c_calls
 
 let hf_equal hf1 hf2 =
      f_equal hf1.hf_pr hf2.hf_pr
@@ -229,6 +306,19 @@ let hs_equal hs1 hs2 =
   && f_equal hs1.hs_po hs2.hs_po
   && s_equal hs1.hs_s hs2.hs_s
   && EcMemory.me_equal hs1.hs_m hs2.hs_m
+
+let chf_equal chf1 chf2 =
+     f_equal chf1.chf_pr chf2.chf_pr
+  && f_equal chf1.chf_po chf2.chf_po
+  && cost_equal chf1.chf_co chf2.chf_co
+  && EcPath.x_equal chf1.chf_f chf2.chf_f
+
+let chs_equal chs1 chs2 =
+     f_equal chs1.chs_pr chs2.chs_pr
+  && f_equal chs1.chs_po chs2.chs_po
+  && cost_equal chs1.chs_co chs2.chs_co
+  && s_equal chs1.chs_s chs2.chs_s
+  && EcMemory.me_equal chs1.chs_m chs2.chs_m
 
 let bhf_equal bhf1 bhf2 =
      f_equal bhf1.bhf_pr bhf2.bhf_pr
@@ -262,10 +352,15 @@ let eqs_equal es1 es2 =
 let egf_equal eg1 eg2 =
      f_equal eg1.eg_pr eg2.eg_pr
   && f_equal eg1.eg_po eg2.eg_po
-  && EcModules.s_equal eg1.eg_sl eg2.eg_sl
+  && EcCoreModules.s_equal eg1.eg_sl eg2.eg_sl
   && EcPath.x_equal eg1.eg_fl eg2.eg_fl
   && EcPath.x_equal eg1.eg_fr eg2.eg_fr
-  && EcModules.s_equal eg1.eg_sr eg2.eg_sr
+  && EcCoreModules.s_equal eg1.eg_sr eg2.eg_sr
+
+let coe_equal coe1 coe2 =
+     EcTypes.e_equal   coe1.coe_e coe2.coe_e
+  && f_equal           coe1.coe_pre coe2.coe_pre
+  && EcMemory.me_equal coe1.coe_mem coe2.coe_mem
 
 let pr_equal pr1 pr2 =
      EcIdent.id_equal pr1.pr_mem pr2.pr_mem
@@ -279,8 +374,47 @@ let hf_hash hf =
     (f_hash hf.hf_pr) (f_hash hf.hf_po) (EcPath.x_hash hf.hf_f)
 
 let hs_hash hs =
+  Why3.Hashcons.combine3
+    (f_hash hs.hs_pr) (f_hash hs.hs_po)
+    (EcCoreModules.s_hash hs.hs_s)
+    (EcMemory.mem_hash hs.hs_m)
+
+let coe_hash coe =
   Why3.Hashcons.combine2
-    (f_hash hs.hs_pr) (f_hash hs.hs_po) (EcModules.s_hash hs.hs_s)
+    (f_hash coe.coe_pre)
+    (EcTypes.e_hash coe.coe_e)
+    (EcMemory.mem_hash coe.coe_mem)
+
+let call_bound_hash cb =
+  Why3.Hashcons.combine
+    (f_hash cb.cb_cost)
+    (f_hash cb.cb_called)
+
+let cost_hash cost =
+  Why3.Hashcons.combine
+    (f_hash cost.c_self)
+    (Why3.Hashcons.combine_list
+       (fun (f,c) ->
+          Why3.Hashcons.combine
+            (EcPath.x_hash f)
+            (call_bound_hash c))
+       0 (EcPath.Mx.bindings cost.c_calls))
+
+let chf_hash chf =
+  Why3.Hashcons.combine3
+    (f_hash chf.chf_pr)
+    (f_hash chf.chf_po)
+    (cost_hash chf.chf_co)
+    (EcPath.x_hash chf.chf_f)
+
+let chs_hash chs =
+  Why3.Hashcons.combine3
+    (f_hash chs.chs_pr)
+    (f_hash chs.chs_po)
+    (cost_hash chs.chs_co)
+    (Why3.Hashcons.combine
+       (EcCoreModules.s_hash chs.chs_s)
+       (EcMemory.mem_hash chs.chs_m))
 
 let bhf_hash bhf =
   Why3.Hashcons.combine_list f_hash
@@ -289,7 +423,10 @@ let bhf_hash bhf =
 
 let bhs_hash bhs =
   Why3.Hashcons.combine_list f_hash
-    (Why3.Hashcons.combine (hcmp_hash bhs.bhs_cmp) (EcModules.s_hash bhs.bhs_s))
+    (Why3.Hashcons.combine2
+       (hcmp_hash bhs.bhs_cmp)
+       (EcCoreModules.s_hash bhs.bhs_s)
+       (EcMemory.mem_hash bhs.bhs_m))
     [bhs.bhs_pr;bhs.bhs_po;bhs.bhs_bd]
 
 let ef_hash ef =
@@ -300,13 +437,17 @@ let ef_hash ef =
 let es_hash es =
   Why3.Hashcons.combine3
     (f_hash es.es_pr) (f_hash es.es_po)
-    (EcModules.s_hash es.es_sl) (EcModules.s_hash es.es_sr)
+    (EcCoreModules.s_hash es.es_sl)
+    (Why3.Hashcons.combine2
+       (EcMemory.mem_hash es.es_mr)
+       (EcMemory.mem_hash es.es_ml)
+       (EcCoreModules.s_hash es.es_sr))
 
 let eg_hash eg =
   Why3.Hashcons.combine3
     (f_hash eg.eg_pr) (f_hash eg.eg_po)
-    (Why3.Hashcons.combine (EcModules.s_hash eg.eg_sl) (EcPath.x_hash eg.eg_fl))
-    (Why3.Hashcons.combine (EcModules.s_hash eg.eg_sr) (EcPath.x_hash eg.eg_fr))
+    (Why3.Hashcons.combine (EcCoreModules.s_hash eg.eg_sl) (EcPath.x_hash eg.eg_fl))
+    (Why3.Hashcons.combine (EcCoreModules.s_hash eg.eg_sr) (EcPath.x_hash eg.eg_fr))
 
 let pr_hash pr =
   Why3.Hashcons.combine3
@@ -359,14 +500,17 @@ module Hsform = Why3.Hashcons.Make (struct
     | Fproj(f1,i1), Fproj(f2,i2) ->
       i1 = i2 && f_equal f1 f2
 
-    | FhoareF   hf1 , FhoareF   hf2  -> hf_equal hf1 hf2
-    | FhoareS   hs1 , FhoareS   hs2  -> hs_equal hs1 hs2
-    | FbdHoareF bhf1, FbdHoareF bhf2 -> bhf_equal bhf1 bhf2
-    | FbdHoareS bhs1, FbdHoareS bhs2 -> bhs_equal bhs1 bhs2
-    | FequivF   eqf1, FequivF   eqf2 -> eqf_equal eqf1 eqf2
-    | FequivS   eqs1, FequivS   eqs2 -> eqs_equal eqs1 eqs2
-    | FeagerF   eg1 , FeagerF   eg2  -> egf_equal eg1 eg2
-    | Fpr       pr1 , Fpr       pr2  -> pr_equal pr1 pr2
+    | FhoareF  hf1 , FhoareF  hf2  -> hf_equal hf1 hf2
+    | FhoareS  hs1 , FhoareS  hs2  -> hs_equal hs1 hs2
+    | FcHoareF hf1 , FcHoareF hf2  -> chf_equal hf1 hf2
+    | FcHoareS hs1 , FcHoareS hs2  -> chs_equal hs1 hs2
+    | FbdHoareF   bhf1, FbdHoareF   bhf2 -> bhf_equal bhf1 bhf2
+    | FbdHoareS   bhs1, FbdHoareS   bhs2 -> bhs_equal bhs1 bhs2
+    | FequivF     eqf1, FequivF     eqf2 -> eqf_equal eqf1 eqf2
+    | FequivS     eqs1, FequivS     eqs2 -> eqs_equal eqs1 eqs2
+    | FeagerF     eg1 , FeagerF     eg2  -> egf_equal eg1 eg2
+    | Fpr         pr1 , Fpr         pr2  -> pr_equal pr1 pr2
+    | Fcoe        coe1, Fcoe        coe2 -> coe_equal coe1 coe2
 
     | _, _ -> false
 
@@ -411,16 +555,29 @@ module Hsform = Why3.Hashcons.Make (struct
     | Fproj(f,i) ->
         Why3.Hashcons.combine (f_hash f) i
 
-    | FhoareF   hf  -> hf_hash hf
-    | FhoareS   hs  -> hs_hash hs
-    | FbdHoareF bhf -> bhf_hash bhf
-    | FbdHoareS bhs -> bhs_hash bhs
-    | FequivF   ef  -> ef_hash ef
-    | FequivS   es  -> es_hash es
-    | FeagerF   eg  -> eg_hash eg
-    | Fpr       pr  -> pr_hash pr
+    | FhoareF  hf   -> hf_hash hf
+    | FhoareS  hs   -> hs_hash hs
+    | FcHoareF chf  -> chf_hash chf
+    | FcHoareS chs  -> chs_hash chs
+    | FbdHoareF   bhf  -> bhf_hash bhf
+    | FbdHoareS   bhs  -> bhs_hash bhs
+    | FequivF     ef   -> ef_hash ef
+    | FequivS     es   -> es_hash es
+    | FeagerF     eg   -> eg_hash eg
+    | Fcoe        coe  -> coe_hash coe
+    | Fpr         pr   -> pr_hash pr
 
   let fv_mlr = Sid.add mleft (Sid.singleton mright)
+
+  let cost_fv cost =
+    let self_fv = f_fv cost.c_self in
+    EcPath.Mx.fold (fun f c fv ->
+        let c_fv =
+          fv_union
+            (fv_union (f_fv c.cb_cost) fv)
+            (f_fv c.cb_called) in
+        EcPath.x_fv c_fv f
+      ) cost.c_calls self_fv
 
   let fv_node f =
     let union ex nodes =
@@ -428,16 +585,17 @@ module Hsform = Why3.Hashcons.Make (struct
     in
 
     match f with
-    | Fint _             -> Mid.empty
-    | Fop (_, tys)       -> union (fun a -> a.ty_fv) tys
-    | Fpvar (pv,m)       -> EcPath.x_fv (fv_add m Mid.empty) pv.pv_name
-    | Fglob (mp,m)       -> EcPath.m_fv (fv_add m Mid.empty) mp
-    | Flocal id          -> fv_singleton id
-    | Fapp (f, args)     -> union f_fv (f :: args)
-    | Ftuple args        -> union f_fv args
-    | Fproj(e, _)        -> f_fv e
-    | Fif (f1, f2, f3)   -> union f_fv [f1; f2; f3]
-    | Fmatch (b, fs, ty) -> fv_union ty.ty_fv (union f_fv (b :: fs))
+    | Fint _              -> Mid.empty
+    | Fop (_, tys)        -> union (fun a -> a.ty_fv) tys
+    | Fpvar (PVglob pv,m) -> EcPath.x_fv (fv_add m Mid.empty) pv
+    | Fpvar (PVloc _,m)   -> fv_add m Mid.empty
+    | Fglob (mp,m)        -> EcPath.m_fv (fv_add m Mid.empty) mp
+    | Flocal id           -> fv_singleton id
+    | Fapp (f, args)      -> union f_fv (f :: args)
+    | Ftuple args         -> union f_fv args
+    | Fproj(e, _)         -> f_fv e
+    | Fif (f1, f2, f3)    -> union f_fv [f1; f2; f3]
+    | Fmatch (b, fs, ty)  -> fv_union ty.ty_fv (union f_fv (b :: fs))
 
     | Fquant(_, b, f) ->
       let do1 (id, ty) fv = fv_union (gty_fv ty) (Mid.remove id fv) in
@@ -453,7 +611,17 @@ module Hsform = Why3.Hashcons.Make (struct
 
     | FhoareS hs ->
       let fv = fv_union (f_fv hs.hs_pr) (f_fv hs.hs_po) in
-      fv_union (EcModules.s_fv hs.hs_s) (Mid.remove (fst hs.hs_m) fv)
+      fv_union (EcCoreModules.s_fv hs.hs_s) (Mid.remove (fst hs.hs_m) fv)
+
+    | FcHoareF chf ->
+      let fv = fv_union (f_fv chf.chf_pr)
+          (fv_union (f_fv chf.chf_po) (cost_fv chf.chf_co)) in
+      EcPath.x_fv (Mid.remove mhr fv) chf.chf_f
+
+    | FcHoareS chs ->
+      let fv = fv_union (f_fv chs.chs_pr)
+          (fv_union (f_fv chs.chs_po) (cost_fv chs.chs_co)) in
+      fv_union (EcCoreModules.s_fv chs.chs_s) (Mid.remove (fst chs.chs_m) fv)
 
     | FbdHoareF bhf ->
       let fv =
@@ -465,7 +633,7 @@ module Hsform = Why3.Hashcons.Make (struct
       let fv =
         fv_union (f_fv bhs.bhs_pr)
           (fv_union (f_fv bhs.bhs_po) (f_fv bhs.bhs_bd)) in
-      fv_union (EcModules.s_fv bhs.bhs_s) (Mid.remove (fst bhs.bhs_m) fv)
+      fv_union (EcCoreModules.s_fv bhs.bhs_s) (Mid.remove (fst bhs.bhs_m) fv)
 
     | FequivF ef ->
         let fv = fv_union (f_fv ef.ef_pr) (f_fv ef.ef_po) in
@@ -477,14 +645,19 @@ module Hsform = Why3.Hashcons.Make (struct
         let ml, mr = fst es.es_ml, fst es.es_mr in
         let fv = fv_diff fv (Sid.add ml (Sid.singleton mr)) in
         fv_union fv
-          (fv_union (EcModules.s_fv es.es_sl) (EcModules.s_fv es.es_sr))
+          (fv_union (EcCoreModules.s_fv es.es_sl) (EcCoreModules.s_fv es.es_sr))
 
     | FeagerF eg ->
         let fv = fv_union (f_fv eg.eg_pr) (f_fv eg.eg_po) in
         let fv = fv_diff fv fv_mlr in
         let fv = EcPath.x_fv (EcPath.x_fv fv eg.eg_fl) eg.eg_fr in
         fv_union fv
-          (fv_union (EcModules.s_fv eg.eg_sl) (EcModules.s_fv eg.eg_sr))
+          (fv_union (EcCoreModules.s_fv eg.eg_sl) (EcCoreModules.s_fv eg.eg_sr))
+
+    | Fcoe coe ->
+      fv_union
+        (Mid.remove (fst coe.coe_mem) (f_fv coe.coe_pre))
+        (EcTypes.e_fv coe.coe_e)
 
     | Fpr pr ->
         let fve = Mid.remove mhr (f_fv pr.pr_event) in
@@ -503,8 +676,7 @@ let gty_as_ty =
 let gty_as_mem =
   function GTmem m -> m  | _ -> assert false
 
-let gty_as_mod =
-  function GTmodty (mt, mr) -> (mt, mr) | _ -> assert false
+let gty_as_mod = function GTmodty mt -> mt | _ -> assert false
 
 let kind_of_gty = function
   | GTty    _ -> `Form
@@ -547,9 +719,11 @@ let f_app f args ty =
 (* -------------------------------------------------------------------- *)
 let f_local  x ty   = mk_form (Flocal x) ty
 let f_pvar   x ty m = mk_form (Fpvar(x, m)) ty
-let f_pvarg  f ty m = f_pvar (pv_arg f) ty m
-let f_pvloc  f v  m = f_pvar (EcTypes.pv_loc f v.v_name) v.v_type m
-let f_pvlocs f vs m = List.map (fun v -> f_pvloc f v m) vs
+let f_pvloc  v  m = f_pvar (pv_loc v.v_name) v.v_type m
+
+let f_pvarg  ty m = f_pvar pv_arg ty m
+
+let f_pvlocs vs menv = List.map (fun v -> f_pvloc v menv) vs
 let f_glob   mp m   = mk_form (Fglob (mp, m)) (tglob mp)
 
 (* -------------------------------------------------------------------- *)
@@ -652,6 +826,30 @@ let f_hoareF hf_pr hf_f hf_po =
   f_hoareF_r { hf_pr; hf_f; hf_po; }
 
 (* -------------------------------------------------------------------- *)
+let call_bound_r cb_cost cb_called =
+  { cb_cost; cb_called }
+
+let cost_r c_self c_calls =
+  (* Invariant: keys of c_calls are functions of local modules,
+     with no arguments. *)
+  assert (EcPath.Mx.for_all (fun x _ ->
+      match x.x_top.m_top with
+      | `Local _ -> x.x_top.m_args = []
+      | _ -> false
+    ) c_calls);
+  let c = { c_self; c_calls; } in
+  c
+
+let f_cHoareS_r chs = mk_form (FcHoareS chs) tbool
+let f_cHoareF_r chf = mk_form (FcHoareF chf) tbool
+
+let f_cHoareS chs_m chs_pr chs_s chs_po chs_co =
+  f_cHoareS_r { chs_m; chs_pr; chs_s; chs_po; chs_co }
+
+let f_cHoareF chf_pr chf_f chf_po chf_co =
+  f_cHoareF_r { chf_pr; chf_f; chf_po; chf_co }
+
+(* -------------------------------------------------------------------- *)
 let f_bdHoareS_r bhs = mk_form (FbdHoareS bhs) tbool
 let f_bdHoareF_r bhf = mk_form (FbdHoareF bhf) tbool
 
@@ -677,6 +875,11 @@ let f_eagerF_r eg = mk_form (FeagerF eg) tbool
 
 let f_eagerF eg_pr eg_sl eg_fl eg_fr eg_sr eg_po =
   f_eagerF_r { eg_pr; eg_sl; eg_fl; eg_fr; eg_sr; eg_po; }
+
+(* -------------------------------------------------------------------- *)
+let f_coe_r coe = mk_form (Fcoe coe) txint
+
+let f_coe coe_pre coe_mem coe_e = f_coe_r { coe_pre; coe_mem; coe_e; }
 
 (* -------------------------------------------------------------------- *)
 let f_pr_r pr = mk_form (Fpr pr) treal
@@ -712,6 +915,45 @@ let rec f_int (n : BI.zint) =
 let f_i0  = f_int BI.zero
 let f_i1  = f_int BI.one
 let f_im1 = f_int_opp f_i1
+
+(* -------------------------------------------------------------------- *)
+let f_op_xopp   = f_op EcCoreLib.CI_xint.p_xopp  [] (toarrow [txint        ] txint)
+let f_op_xadd   = f_op EcCoreLib.CI_xint.p_xadd  [] (toarrow [txint; txint ] txint)
+let f_op_xmul   = f_op EcCoreLib.CI_xint.p_xmul  [] (toarrow [txint; txint ] txint)
+let f_op_xle    = f_op EcCoreLib.CI_xint.p_xle   [] (toarrow [txint; txint ] tbool)
+let f_op_xmax   = f_op EcCoreLib.CI_xint.p_xmax  [] (toarrow [txint;  txint] txint)
+
+let f_op_inf    = f_op EcCoreLib.CI_xint.p_inf    [] txint
+let f_op_N      = f_op EcCoreLib.CI_xint.p_N      [] (toarrow [tint ] txint)
+let f_op_is_inf = f_op EcCoreLib.CI_xint.p_is_inf [] (toarrow [txint] tbool)
+let f_op_is_int = f_op EcCoreLib.CI_xint.p_is_int [] (toarrow [txint] tbool)
+
+let f_is_inf f  = f_app f_op_is_inf [f] tbool
+let f_is_int f  = f_app f_op_is_int [f] tbool
+
+let f_Inf         = f_app f_op_inf  []       txint
+let f_N     f     = f_app f_op_N    [f]      txint
+let f_xopp  f     = f_app f_op_xopp [f]      txint
+let f_xadd  f1 f2 = f_app f_op_xadd [f1; f2] txint
+let f_xmul  f1 f2 = f_app f_op_xmul [f1; f2] txint
+let f_xmuli fi f  = f_xmul (f_N fi) f
+let f_xle   f1 f2 = f_app f_op_xle  [f1; f2] tbool
+let f_xmax  f1 f2 = f_app f_op_xmax [f1; f2] txint
+
+let f_x0 = f_N f_i0
+let f_x1 = f_N f_i1
+
+let f_xadd_simpl f1 f2 =
+  if f_equal f1 f_x0 then f2 else
+  if f_equal f2 f_x0 then f1 else f_xadd f1 f2
+
+let f_xmul_simpl f1 f2 =
+  if   f_equal f1 f_x0 || f_equal f2 f_x0
+  then f_x0
+  else f_xmul f1 f2
+
+let f_xmuli_simpl f1 f2 =
+  f_xmul_simpl (f_N f1) f2
 
 (* -------------------------------------------------------------------- *)
 module FSmart = struct
@@ -792,8 +1034,14 @@ module FSmart = struct
   let f_hoareF (fp, hf) hf' =
     if hf_equal hf hf' then fp else mk_form (FhoareF hf') fp.f_ty
 
+  let f_cHoareF (fp, chf) chf' =
+    if chf_equal chf chf' then fp else mk_form (FcHoareF chf') fp.f_ty
+
   let f_hoareS (fp, hs) hs' =
     if hs_equal hs hs' then fp else f_hoareS_r hs'
+
+  let f_cHoareS (fp, chs) chs' =
+    if chs_equal chs chs' then fp else f_cHoareS_r chs'
 
   let f_bdHoareF (fp, bhf) bhf' =
     if bhf_equal bhf bhf' then fp else mk_form (FbdHoareF bhf') fp.f_ty
@@ -801,11 +1049,27 @@ module FSmart = struct
   let f_bdHoareS (fp, bhs) bhs' =
     if bhs_equal bhs bhs' then fp else f_bdHoareS_r bhs'
 
+  let f_coe (fp, coe) coe' =
+    if coe_equal coe coe' then fp else f_coe_r coe'
+
   let f_pr (fp, pr) pr' =
     if pr_equal pr pr' then fp else f_pr_r pr'
 end
 
 (* -------------------------------------------------------------------- *)
+let cost_map g cost =
+  let calls =
+    EcPath.Mx.map (fun cb ->
+        { cb_cost  = g cb.cb_cost;
+          cb_called = g cb.cb_called }
+      ) cost.c_calls in
+
+  cost_r (g cost.c_self) calls
+
+let cost_iter g cost =
+  g cost.c_self;
+  EcPath.Mx.iter (fun _ cb -> g cb.cb_cost; g cb.cb_called; ) cost.c_calls
+
 let f_map gt g fp =
   match fp.f_node with
   | Fquant(q, b, f) ->
@@ -876,6 +1140,20 @@ let f_map gt g fp =
         FSmart.f_hoareS (fp, hs)
           { hs with hs_pr = pr'; hs_po = po'; }
 
+  | FcHoareF chf ->
+      let pr' = g chf.chf_pr in
+      let po' = g chf.chf_po in
+      let c'  = cost_map g chf.chf_co in
+        FSmart.f_cHoareF (fp, chf)
+          { chf with chf_pr = pr'; chf_po = po'; chf_co = c' }
+
+  | FcHoareS chs ->
+      let pr' = g chs.chs_pr in
+      let po' = g chs.chs_po in
+      let c'  = cost_map g chs.chs_co in
+        FSmart.f_cHoareS (fp, chs)
+          { chs with chs_pr = pr'; chs_po = po'; chs_co = c' }
+
   | FbdHoareF bhf ->
       let pr' = g bhf.bhf_pr in
       let po' = g bhf.bhf_po in
@@ -908,6 +1186,11 @@ let f_map gt g fp =
         FSmart.f_eagerF (fp, eg)
           { eg with eg_pr = pr'; eg_po = po'; }
 
+  | Fcoe coe ->
+    let pre' = g coe.coe_pre in
+    FSmart.f_coe (fp, coe)
+      { coe with coe_pre = pre'; }
+
   | Fpr pr ->
       let args' = g pr.pr_args in
       let ev'   = g pr.pr_event in
@@ -931,13 +1214,16 @@ let f_iter g f =
   | Ftuple   es           -> List.iter g es
   | Fproj    (e, _)       -> g e
 
-  | FhoareF   hf  -> g hf.hf_pr; g hf.hf_po
-  | FhoareS   hs  -> g hs.hs_pr; g hs.hs_po
-  | FbdHoareF bhf -> g bhf.bhf_pr; g bhf.bhf_po
-  | FbdHoareS bhs -> g bhs.bhs_pr; g bhs.bhs_po
+  | FhoareF  hf  -> g hf.hf_pr; g hf.hf_po
+  | FhoareS  hs  -> g hs.hs_pr; g hs.hs_po
+  | FcHoareF  chf -> g chf.chf_pr; g chf.chf_po; cost_iter g chf.chf_co
+  | FcHoareS  chs -> g chs.chs_pr; g chs.chs_po; cost_iter g chs.chs_co
+  | FbdHoareF bhf -> g bhf.bhf_pr; g bhf.bhf_po; g bhf.bhf_bd
+  | FbdHoareS bhs -> g bhs.bhs_pr; g bhs.bhs_po; g bhs.bhs_bd
   | FequivF   ef  -> g ef.ef_pr; g ef.ef_po
   | FequivS   es  -> g es.es_pr; g es.es_po
   | FeagerF   eg  -> g eg.eg_pr; g eg.eg_po
+  | Fcoe      coe -> g coe.coe_pre;
   | Fpr       pr  -> g pr.pr_args; g pr.pr_event
 
 
@@ -958,14 +1244,17 @@ let form_exists g f =
   | Ftuple   es           -> List.exists g es
   | Fproj    (e, _)       -> g e
 
-  | FhoareF   hf  -> g hf.hf_pr   || g hf.hf_po
-  | FhoareS   hs  -> g hs.hs_pr   || g hs.hs_po
-  | FbdHoareF bhf -> g bhf.bhf_pr || g bhf.bhf_po
-  | FbdHoareS bhs -> g bhs.bhs_pr || g bhs.bhs_po
-  | FequivF   ef  -> g ef.ef_pr   || g ef.ef_po
-  | FequivS   es  -> g es.es_pr   || g es.es_po
-  | FeagerF   eg  -> g eg.eg_pr   || g eg.eg_po
-  | Fpr       pr  -> g pr.pr_args || g pr.pr_event
+  | FhoareF   hf -> g hf.hf_pr   || g hf.hf_po
+  | FhoareS   hs -> g hs.hs_pr   || g hs.hs_po
+  | FcHoareF  chf -> g chf.chf_pr  || g chf.chf_po
+  | FcHoareS  chs -> g chs.chs_pr  || g chs.chs_po
+  | FbdHoareF bhf -> g bhf.bhf_pr  || g bhf.bhf_po
+  | FbdHoareS bhs -> g bhs.bhs_pr  || g bhs.bhs_po
+  | FequivF   ef  -> g ef.ef_pr    || g ef.ef_po
+  | FequivS   es  -> g es.es_pr    || g es.es_po
+  | FeagerF   eg  -> g eg.eg_pr    || g eg.eg_po
+  | Fcoe      coe -> g coe.coe_pre
+  | Fpr       pr  -> g pr.pr_args  || g pr.pr_event
 
 (* -------------------------------------------------------------------- *)
 let form_forall g f =
@@ -984,13 +1273,16 @@ let form_forall g f =
   | Ftuple   es           -> List.for_all g es
   | Fproj    (e, _)       -> g e
 
-  | FhoareF   hf  -> g hf.hf_pr   && g hf.hf_po
-  | FhoareS   hs  -> g hs.hs_pr   && g hs.hs_po
+  | FhoareF  hf  -> g hf.hf_pr  && g hf.hf_po
+  | FhoareS  hs  -> g hs.hs_pr  && g hs.hs_po
+  | FcHoareF  chf -> g chf.chf_pr && g chf.chf_po
+  | FcHoareS  chs -> g chs.chs_pr && g chs.chs_po
   | FbdHoareF bhf -> g bhf.bhf_pr && g bhf.bhf_po
   | FbdHoareS bhs -> g bhs.bhs_pr && g bhs.bhs_po
   | FequivF   ef  -> g ef.ef_pr   && g ef.ef_po
   | FequivS   es  -> g es.es_pr   && g es.es_po
   | FeagerF   eg  -> g eg.eg_pr   && g eg.eg_po
+  | Fcoe      coe -> g coe.coe_pre
   | Fpr       pr  -> g pr.pr_args && g pr.pr_event
 
 (* -------------------------------------------------------------------- *)
@@ -1078,6 +1370,16 @@ let destr_hoareF f =
   | FhoareF es -> es
   | _ -> destr_error "hoareF"
 
+let destr_cHoareS f =
+  match f.f_node with
+  | FcHoareS es -> es
+  | _ -> destr_error "cHoareS"
+
+let destr_cHoareF f =
+  match f.f_node with
+  | FcHoareF es -> es
+  | _ -> destr_error "cHoareF"
+
 let destr_bdHoareS f =
   match f.f_node with
   | FbdHoareS es -> es
@@ -1088,6 +1390,11 @@ let destr_bdHoareF f =
   | FbdHoareF es -> es
   | _ -> destr_error "bdHoareF"
 
+let destr_coe f =
+  match f.f_node with
+  | Fcoe coe -> coe
+  | _ -> destr_error "coe"
+
 let destr_pr f =
   match f.f_node with
   | Fpr pr -> pr
@@ -1095,7 +1402,8 @@ let destr_pr f =
 
 let destr_programS side f =
   match side, f.f_node with
-  | None  , FhoareS   hs  -> (hs.hs_m, hs.hs_s)
+  | None  , FhoareS   hs -> (hs.hs_m, hs.hs_s)
+  | None  , FcHoareS  chs -> (chs.chs_m, chs.chs_s)
   | None  , FbdHoareS bhs -> (bhs.bhs_m, bhs.bhs_s)
   | Some b, FequivS   es  -> begin
       match b with
@@ -1231,8 +1539,11 @@ let is_equivS    f = is_from_destr destr_equivS    f
 let is_eagerF    f = is_from_destr destr_eagerF    f
 let is_hoareS    f = is_from_destr destr_hoareS    f
 let is_hoareF    f = is_from_destr destr_hoareF    f
+let is_cHoareS   f = is_from_destr destr_cHoareS   f
+let is_cHoareF   f = is_from_destr destr_cHoareF   f
 let is_bdHoareS  f = is_from_destr destr_bdHoareS  f
 let is_bdHoareF  f = is_from_destr destr_bdHoareF  f
+let is_coe       f = is_from_destr destr_coe       f
 let is_pr        f = is_from_destr destr_pr        f
 let is_eq_or_iff f = (is_eq f) || (is_iff f)
 
@@ -1254,6 +1565,13 @@ let quantif_of_equantif (qt : equantif) =
   | `ELambda -> Llambda
   | `EForall -> Lforall
   | `EExists -> Lexists
+
+(* -------------------------------------------------------------------- *)
+let equantif_of_quantif (qt : quantif) : equantif =
+  match qt with
+  | Llambda -> `ELambda
+  | Lforall -> `EForall
+  | Lexists -> `EExists
 
 (* -------------------------------------------------------------------- *)
 let rec form_of_expr mem (e : expr) =
@@ -1298,6 +1616,57 @@ let rec form_of_expr mem (e : expr) =
      let e = form_of_expr mem e in
      f_quant (quantif_of_equantif qt) b e
 
+
+(* -------------------------------------------------------------------- *)
+exception CannotTranslate
+
+let expr_of_form mh f =
+  let rec aux fp =
+    match fp.f_node with
+    | Fint   z -> e_int z
+    | Flocal x -> e_local x fp.f_ty
+
+    | Fop  (p, tys) -> e_op p tys fp.f_ty
+    | Fapp (f, fs)  -> e_app (aux f) (List.map aux fs) fp.f_ty
+    | Ftuple fs     -> e_tuple (List.map aux fs)
+    | Fproj  (f, i) -> e_proj (aux f) i fp.f_ty
+
+    | Fif (c, f1, f2) ->
+      e_if (aux c) (aux f1) (aux f2)
+
+    | Fmatch (c, bs, ty) ->
+      e_match (aux c) (List.map aux bs) ty
+
+    | Flet (lp, f1, f2) ->
+      e_let lp (aux f1) (aux f2)
+
+    | Fquant (kd, bds, f) ->
+      e_quantif (equantif_of_quantif kd) (List.map auxbd bds) (aux f)
+
+    | Fpvar (pv, m) ->
+      if EcIdent.id_equal m mh
+      then e_var pv fp.f_ty
+      else raise CannotTranslate
+
+    | Fcoe      _
+    | Fglob     _
+    | FhoareF   _ | FhoareS   _
+    | FcHoareF  _ | FcHoareS  _
+    | FbdHoareF _ | FbdHoareS _
+    | FequivF   _ | FequivS   _
+    | FeagerF   _ | Fpr       _ -> raise CannotTranslate
+
+  and auxbd ((x, bd) : binding) =
+    match bd with
+    | GTty ty -> (x, ty)
+    | _ -> raise CannotTranslate
+
+  in aux f
+
+(* -------------------------------------------------------------------- *)
+(* A predicate on memory: λ mem. -> pred *)
+type mem_pr = EcMemory.memory * form
+
 (* -------------------------------------------------------------------- *)
 type f_subst = {
   fs_freshen : bool; (* true means freshen locals *)
@@ -1309,6 +1678,9 @@ type f_subst = {
   fs_opdef   : (EcIdent.t list * expr) Mp.t;
   fs_pddef   : (EcIdent.t list * form) Mp.t;
   fs_esloc   : expr Mid.t;
+  fs_memtype : EcMemory.memtype option; (* Only substituted in Fcoe *)
+  fs_mempred : mem_pr Mid.t;  (* For predicates over memories,
+                                 only substituted in Fcoe *)
 }
 
 (* -------------------------------------------------------------------- *)
@@ -1323,6 +1695,8 @@ module Fsubst = struct
     fs_opdef   = Mp.empty;
     fs_pddef   = Mp.empty;
     fs_esloc   = Mid.empty;
+    fs_memtype = None;
+    fs_mempred = Mid.empty;
   }
 
   let is_subst_id s =
@@ -1333,8 +1707,9 @@ module Fsubst = struct
     && Mp.is_empty    s.fs_opdef
     && Mp.is_empty    s.fs_pddef
     && Mid.is_empty   s.fs_esloc
+    && s.fs_memtype = None
 
-  let f_subst_init ?freshen ?mods ?sty ?opdef ?prdef () =
+  let f_subst_init ?freshen ?mods ?sty ?opdef ?prdef ?esloc ?mt ?mempred () =
     let sty = odfl ty_subst_id sty in
     { f_subst_id
         with fs_freshen = odfl false freshen;
@@ -1343,7 +1718,9 @@ module Fsubst = struct
              fs_ty      = ty_subst sty;
              fs_opdef   = odfl Mp.empty opdef;
              fs_pddef   = odfl Mp.empty prdef;
-             fs_esloc   = Mid.empty; }
+             fs_esloc   = odfl Mid.empty esloc;
+             fs_mempred = odfl Mid.empty mempred;
+             fs_memtype = mt; }
 
   (* ------------------------------------------------------------------ *)
   let f_bind_local s x t =
@@ -1353,6 +1730,10 @@ module Fsubst = struct
   let f_bind_mem s m1 m2 =
     let merger o = assert (o = None); Some m2 in
       { s with fs_mem = Mid.change merger m1 s.fs_mem }
+
+  let f_rebind_mem s m1 m2 =
+    let merger _ = Some m2 in
+    { s with fs_mem = Mid.change merger m1 s.fs_mem }
 
   let f_bind_mod s x mp =
     let merger o = assert (o = None); Some mp in
@@ -1421,52 +1802,6 @@ module Fsubst = struct
         in
           if xs == xs' then (s, lp) else (s, LRecord (p, xs'))
 
-  let gty_subst s gty =
-    if is_subst_id s then gty else
-
-    match gty with
-    | GTty ty ->
-        let ty' = s.fs_ty ty in
-        if ty == ty' then gty else GTty ty'
-
-    | GTmodty (p, (rx, r)) ->
-        let sub  = s.fs_sty.ts_mp in
-        let xsub = EcPath.x_substm s.fs_sty.ts_p s.fs_mp in
-        let p'   = mty_subst s.fs_sty.ts_p sub p in
-        let rx'  = Sx.fold (fun m rx' -> Sx.add (xsub m) rx') rx Sx.empty in
-        let r'   = Sm.fold (fun m r' -> Sm.add (sub m) r') r Sm.empty in
-
-        if   p == p' && Sx.equal rx rx' && Sm.equal r r'
-        then gty
-        else GTmodty (p', (rx', r'))
-
-    | GTmem mt ->
-        let mt' = EcMemory.mt_substm s.fs_sty.ts_p s.fs_mp s.fs_ty mt in
-        if mt == mt' then gty else GTmem mt'
-
-  (* ------------------------------------------------------------------ *)
-  let add_binding s (x, gty as xt) =
-    let gty' = gty_subst s gty in
-    let x'   = if s.fs_freshen then EcIdent.fresh x else x in
-
-    if   x == x' && gty == gty'
-    then
-      let s = match gty with
-        | GTty    _ -> f_rem_local s x
-        | GTmodty _ -> f_rem_mod   s x
-        | GTmem   _ -> f_rem_mem   s x
-      in
-        (s, xt)
-    else
-      let s = match gty' with
-        | GTty   ty -> f_bind_rename s x x' ty
-        | GTmodty _ -> f_bind_mod s x (EcPath.mident x')
-        | GTmem   _ -> f_bind_mem s x x'
-      in
-        (s, (x', gty'))
-
-  let add_bindings = List.map_fold add_binding
-
   (* ------------------------------------------------------------------ *)
   let subst_xpath s f =
     let m_subst = EcPath.x_substm s.fs_sty.ts_p s.fs_mp in
@@ -1475,10 +1810,15 @@ module Fsubst = struct
   let subst_stmt s c =
     let es  = e_subst_init s.fs_freshen s.fs_sty.ts_p
                 s.fs_ty s.fs_opdef s.fs_mp s.fs_esloc in
-    EcModules.s_subst es c
+    EcCoreModules.s_subst es c
+
+  let subst_e s e =
+    let es  = e_subst_init s.fs_freshen s.fs_sty.ts_p
+                s.fs_ty s.fs_opdef s.fs_mp s.fs_esloc in
+    EcTypes.e_subst es e
 
   let subst_me s me =
-    EcMemory.me_substm s.fs_sty.ts_p s.fs_mp s.fs_mem s.fs_ty me
+    EcMemory.me_subst s.fs_mem s.fs_ty me
 
   let subst_m s m = Mid.find_def m m s.fs_mem
 
@@ -1488,7 +1828,7 @@ module Fsubst = struct
   let rec f_subst ~tx s fp =
     tx fp (match fp.f_node with
     | Fquant (q, b, f) ->
-        let s, b' = add_bindings s b in
+        let s, b' = add_bindings ~tx s b in
         let f'    = f_subst ~tx s f in
           FSmart.f_quant (fp, (q, b, f)) (q, b', f')
 
@@ -1562,10 +1902,31 @@ module Fsubst = struct
                                s.fs_ty s.fs_opdef s.fs_mp s.fs_esloc in
         let pr' = f_subst ~tx s hs.hs_pr in
         let po' = f_subst ~tx s hs.hs_po in
-        let st' = EcModules.s_subst es hs.hs_s in
-        let me' = EcMemory.me_substm s.fs_sty.ts_p s.fs_mp s.fs_mem s.fs_ty hs.hs_m in
+        let st' = EcCoreModules.s_subst es hs.hs_s in
+        let me' = EcMemory.me_subst s.fs_mem s.fs_ty hs.hs_m in
         FSmart.f_hoareS (fp, hs)
           { hs_pr = pr'; hs_po = po'; hs_s = st'; hs_m = me'; }
+
+    | FcHoareF chf ->
+      assert (not (Mid.mem mhr s.fs_mem));
+      let pr' = f_subst ~tx s chf.chf_pr in
+      let po' = f_subst ~tx s chf.chf_po in
+      let mp' = EcPath.x_substm s.fs_sty.ts_p s.fs_mp chf.chf_f in
+      let c'  = cost_subst ~tx s chf.chf_co in
+      FSmart.f_cHoareF (fp, chf)
+        { chf_pr = pr'; chf_po = po'; chf_f = mp'; chf_co = c'; }
+
+    | FcHoareS chs ->
+      assert (not (Mid.mem (fst chs.chs_m) s.fs_mem));
+      let es  = e_subst_init s.fs_freshen s.fs_sty.ts_p
+          s.fs_ty s.fs_opdef s.fs_mp s.fs_esloc in
+      let pr' = f_subst ~tx s chs.chs_pr in
+      let po' = f_subst ~tx s chs.chs_po in
+      let st' = EcCoreModules.s_subst es chs.chs_s in
+      let me' = EcMemory.me_subst s.fs_mem s.fs_ty chs.chs_m in
+      let c'  = cost_subst ~tx s chs.chs_co in
+      FSmart.f_cHoareS (fp, chs)
+        { chs_pr = pr'; chs_po = po'; chs_s = st'; chs_m = me'; chs_co = c'; }
 
     | FbdHoareF bhf ->
       let pr', po', bd' =
@@ -1585,8 +1946,8 @@ module Fsubst = struct
                              s.fs_opdef s.fs_mp s.fs_esloc in
       let pr' = f_subst ~tx s bhs.bhs_pr in
       let po' = f_subst ~tx s bhs.bhs_po in
-      let st' = EcModules.s_subst es bhs.bhs_s in
-      let me' = EcMemory.me_substm s.fs_sty.ts_p s.fs_mp s.fs_mem s.fs_ty bhs.bhs_m in
+      let st' = EcCoreModules.s_subst es bhs.bhs_s in
+      let me' = EcMemory.me_subst s.fs_mem s.fs_ty bhs.bhs_m in
       let bd' = f_subst ~tx s bhs.bhs_bd in
       FSmart.f_bdHoareS (fp, bhs)
         { bhs with bhs_pr = pr'; bhs_po = po'; bhs_s = st';
@@ -1610,13 +1971,13 @@ module Fsubst = struct
                 not (Mid.mem (fst eqs.es_mr) s.fs_mem));
       let es = e_subst_init s.fs_freshen s.fs_sty.ts_p s.fs_ty
                             s.fs_opdef s.fs_mp s.fs_esloc in
-      let s_subst = EcModules.s_subst es in
+      let s_subst = EcCoreModules.s_subst es in
       let pr' = f_subst ~tx s eqs.es_pr in
       let po' = f_subst ~tx s eqs.es_po in
       let sl' = s_subst eqs.es_sl in
       let sr' = s_subst eqs.es_sr in
-      let ml' = EcMemory.me_substm s.fs_sty.ts_p s.fs_mp s.fs_mem s.fs_ty eqs.es_ml in
-      let mr' = EcMemory.me_substm s.fs_sty.ts_p s.fs_mp s.fs_mem s.fs_ty eqs.es_mr in
+      let ml' = EcMemory.me_subst s.fs_mem s.fs_ty eqs.es_ml in
+      let mr' = EcMemory.me_subst s.fs_mem s.fs_ty eqs.es_mr in
 
       FSmart.f_equivS (fp, eqs)
         { es_ml = ml'; es_mr = mr';
@@ -1636,13 +1997,44 @@ module Fsubst = struct
 
       let es = e_subst_init s.fs_freshen s.fs_sty.ts_p s.fs_ty
                             s.fs_opdef s.fs_mp s.fs_esloc in
-      let s_subst = EcModules.s_subst es in
+      let s_subst = EcCoreModules.s_subst es in
       let sl' = s_subst eg.eg_sl in
       let sr' = s_subst eg.eg_sr in
 
       FSmart.f_eagerF (fp, eg)
         { eg_pr = pr'; eg_sl = sl';eg_fl = fl';
           eg_fr = fr'; eg_sr = sr'; eg_po = po'; }
+
+    | Fcoe coe ->
+      (* We freshen the binded memory. *)
+      let m = fst coe.coe_mem in
+      let m' = EcIdent.fresh m in
+      let s = f_rebind_mem s m m' in
+
+      (* We bind the memory of all memory predicates with the fresh memory
+         we just created, and add them as local variable substitutions. *)
+      let s = Mid.fold (fun id (pmem,p) s ->
+          let fs_mem = f_bind_mem f_subst_id pmem m' in
+          let p = f_subst ~tx:(fun _ f -> f) fs_mem p in
+          f_bind_local s id p
+        ) s.fs_mempred { s with fs_mempred = Mid.empty; } in
+
+
+      (* Then we substitute *)
+      let es  = e_subst_init s.fs_freshen s.fs_sty.ts_p
+          s.fs_ty s.fs_opdef s.fs_mp s.fs_esloc in
+      let pr' = f_subst ~tx s coe.coe_pre in
+      let me' = EcMemory.me_subst s.fs_mem s.fs_ty coe.coe_mem in
+      let e' = EcTypes.e_subst es coe.coe_e in
+
+      (* If necessary, we substitute the memtype. *)
+      let me' =
+        if EcMemory.is_schema (snd me') && s.fs_memtype <> None
+        then (fst me', oget s.fs_memtype)
+        else me' in
+
+      FSmart.f_coe (fp, coe)
+        { coe_pre = pr'; coe_mem = me'; coe_e = e'; }
 
     | Fpr pr ->
       let pr_mem   = Mid.find_def pr.pr_mem pr.pr_mem s.fs_mem in
@@ -1653,7 +2045,8 @@ module Fsubst = struct
 
       FSmart.f_pr (fp, pr) { pr_mem; pr_fun; pr_args; pr_event; }
 
-    | _ -> f_map s.fs_ty (f_subst ~tx s) fp)
+    | _ ->
+      f_map s.fs_ty (f_subst ~tx s) fp)
 
   and f_subst_op ~tx freshen fty tys args (tyids, e) =
     (* FIXME: factor this out *)
@@ -1705,9 +2098,121 @@ module Fsubst = struct
     let sag = { f_subst_id with fs_loc = sag } in
     f_app (f_subst ~tx sag f) args fty
 
+  and subst_oi ~(tx : form -> form -> form) (s : f_subst) (oi : form PreOI.t) =
+    let sx = EcPath.x_substm s.fs_sty.ts_p s.fs_mp in
+
+    let costs = match PreOI.costs oi with
+      | `Unbounded -> `Unbounded
+      | `Bounded (self,calls) ->
+        let calls = EcPath.Mx.fold (fun x a calls ->
+            EcPath.Mx.change
+              (fun old -> assert (old = None); Some (f_subst ~tx s a))
+              (sx x)
+              calls
+          ) calls EcPath.Mx.empty in
+        let self = f_subst ~tx s self in
+        `Bounded (self,calls) in
+
+    PreOI.mk
+      (List.map sx (PreOI.allowed oi))
+      (PreOI.is_in oi)
+      costs
+
+  and mr_subst ~tx s mr : form p_mod_restr =
+    let sx = EcPath.x_substm s.fs_sty.ts_p s.fs_mp in
+    let sm = s.fs_sty.ts_mp in
+    { mr_xpaths = ur_app (fun s -> Sx.fold (fun m rx ->
+          Sx.add (sx m) rx) s Sx.empty) mr.mr_xpaths;
+      mr_mpaths = ur_app (fun s -> Sm.fold (fun m r ->
+          Sm.add (sm m) r) s Sm.empty) mr.mr_mpaths;
+      mr_oinfos = EcSymbols.Msym.map (subst_oi ~tx s) mr.mr_oinfos;
+    }
+
+  and subst_mty ~tx s mty =
+    let sm = s.fs_sty.ts_mp in
+
+    let mt_params = List.map (snd_map (subst_mty ~tx s)) mty.mt_params in
+    let mt_name   = s.fs_sty.ts_p mty.mt_name in
+    let mt_args   = List.map sm mty.mt_args in
+    let mt_restr  = mr_subst ~tx s mty.mt_restr in
+    { mt_params; mt_name; mt_args; mt_restr; }
+
+  and subst_gty ~tx s gty =
+    if is_subst_id s then gty else
+
+    match gty with
+    | GTty ty ->
+        let ty' = s.fs_ty ty in
+        if ty == ty' then gty else GTty ty'
+
+    | GTmodty p ->
+        let p'   = subst_mty ~tx s p in
+
+        if   p == p'
+        then gty
+        else GTmodty p'
+
+    | GTmem mt ->
+        let mt' = EcMemory.mt_subst s.fs_ty mt in
+        if mt == mt' then gty else GTmem mt'
+
+  and add_binding ~tx s (x, gty as xt) =
+    let gty' = subst_gty ~tx s gty in
+    let x'   = if s.fs_freshen then EcIdent.fresh x else x in
+
+    if   x == x' && gty == gty'
+    then
+      let s = match gty with
+        | GTty    _ -> f_rem_local s x
+        | GTmodty _ -> f_rem_mod   s x
+        | GTmem   _ -> f_rem_mem   s x
+      in
+        (s, xt)
+    else
+      let s = match gty' with
+        | GTty   ty -> f_bind_rename s x x' ty
+        | GTmodty _ -> f_bind_mod s x (EcPath.mident x')
+        | GTmem   _ -> f_bind_mem s x x'
+      in
+        (s, (x', gty'))
+
+  and add_bindings ~tx = List.map_fold (add_binding ~tx)
+
+  (* When substituting a abstract module (i.e. a mident) by a concrete one,
+     we move the module cost from [c_calls] to [c_self]. *)
+  and cost_subst ~tx s cost =
+    let c_self = f_subst ~tx s cost.c_self
+    and self', c_calls = EcPath.Mx.fold (fun x cb (self',calls) ->
+        let x' = EcPath.x_substm s.fs_sty.ts_p s.fs_mp x in
+        let cb_cost'   = f_subst ~tx s cb.cb_cost in
+        let cb_called' = f_subst ~tx s cb.cb_called in
+        match x'.x_top.m_top with
+        | `Local _ ->
+          let cb' = { cb_cost   = cb_cost';
+                      cb_called = cb_called'; } in
+          ( self',
+            EcPath.Mx.change
+              (fun old -> assert (old  = None); Some cb')
+              x' calls )
+        | `Concrete _ ->
+          (* TODO: A: better simplification*)
+          ( f_xadd_simpl self' (f_xmuli_simpl cb_called' cb_cost'), calls)
+      ) cost.c_calls (f_x0, EcPath.Mx.empty) in
+
+    let c_self = f_xadd_simpl c_self self' in
+    cost_r c_self c_calls
+
+  (* ------------------------------------------------------------------ *)
+  let add_binding  = add_binding ~tx:(fun _ f -> f)
+  let add_bindings = add_bindings ~tx:(fun _ f -> f)
+
   (* ------------------------------------------------------------------ *)
   let f_subst ?(tx = fun _ f -> f) s =
     if is_subst_id s then identity else f_subst ~tx s
+
+  let subst_gty = subst_gty ~tx:(fun _ f -> f)
+  let subst_mty = subst_mty ~tx:(fun _ f -> f)
+  let subst_oi  = subst_oi ~tx:(fun _ f -> f)
 
   let f_subst_local x t =
     let s = f_bind_local f_subst_id x t in
@@ -1740,19 +2245,24 @@ module Fsubst = struct
       match f.f_node with
       | Flocal id ->
           (try Mid.find id s with Not_found -> f)
-      | _ -> f_map (fun ty -> ty) aux f)
+      | _ ->
+        (* TODO: (Adrien) is thit ok? *)
+        f_map (fun ty -> ty) aux f)
 
   let subst_local id f1 f2 =
     subst_locals (Mid.singleton id f1) f2
 
   (* ------------------------------------------------------------------ *)
-  let init_subst_tvar s =
+  let init_subst_tvar ?es_loc s =
     let sty = { ty_subst_id with ts_v = Mid.find_opt^~ s } in
     { f_subst_id with
-        fs_freshen = true; fs_sty = sty; fs_ty = ty_subst sty }
+      fs_freshen = true;
+      fs_sty = sty;
+      fs_ty = ty_subst sty;
+      fs_esloc = odfl Mid.empty es_loc; }
 
-  let subst_tvar s =
-    f_subst (init_subst_tvar s)
+  let subst_tvar ?es_loc s =
+    f_subst (init_subst_tvar ?es_loc s)
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecCoreGoal.ml
+++ b/src/ecCoreGoal.ml
@@ -58,6 +58,8 @@ and pt_head =
 | PTHandle of handle
 | PTLocal  of EcIdent.t
 | PTGlobal of EcPath.path * (ty list)
+| PTSchema of
+    EcPath.path * (ty list) * EcMemory.memtype * mem_pr list * (expr list)
 
 and pt_arg =
 | PAFormula of EcFol.form
@@ -238,12 +240,13 @@ let tc_error_lazy (penv : proofenv) ?(catchable = true) ?loc ?who msg =
   raise (TcError (mk_tcerror ~catchable ~penv ?loc (lazy (getmsg ()))))
 
 (* -------------------------------------------------------------------- *)
-type symkind = [`Lemma | `Operator | `Local]
+type symkind = [`Lemma | `Operator | `Local | `Schema]
 
 let tc_lookup_error pe ?loc ?who kind qs =
   let string_of_kind kind =
     match kind with
     | `Lemma    -> "lemma"
+    | `Schema   -> "schema"
     | `Operator -> "operator"
     | `Local    -> "local variable"
   in

--- a/src/ecCoreGoal.mli
+++ b/src/ecCoreGoal.mli
@@ -42,6 +42,7 @@ val eq_handle : handle -> handle -> bool
 (*   |  handle                     (formula associated to <handle>)     *)
 (*   |  local<id>                  (local hypothesis <id>)              *)
 (*   |  global<p,tyargs>           (global lemma <p<:tyargs>>)          *)
+(*   |  schema<p,tyargs,eargs>     (global schema <p<:tyargs>> eargs)   *)
 (*                                                                      *)
 (* pt-arg ::=                                                           *)
 (*   | formula                     (∀-elimination)                      *)
@@ -57,6 +58,8 @@ and pt_head =
 | PTHandle of handle
 | PTLocal  of EcIdent.t
 | PTGlobal of EcPath.path * (ty list)
+| PTSchema of
+    EcPath.path * (ty list) * EcMemory.memtype * mem_pr list * (expr list)
 
 and pt_arg =
 | PAFormula of EcFol.form
@@ -211,7 +214,7 @@ val tacuerror_exn :
   ?catchable:bool -> exn -> 'a
 
 (* -------------------------------------------------------------------- *)
-type symkind = [`Lemma | `Operator | `Local]
+type symkind = [`Lemma | `Operator | `Local | `Schema]
 
 val tc_lookup_error :
   proofenv -> ?loc:EcLocation.t -> ?who:string -> symkind -> qsymbol -> 'a

--- a/src/ecCoreLib.ml
+++ b/src/ecCoreLib.ml
@@ -89,6 +89,31 @@ module CI_Int = struct
   let p_int_le    = _Int "le"
   let p_int_lt    = _Int "lt"
   let p_int_edivz = _IntDiv "edivz"
+  let p_int_max   = _IntDiv "max"
+end
+
+(* -------------------------------------------------------------------- *)
+module CI_xint = struct
+  let i_Xint  = "Xint"
+  let p_Xint  = EcPath.pqname p_top i_Xint
+  let _Xint   = fun x -> EcPath.pqname p_Xint x
+  let mk_Xint = _Xint
+
+  let p_xint   = mk_Xint "xint"
+  let p_N      = mk_Xint "N"
+  let p_inf    = mk_Xint "Inf"
+  let p_xopp   = mk_Xint "xopp"
+  let p_xadd   = mk_Xint "xadd"
+  let p_xmul   = mk_Xint "xmul"
+  let p_is_inf = mk_Xint "is_inf"
+  let p_is_int = mk_Xint "is_int"
+
+  let p_choaretac = EcPath.pqname p_top "CHoareTactic"
+
+  let p_xle     = EcPath.pqname p_choaretac "xle"
+  let p_xmax    = EcPath.pqname p_choaretac "xmax"
+  let p_bigxint = EcPath.pqname p_choaretac "Bigxint"
+  let p_big     = EcPath.pqname p_bigxint "big"
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecCoreLib.mli
+++ b/src/ecCoreLib.mli
@@ -94,6 +94,24 @@ module CI_Int : sig
 end
 
 (* -------------------------------------------------------------------- *)
+module CI_xint : sig
+  val p_Xint      : path
+  val p_xint      : path
+  val p_N         : path
+  val p_inf       : path
+  val p_xopp      : path
+  val p_xadd      : path
+  val p_xmul      : path
+  val p_xle       : path
+  val p_xmax      : path
+  val p_is_int    : path
+  val p_is_inf    : path
+  val p_choaretac : path
+  val p_bigxint   : path
+  val p_big       : path
+end
+
+(* -------------------------------------------------------------------- *)
 module CI_Real : sig
   val i_Real : symbol
   val p_Real : path

--- a/src/ecCoreModules.ml
+++ b/src/ecCoreModules.ml
@@ -1,0 +1,961 @@
+(* --------------------------------------------------------------------
+ * Copyright (c) - 2012--2016 - IMDEA Software Institute
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
+ *
+ * Distributed under the terms of the CeCILL-C-V1 license
+ * -------------------------------------------------------------------- *)
+
+(* -------------------------------------------------------------------- *)
+open EcUtils
+open EcSymbols
+open EcTypes
+open EcPath
+
+module Sid = EcIdent.Sid
+module Mid = EcIdent.Mid
+
+(* -------------------------------------------------------------------- *)
+type lvalue =
+  | LvVar   of (EcTypes.prog_var * EcTypes.ty)
+  | LvTuple of (EcTypes.prog_var * EcTypes.ty) list
+
+let lv_equal lv1 lv2 =
+  match lv1, lv2 with
+  | LvVar (pv1, ty1), LvVar (pv2, ty2) ->
+         (EcTypes.pv_equal pv1 pv2)
+      && (EcTypes.ty_equal ty1 ty2)
+
+  | LvTuple tu1, LvTuple tu2 ->
+      List.all2
+        (fun (pv1, ty1) (pv2, ty2) ->
+             (EcTypes.pv_equal pv1 pv2)
+          && (EcTypes.ty_equal ty1 ty2))
+        tu1 tu2
+
+  | _, _ -> false
+
+(* -------------------------------------------------------------------- *)
+let lv_fv = function
+  | LvVar (pv, _) ->
+      EcTypes.pv_fv pv
+
+  | LvTuple pvs ->
+      let add s (pv, _) = EcIdent.fv_union s (EcTypes.pv_fv pv) in
+      List.fold_left add Mid.empty pvs
+
+let symbol_of_lv = function
+  | LvVar (pv, _) ->
+      EcTypes.symbol_of_pv pv
+
+  | LvTuple pvs ->
+      String.concat "" (List.map (EcTypes.symbol_of_pv |- fst) pvs)
+
+let ty_of_lv = function
+  | LvVar   (_, ty)       -> ty
+  | LvTuple tys           -> EcTypes.ttuple (List.map snd tys)
+
+let lv_of_list = function
+  | [] -> None
+  | [(pv, ty)] -> Some (LvVar (pv, ty))
+  | pvs -> Some (LvTuple pvs)
+
+(* -------------------------------------------------------------------- *)
+type instr = {
+  i_node : instr_node;
+  i_fv : int Mid.t;
+  i_tag  : int;
+}
+
+and instr_node =
+  | Sasgn     of lvalue * EcTypes.expr
+  | Srnd      of lvalue * EcTypes.expr
+  | Scall     of lvalue option * EcPath.xpath * EcTypes.expr list
+  | Sif       of EcTypes.expr * stmt * stmt
+  | Swhile    of EcTypes.expr * stmt
+  | Smatch    of expr * ((EcIdent.t * EcTypes.ty) list * stmt) list
+  | Sassert   of EcTypes.expr
+  | Sabstract of EcIdent.t
+
+and stmt = {
+  s_node : instr list;
+  s_fv   : int Mid.t;
+  s_tag  : int;
+}
+
+(* -------------------------------------------------------------------- *)
+let i_equal   = ((==) : instr -> instr -> bool)
+let i_hash    = fun i -> i.i_tag
+let i_compare = fun i1 i2 -> i_hash i1 - i_hash i2
+let i_fv i    = i.i_fv
+let i_node i  = i.i_node
+
+let s_equal   = ((==) : stmt -> stmt -> bool)
+let s_hash    = fun s -> s.s_tag
+let s_compare = fun s1 s2 -> s_hash s1 - s_hash s2
+let s_fv      = fun s -> s.s_fv
+
+(* -------------------------------------------------------------------- *)
+module Hinstr = Why3.Hashcons.Make (struct
+  type t = instr
+
+  let equal_node i1 i2 =
+    match i1, i2 with
+    | Sasgn (lv1, e1), Sasgn (lv2, e2) ->
+        (lv_equal lv1 lv2) && (EcTypes.e_equal e1 e2)
+
+    | Srnd (lv1, e1), Srnd (lv2, e2) ->
+        (lv_equal lv1 lv2) && (EcTypes.e_equal e1 e2)
+
+    | Scall (lv1, f1, es1), Scall (lv2, f2, es2) ->
+           (EcUtils.opt_equal lv_equal lv1 lv2)
+        && (EcPath.x_equal f1 f2)
+        && (List.all2 EcTypes.e_equal es1 es2)
+
+    | Sif (c1, s1, r1), Sif (c2, s2, r2) ->
+           (EcTypes.e_equal c1 c2)
+        && (s_equal s1 s2)
+        && (s_equal r1 r2)
+
+    | Swhile (c1, s1), Swhile (c2, s2) ->
+           (EcTypes.e_equal c1 c2)
+        && (s_equal s1 s2)
+
+    | Smatch (e1, b1), Smatch (e2, b2) when List.length b1 = List.length b2 ->
+        let forb (bs1, s1) (bs2, s2) =
+          let forbs (x1, ty1) (x2, ty2) =
+               EcIdent.id_equal x1  x2
+            && EcTypes.ty_equal ty1 ty2
+          in List.all2 forbs bs1 bs2 && s_equal s1 s2
+        in EcTypes.e_equal e1 e2 && List.all2 forb b1 b2
+
+    | Sassert e1, Sassert e2 ->
+        (EcTypes.e_equal e1 e2)
+
+    | Sabstract id1, Sabstract id2 -> EcIdent.id_equal id1 id2
+
+    | _, _ -> false
+
+  let equal i1 i2 = equal_node i1.i_node i2.i_node
+
+  let hash p =
+    match p.i_node with
+    | Sasgn (lv, e) ->
+        Why3.Hashcons.combine
+          (Hashtbl.hash lv) (EcTypes.e_hash e)
+
+    | Srnd (lv, e) ->
+        Why3.Hashcons.combine
+          (Hashtbl.hash lv) (EcTypes.e_hash e)
+
+    | Scall (lv, f, tys) ->
+        Why3.Hashcons.combine_list EcTypes.e_hash
+          (Why3.Hashcons.combine
+             (Hashtbl.hash lv) (EcPath.x_hash f))
+          tys
+
+    | Sif (c, s1, s2) ->
+        Why3.Hashcons.combine2
+          (EcTypes.e_hash c) (s_hash s1) (s_hash s2)
+
+    | Swhile (c, s) ->
+        Why3.Hashcons.combine (EcTypes.e_hash c) (s_hash s)
+
+    | Smatch (e, b) ->
+        let forb (bds, s) =
+          let forbs (x, ty) =
+            Why3.Hashcons.combine (EcIdent.id_hash x) (EcTypes.ty_hash ty)
+          in Why3.Hashcons.combine_list forbs (s_hash s) bds
+        in Why3.Hashcons.combine_list forb (EcTypes.e_hash e) b
+
+    | Sassert e -> EcTypes.e_hash e
+
+    | Sabstract id -> EcIdent.id_hash id
+
+  let i_fv   = function
+    | Sasgn (lv, e) ->
+        EcIdent.fv_union (lv_fv lv) (EcTypes.e_fv e)
+
+    | Srnd (lv, e) ->
+        EcIdent.fv_union (lv_fv lv) (EcTypes.e_fv e)
+
+    | Scall (olv, f, args) ->
+        let ffv = EcPath.x_fv Mid.empty f in
+        let ofv = olv |> omap lv_fv |> odfl Mid.empty in
+        List.fold_left
+          (fun s a -> EcIdent.fv_union s (EcTypes.e_fv a))
+          (EcIdent.fv_union ffv ofv) args
+
+    | Sif (e, s1, s2) ->
+        List.fold_left EcIdent.fv_union Mid.empty
+          [EcTypes.e_fv e; s_fv s1; s_fv s2]
+
+    | Swhile (e, s)  ->
+        EcIdent.fv_union (EcTypes.e_fv e) (s_fv s)
+
+    | Smatch (e, b) ->
+        let forb (bs, s) =
+          let bs = Sid.of_list (List.map fst bs) in
+          EcIdent.fv_diff (s_fv s) bs
+
+        in List.fold_left
+             (fun s b -> EcIdent.fv_union s (forb b))
+             (EcTypes.e_fv e) b
+
+    | Sassert e    ->
+        EcTypes.e_fv e
+
+    | Sabstract id ->
+        EcIdent.fv_singleton id
+
+  let tag n p = { p with i_tag = n; i_fv = i_fv p.i_node }
+end)
+
+(* -------------------------------------------------------------------- *)
+module Hstmt = Why3.Hashcons.Make (struct
+  type t = stmt
+
+  let equal_node s1 s2 =
+    List.all2 i_equal s1 s2
+
+  let equal s1 s2 = equal_node s1.s_node s2.s_node
+
+  let hash p =
+    Why3.Hashcons.combine_list i_hash 0 p.s_node
+
+  let tag n p =
+    let fv =
+      List.fold_left
+        (fun s i -> EcIdent.fv_union s (i_fv i))
+        Mid.empty p.s_node
+    in { p with s_tag = n; s_fv = fv; }
+end)
+
+(* -------------------------------------------------------------------- *)
+module MSHi = EcMaps.MakeMSH(struct type t = instr let tag i = i.i_tag end)
+module Si   = MSHi.S
+module Mi   = MSHi.M
+module Hi   = MSHi.H
+
+(* -------------------------------------------------------------------- *)
+let mk_instr i = Hinstr.hashcons
+  { i_node = i; i_tag = -1; i_fv = Mid.empty }
+
+let stmt s = Hstmt.hashcons
+  { s_node = s; s_tag = -1; s_fv = Mid.empty}
+
+let rstmt s = stmt (List.rev s)
+
+(* --------------------------------------------------------------------- *)
+let i_asgn     (lv, e)      = mk_instr (Sasgn (lv, e))
+let i_rnd      (lv, e)      = mk_instr (Srnd (lv, e))
+let i_call     (lv, m, tys) = mk_instr (Scall (lv, m, tys))
+let i_if       (c, s1, s2)  = mk_instr (Sif (c, s1, s2))
+let i_while    (c, s)       = mk_instr (Swhile (c, s))
+let i_match    (e, b)       = mk_instr (Smatch (e, b))
+let i_assert   e            = mk_instr (Sassert e)
+let i_abstract id           = mk_instr (Sabstract id)
+
+let s_seq      s1 s2        = stmt (s1.s_node @ s2.s_node)
+let s_empty                 = stmt []
+
+let s_asgn     arg = stmt [i_asgn arg]
+let s_rnd      arg = stmt [i_rnd arg]
+let s_call     arg = stmt [i_call arg]
+let s_if       arg = stmt [i_if arg]
+let s_while    arg = stmt [i_while arg]
+let s_match    arg = stmt [i_match arg]
+let s_assert   arg = stmt [i_assert arg]
+let s_abstract arg = stmt [i_abstract arg]
+
+(* -------------------------------------------------------------------- *)
+let get_asgn = function
+  | { i_node = Sasgn (lv, e) } -> Some (lv, e)
+  | _ -> None
+
+let get_rnd = function
+  | { i_node = Srnd (lv, e) } -> Some (lv, e)
+  | _ -> None
+
+let get_call = function
+  | { i_node = Scall (lv, f, fs) } -> Some (lv, f, fs)
+  | _ -> None
+
+let get_if = function
+  | { i_node = Sif (e, s1, s2) } -> Some (e, s1, s2)
+  | _ -> None
+
+let get_while = function
+  | { i_node = Swhile (e, s) } -> Some (e, s)
+  | _ -> None
+
+let get_match = function
+  | { i_node = Smatch (e, b) } -> Some (e, b)
+  | _ -> None
+
+let get_assert = function
+  | { i_node = Sassert e } -> Some e
+  | _ -> raise Not_found
+
+(* -------------------------------------------------------------------- *)
+let _destr_of_get (get : instr -> 'a option) (i : instr) =
+  match get i with Some x -> x | None -> raise Not_found
+
+let destr_asgn   = _destr_of_get get_asgn
+let destr_rnd    = _destr_of_get get_rnd
+let destr_call   = _destr_of_get get_call
+let destr_if     = _destr_of_get get_if
+let destr_while  = _destr_of_get get_while
+let destr_match  = _destr_of_get get_match
+let destr_assert = _destr_of_get get_assert
+
+(* -------------------------------------------------------------------- *)
+let _is_of_get (get : instr -> 'a option) (i : instr) =
+  EcUtils.is_some (get i)
+
+let is_asgn   = _is_of_get get_asgn
+let is_rnd    = _is_of_get get_rnd
+let is_call   = _is_of_get get_call
+let is_if     = _is_of_get get_if
+let is_while  = _is_of_get get_while
+let is_match  = _is_of_get get_match
+let is_assert = _is_of_get get_assert
+
+(* -------------------------------------------------------------------- *)
+module ISmart : sig
+  type lv_var   = EcTypes.prog_var * EcTypes.ty
+  type lv_tuple = lv_var list
+
+  val lv_var   : lvalue * lv_var   -> lv_var   -> lvalue
+  val lv_tuple : lvalue * lv_tuple -> lv_tuple -> lvalue
+
+  type i_asgn     = lvalue * EcTypes.expr
+  type i_rnd      = lvalue * EcTypes.expr
+  type i_call     = lvalue option * EcPath.xpath * EcTypes.expr list
+  type i_if       = EcTypes.expr * stmt * stmt
+  type i_while    = EcTypes.expr * stmt
+  type i_match    = EcTypes.expr * ((EcIdent.t * ty) list * stmt) list
+  type i_assert   = EcTypes.expr
+  type i_abstract = EcIdent.t
+
+  val i_asgn     : (instr * i_asgn    ) -> i_asgn     -> instr
+  val i_rnd      : (instr * i_rnd     ) -> i_rnd      -> instr
+  val i_call     : (instr * i_call    ) -> i_call     -> instr
+  val i_if       : (instr * i_if      ) -> i_if       -> instr
+  val i_while    : (instr * i_while   ) -> i_while    -> instr
+  val i_match    : (instr * i_match   ) -> i_match    -> instr
+  val i_assert   : (instr * i_assert  ) -> i_assert   -> instr
+  val i_abstract : (instr * i_abstract) -> i_abstract -> instr
+
+  val s_stmt : stmt -> instr list -> stmt
+end = struct
+  type lv_var   = EcTypes.prog_var * EcTypes.ty
+  type lv_tuple = lv_var list
+
+  type i_asgn     = lvalue * EcTypes.expr
+  type i_rnd      = lvalue * EcTypes.expr
+  type i_call     = lvalue option * EcPath.xpath * EcTypes.expr list
+  type i_if       = EcTypes.expr * stmt * stmt
+  type i_while    = EcTypes.expr * stmt
+  type i_match    = EcTypes.expr * ((EcIdent.t * ty) list * stmt) list
+  type i_assert   = EcTypes.expr
+  type i_abstract = EcIdent.t
+
+  let lv_var (lv, pvt) pvt' =
+    if pvt == pvt' then lv else LvVar pvt'
+
+  let lv_tuple (lv, pvs) pvs' =
+    if pvs == pvs' then lv else LvTuple pvs'
+
+  let i_asgn (i, (lv, e)) (lv', e') =
+    if lv == lv' && e == e' then i else i_asgn (lv', e')
+
+  let i_rnd (i, (lv, e)) (lv', e') =
+    if lv == lv' && e == e' then i else i_rnd (lv', e')
+
+  let i_call (i, (olv, mp, args)) (olv', mp', args') =
+    if   olv == olv' && mp == mp' && args == args'
+    then i else  i_call (olv', mp', args')
+
+  let i_if (i, (e, s1, s2)) (e', s1', s2') =
+    if   e == e' && s1 == s1' && s2 == s2'
+    then i else i_if (e', s1', s2')
+
+  let i_while (i, (e, s)) (e', s') =
+    if e == e' && s == s' then i else i_while (e', s')
+
+  let i_match (i, (e, b)) (e', b') =
+    if e == e' && b == b' then i else i_match (e', b')
+
+  let i_assert (i, e) e' =
+    if e == e' then i else i_assert e'
+
+  let i_abstract (i, x) x' =
+    if x == x' then i else i_abstract x
+
+  let s_stmt s is' =
+    if s.s_node == is' then s else stmt is'
+end
+
+(* -------------------------------------------------------------------- *)
+let rec s_subst_top (s : EcTypes.e_subst) =
+  let e_subst = EcTypes.e_subst s in
+
+  if e_subst == identity then identity else
+
+  let pvt_subst (pv,ty as p) =
+    let pv' = EcTypes.pv_subst s.EcTypes.es_xp pv in
+    let ty' = s.EcTypes.es_ty ty in
+
+    if pv == pv' && ty == ty' then p else (pv', ty') in
+
+  let lv_subst lv =
+    match lv with
+    | LvVar pvt ->
+        ISmart.lv_var (lv, pvt) (pvt_subst pvt)
+
+    | LvTuple pvs ->
+        let pvs' = List.Smart.map pvt_subst pvs in
+        ISmart.lv_tuple (lv, pvs) pvs'
+
+  in
+
+  let rec i_subst i =
+    match i.i_node with
+    | Sasgn (lv, e) ->
+        ISmart.i_asgn (i, (lv, e)) (lv_subst lv, e_subst e)
+
+    | Srnd (lv, e) ->
+        ISmart.i_rnd (i, (lv, e)) (lv_subst lv, e_subst e)
+
+    | Scall (olv, mp, args) ->
+        let olv'  = olv |> OSmart.omap lv_subst in
+        let mp'   = s.EcTypes.es_xp mp in
+        let args' = List.Smart.map e_subst args in
+
+        ISmart.i_call (i, (olv, mp, args)) (olv', mp', args')
+
+    | Sif (e, s1, s2) ->
+        ISmart.i_if (i, (e, s1, s2))
+          (e_subst e, s_subst s1, s_subst s2)
+
+    | Swhile(e, b) ->
+        ISmart.i_while (i, (e, b)) (e_subst e, s_subst b)
+
+    | Smatch (e, b) ->
+        let forb ((xs, subs) as b1) =
+          let s, xs' = EcTypes.add_locals s xs in
+          let subs'  = s_subst_top s subs in
+          if xs == xs' && subs == subs' then b1 else (xs', subs')
+        in
+
+        ISmart.i_match (i, (e, b)) (e_subst e, List.Smart.map forb b)
+
+    | Sassert e ->
+        ISmart.i_assert (i, e) (e_subst e)
+
+    | Sabstract _ ->
+        i
+
+  and s_subst s =
+    ISmart.s_stmt s (List.Smart.map i_subst s.s_node)
+
+  in s_subst
+
+let s_subst = s_subst_top
+
+(* -------------------------------------------------------------------- *)
+module Uninit = struct    (* FIXME: generalize this for use in ecPV *)
+  let e_pv e =
+    let rec e_pv sid e =
+      match e.e_node with
+      | Evar (PVglob _) -> sid
+      | Evar (PVloc id) -> Ssym.add id sid
+      | _               -> e_fold e_pv sid e in
+
+    e_pv Ssym.empty e
+end
+
+let rec lv_get_uninit_read (w : Ssym.t) (lv : lvalue) =
+  let sx_of_pv pv = match pv with
+    | PVloc v -> Ssym.singleton v
+    | PVglob _ -> Ssym.empty
+  in
+
+  match lv with
+  | LvVar (x, _) ->
+      Ssym.union (sx_of_pv x) w
+
+  | LvTuple xs ->
+      let w' = List.map (sx_of_pv |- fst) xs in
+      Ssym.big_union (w :: w')
+
+and s_get_uninit_read (w : Ssym.t) (s : stmt) =
+  let do1 (w, r) i =
+    let w, r' = i_get_uninit_read w i in
+    (w, Ssym.union r r')
+
+  in List.fold_left do1 (w, Ssym.empty) s.s_node
+
+and i_get_uninit_read (w : Ssym.t) (i : instr) =
+  match i.i_node with
+  | Sasgn (lv, e) | Srnd (lv, e) ->
+      let r1 = Ssym.diff (Uninit.e_pv e) w in
+      let w2 = lv_get_uninit_read w lv in
+      (Ssym.union w w2, r1)
+
+  | Scall (olv, _, args) ->
+      let r1 = Ssym.diff (Ssym.big_union (List.map (Uninit.e_pv) args)) w in
+      let w = olv |> omap (lv_get_uninit_read w) |> odfl w in
+      (w, r1)
+
+  | Sif (e, s1, s2) ->
+      let r = Ssym.diff (Uninit.e_pv e) w in
+      let w1, r1 = s_get_uninit_read w s1 in
+      let w2, r2 = s_get_uninit_read w s2 in
+      (Ssym.union w (Ssym.inter w1 w2), Ssym.big_union [r; r1; r2])
+
+  | Swhile (e, s) ->
+      let r  = Ssym.diff (Uninit.e_pv e) w in
+      let rs = snd (s_get_uninit_read w s) in
+      (w, Ssym.union r rs)
+
+  | Smatch (e, bs) ->
+      let r   = Ssym.diff (Uninit.e_pv e) w in
+      let wrs = List.map (fun (_, b) -> s_get_uninit_read w b) bs in
+      let ws, rs = List.split wrs in
+      (Ssym.union w (Ssym.big_inter ws), Ssym.big_union (r :: rs))
+
+  | Sassert e ->
+      (w, Ssym.diff (Uninit.e_pv e) w)
+
+  | Sabstract (_ : EcIdent.t) ->
+      (w, Ssym.empty)
+
+let get_uninit_read (s : stmt) =
+  snd (s_get_uninit_read Ssym.empty s)
+
+(* -------------------------------------------------------------------- *)
+type 'a use_restr = {
+  ur_pos : 'a option;   (* If not None, can use only element in this set. *)
+  ur_neg : 'a;          (* Cannot use element in this set. *)
+}
+
+let ur_app f a =
+  { ur_pos = (omap f) a.ur_pos;
+    ur_neg = f a.ur_neg; }
+
+(* Noting is restricted. *)
+let ur_empty emp = { ur_pos = None; ur_neg = emp; }
+
+(* Everything is restricted. *)
+let ur_full emp = { ur_pos = Some emp; ur_neg = emp; }
+
+let ur_pos_subset subset ur1 ur2 = match ur1,ur2 with
+  | _, None -> true             (* Indeed, [None] means everybody. *)
+  | None, Some _ -> false
+  | Some s1, Some s2 -> subset s1 s2
+
+let ur_equal (equal : 'a -> 'a -> bool) ur1 ur2 =
+  equal ur1.ur_neg ur2.ur_neg
+  && (opt_equal equal) ur1.ur_pos ur2.ur_pos
+
+(* Union for negative restrictions, intersection for positive ones.
+   [None] stands for everybody. *)
+let ur_union union inter ur1 ur2 =
+  let ur_pos = match ur1.ur_pos, ur2.ur_pos with
+    | None, None -> None
+    | None, Some s | Some s, None -> Some s
+    | Some s1, Some s2 -> some @@ inter s1 s2 in
+
+  { ur_pos = ur_pos;
+    ur_neg = union ur1.ur_neg ur2.ur_neg; }
+
+(* Converse of ur_union. *)
+let ur_inter union inter ur1 ur2 =
+  let ur_pos = match ur1.ur_pos, ur2.ur_pos with
+    | None, _ | _, None -> None
+    | Some s1, Some s2 -> some @@ union s1 s2 in
+
+  { ur_pos = ur_pos;
+    ur_neg = inter ur1.ur_neg ur2.ur_neg; }
+
+(* -------------------------------------------------------------------- *)
+(* Oracle information of a procedure [M.f]. *)
+module PreOI : sig
+  type 'a t
+
+  val hash : ('a -> int) -> 'a t -> int
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val is_in : 'a t -> bool
+
+  val cost_self : 'a t -> [`Bounded of 'a | `Unbounded]
+  val cost : 'a t -> xpath -> [`Bounded of 'a | `Zero | `Unbounded]
+  val cost_calls : 'a t -> [`Bounded of 'a Mx.t | `Unbounded]
+  val costs : 'a t -> [`Bounded of 'a * 'a Mx.t | `Unbounded]
+
+  val allowed : 'a t -> xpath list
+  val allowed_s : 'a t -> Sx.t
+
+  val mk : xpath list -> bool -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
+  (* val change_calls : 'a t -> xpath list -> 'a t *)
+  val filter : (xpath -> bool) -> 'a t -> 'a t
+end = struct
+  (* Oracle information of a procedure [M.f]:
+   * - oi_calls : list of oracles that can be called by [M.f].
+   * - oi_in    : true if equality of globals is required to ensure
+   * equality of result and globals (in the post).
+   * - oi_costs : self cost, plus a mapping from oracles to the number of time
+   * that they can be called by [M.f]. Missing entries are can be called
+   * zero times. No restrictio of [None]
+   *
+   * Remark: there is redundancy between oi_calls and oi_costs. *)
+  type 'a t = {
+    oi_calls : xpath list;
+    oi_in    : bool;
+    oi_costs : ('a * 'a Mx.t) option;
+  }
+
+  let is_in t = t.oi_in
+
+  let allowed oi = oi.oi_calls
+
+  let allowed_s oi = allowed oi |> Sx.of_list
+
+  let cost_self (oi : 'a t) =
+    omap_dfl (fun (self,_) -> `Bounded self) `Unbounded oi.oi_costs
+
+  let cost (oi : 'a t) (x : xpath) =
+    omap_dfl (fun (_,oi) ->
+        let c = Mx.find_opt x oi in
+        omap_dfl (fun c -> `Bounded c) `Zero c)
+      `Unbounded oi.oi_costs
+
+  let cost_calls oi = omap_dfl (fun (_,x) -> `Bounded x) `Unbounded oi.oi_costs
+
+  let costs oi = omap_dfl (fun x -> `Bounded x) `Unbounded oi.oi_costs
+
+  let mk oi_calls oi_in oi_costs = match oi_costs with
+    | `Bounded oi_costs ->
+      { oi_calls; oi_in; oi_costs = Some (oi_costs) ; }
+    | `Unbounded ->
+      { oi_calls; oi_in; oi_costs = None; }
+
+  (* let change_calls oi calls =
+   *   mk calls oi.oi_in
+   *     (Mx.filter (fun x _ -> List.mem x calls) oi.oi_costs) *)
+
+  let filter f oi =
+    let costs = match oi.oi_costs with
+      | Some (self,costs) -> `Bounded (self, Mx.filter (fun x _ -> f x) costs)
+      | None -> `Unbounded in
+    mk (List.filter f oi.oi_calls) oi.oi_in costs
+
+  let equal a_equal oi1 oi2 =
+    let check_costs_eq c1 c2 =
+      match c1,c2 with
+      | None, None -> true
+      | Some _, None | None, Some _ -> false
+      | Some (s1,c1), Some (s2,c2) ->
+        let exception Not_equal in
+        try Mx.fold2_union (fun _ a b () -> match a, b with
+            | Some _, None | None, Some _ -> raise Not_equal
+            | None, None -> ()
+            | Some a, Some b -> if a_equal a b then () else raise Not_equal
+          ) c1 c2 ();
+          a_equal s1 s2
+        with Not_equal -> false in
+
+    oi1.oi_in = oi2.oi_in
+    && List.all2 EcPath.x_equal oi1.oi_calls oi1.oi_calls
+    && check_costs_eq oi1.oi_costs oi2.oi_costs
+
+  let hash ahash oi =
+    let costs_hash =
+      Why3.Hashcons.combine_option (fun (self,costs) ->
+          (Why3.Hashcons.combine_list
+             (Why3.Hashcons.combine_pair EcPath.x_hash ahash)
+             (ahash self) (Mx.bindings costs))) oi.oi_costs in
+
+    Why3.Hashcons.combine2
+      (if oi.oi_in then 0 else 1)
+      (Why3.Hashcons.combine_list EcPath.x_hash 0
+         (List.sort EcPath.x_compare oi.oi_calls))
+      costs_hash
+end
+
+(* -------------------------------------------------------------------- *)
+type mr_xpaths = EcPath.Sx.t use_restr
+
+type mr_mpaths = EcPath.Sm.t use_restr
+
+type 'a p_mod_restr = {
+  mr_xpaths : mr_xpaths;
+  mr_mpaths : mr_mpaths;
+  mr_oinfos : 'a PreOI.t Msym.t;
+}
+
+let p_mr_equal a_equal mr1 mr2 =
+  ur_equal EcPath.Sx.equal mr1.mr_xpaths mr2.mr_xpaths
+  && ur_equal EcPath.Sm.equal mr1.mr_mpaths mr2.mr_mpaths
+  && Msym.equal (PreOI.equal a_equal) mr1.mr_oinfos mr2.mr_oinfos
+
+let has_compl_restriction mr =
+  Msym.exists (fun _ oi ->
+      (PreOI.costs oi) <> `Unbounded
+    ) mr.mr_oinfos
+
+let mr_xpaths_fv (m : mr_xpaths) : int Mid.t =
+  EcPath.Sx.fold
+    (fun xp fv -> EcPath.x_fv fv xp)
+    (Sx.union
+       m.ur_neg
+       (EcUtils.odfl Sx.empty m.ur_pos))
+    EcIdent.Mid.empty
+
+let mr_mpaths_fv (m : mr_mpaths) : int Mid.t =
+  EcPath.Sm.fold
+    (fun mp fv -> EcPath.m_fv fv mp)
+    (Sm.union
+       m.ur_neg
+       (EcUtils.odfl Sm.empty m.ur_pos))
+    EcIdent.Mid.empty
+
+(* -------------------------------------------------------------------- *)
+type funsig = {
+  fs_name   : symbol;
+  fs_arg    : EcTypes.ty;
+  fs_anames : variable list option;
+  fs_ret    : EcTypes.ty;
+}
+
+let fs_equal f1 f2 =
+    (EcUtils.opt_equal (List.all2 EcTypes.v_equal) f1.fs_anames f2.fs_anames)
+    && (EcTypes.ty_equal f1.fs_ret f2.fs_ret)
+    && (EcTypes.ty_equal f1.fs_arg f2.fs_arg)
+    && (EcSymbols.sym_equal f1.fs_name f2.fs_name)
+
+(* -------------------------------------------------------------------- *)
+type 'a p_module_type = {
+  mt_params : (EcIdent.t * 'a p_module_type) list;
+  mt_name   : EcPath.path;
+  mt_args   : EcPath.mpath list;
+  mt_restr  : 'a p_mod_restr;
+}
+
+type module_sig_body_item = Tys_function of funsig
+
+type module_sig_body = module_sig_body_item list
+
+type 'a p_module_sig = {
+  mis_params : (EcIdent.t * 'a p_module_type) list;
+  mis_body   : module_sig_body;
+  mis_restr  : 'a p_mod_restr;
+}
+
+type 'a p_top_module_sig = {
+  tms_sig  : 'a p_module_sig;
+  tms_loca : is_local;
+}
+
+(* -------------------------------------------------------------------- *)
+(* Simple module signature, without restrictions. *)
+type 'a p_module_smpl_sig = {
+  miss_params : (EcIdent.t * 'a p_module_type) list;
+  miss_body   : module_sig_body;
+}
+
+let sig_smpl_sig_coincide msig smpl_sig =
+  let eqparams =
+    List.for_all2 EcIdent.id_equal
+      (List.map fst msig.mis_params)
+      (List.map fst smpl_sig.miss_params) in
+
+  let ls =
+    List.map (fun (Tys_function fs) -> fs.fs_name, fs ) msig.mis_body
+    |> EcSymbols.Msym.of_list
+  and ls_smpl =
+    List.map (fun (Tys_function fs) -> fs.fs_name, fs ) smpl_sig.miss_body
+    |> EcSymbols.Msym.of_list in
+  let eqsig =
+    Msym.fold2_union (fun _ aopt bopt eqsig -> match aopt, bopt with
+        | Some fs1, Some fs2 -> (fs_equal fs1 fs2) && eqsig
+        | _ -> false)  ls_smpl ls true; in
+
+  eqparams && eqsig
+
+(* -------------------------------------------------------------------- *)
+type uses = {
+  us_calls  : xpath list;
+  us_reads  : Sx.t;
+  us_writes : Sx.t;
+}
+
+let mk_uses c r w =
+  let map s = Sx.fold (fun x s ->
+      Sx.change
+        (fun b -> assert (not b); true)
+        (EcTypes.xp_glob x) s) s Sx.empty in
+  {us_calls = c; us_reads = map r; us_writes = map w }
+
+(* -------------------------------------------------------------------- *)
+type function_def = {
+  f_locals : variable list;
+  f_body   : stmt;
+  f_ret    : EcTypes.expr option;
+  f_uses   : uses;
+}
+
+let fd_equal f1 f2 =
+     (s_equal f1.f_body f2.f_body)
+  && (EcUtils.opt_equal EcTypes.e_equal f1.f_ret f2.f_ret)
+  && (List.all2 EcTypes.v_equal f1.f_locals f2.f_locals)
+
+let fd_hash f =
+  Why3.Hashcons.combine2
+    (s_hash f.f_body)
+    (Why3.Hashcons.combine_option EcTypes.e_hash f.f_ret)
+    (Why3.Hashcons.combine_list EcTypes.v_hash 0 f.f_locals)
+
+(* -------------------------------------------------------------------- *)
+type 'a p_function_body =
+| FBdef   of function_def
+| FBalias of xpath
+| FBabs   of 'a PreOI.t
+
+type 'a p_function_ = {
+  f_name   : symbol;
+  f_sig    : funsig;
+  f_def    : 'a p_function_body;
+}
+
+(* -------------------------------------------------------------------- *)
+type abs_uses = {
+  aus_calls  : EcPath.xpath list;
+  aus_reads  : (EcTypes.prog_var * EcTypes.ty) list;
+  aus_writes : (EcTypes.prog_var * EcTypes.ty) list;
+}
+
+type 'a p_module_expr = {
+  me_name     : symbol;
+  me_body     : 'a p_module_body;
+  me_comps    : 'a p_module_comps;
+  me_sig_body : module_sig_body;
+  me_params   : (EcIdent.t * 'a p_module_type) list;
+}
+
+(* Invariant:
+   In an abstract module [ME_Decl mt], [mt] must not be a functor, i.e. it must
+   be fully applied. Therefore, we must have:
+   [List.length mp.mt_params = List.length mp.mt_args]  *)
+and 'a p_module_body =
+  | ME_Alias       of int * EcPath.mpath
+  | ME_Structure   of 'a p_module_structure       (* Concrete modules. *)
+  | ME_Decl        of 'a p_module_type         (* Abstract modules. *)
+
+and 'a p_module_structure = {
+  ms_body      : 'a p_module_item list;
+}
+
+and 'a p_module_item =
+  | MI_Module   of 'a p_module_expr
+  | MI_Variable of variable
+  | MI_Function of 'a p_function_
+
+and 'a p_module_comps = 'a p_module_comps_item list
+
+and 'a p_module_comps_item = 'a p_module_item
+
+type 'a p_top_module_expr = {
+  tme_expr : 'a p_module_expr;
+  tme_loca : locality;
+}
+
+(* -------------------------------------------------------------------- *)
+let ur_hash elems el_hash ur =
+  Why3.Hashcons.combine
+    (Why3.Hashcons.combine_option
+       (fun l -> Why3.Hashcons.combine_list el_hash 0 (elems l))
+       ur.ur_pos)
+    (Why3.Hashcons.combine_list el_hash 0
+       (elems ur.ur_neg))
+
+let p_mr_hash a_hash mr =
+  Why3.Hashcons.combine2
+    (ur_hash EcPath.Sx.ntr_elements EcPath.x_hash mr.mr_xpaths)
+    (ur_hash EcPath.Sm.ntr_elements EcPath.m_hash mr.mr_mpaths)
+    (Why3.Hashcons.combine_list
+       (Why3.Hashcons.combine_pair Hashtbl.hash (PreOI.hash a_hash)) 0
+       (EcSymbols.Msym.bindings mr.mr_oinfos
+        |> List.sort (fun (s,_) (s',_) -> EcSymbols.sym_compare s s')))
+
+let p_mty_hash a_hash mty =
+  Why3.Hashcons.combine3
+    (EcPath.p_hash mty.mt_name)
+    (Why3.Hashcons.combine_list
+       (fun (x, _) -> EcIdent.id_hash x)
+       0 mty.mt_params)
+    (Why3.Hashcons.combine_list EcPath.m_hash 0 mty.mt_args)
+    (p_mr_hash a_hash mty.mt_restr)
+
+let rec p_mty_equal a_equal mty1 mty2 =
+     (EcPath.p_equal mty1.mt_name mty2.mt_name)
+  && (List.all2 EcPath.m_equal mty1.mt_args mty2.mt_args)
+  && (List.all2 (pair_equal EcIdent.id_equal (p_mty_equal a_equal))
+        mty1.mt_params mty2.mt_params)
+  && (p_mr_equal a_equal mty1.mt_restr mty2.mt_restr)
+
+(* -------------------------------------------------------------------- *)
+let get_uninit_read_of_fun (f : _ p_function_) =
+  match f.f_def with
+  | FBalias _ | FBabs _ -> Ssym.empty
+
+  | FBdef fd ->
+      let w =
+        let toloc { v_name = x } = x in
+        let w = List.map toloc (f.f_sig.fs_anames |> odfl []) in
+        Ssym.of_list w
+      in
+
+      let w, r  = s_get_uninit_read w fd.f_body in
+      let raout = fd.f_ret |> omap (Uninit.e_pv) in
+      let raout = Ssym.diff (raout |> odfl Ssym.empty) w in
+      Ssym.union r raout
+
+(* -------------------------------------------------------------------- *)
+let get_uninit_read_of_module (p : path) (me : _ p_module_expr) =
+  let rec doit_me acc (mp, me) =
+    match me.me_body with
+    | ME_Alias     _  -> acc
+    | ME_Decl      _  -> acc
+    | ME_Structure mb -> doit_mb acc (mp, mb)
+
+  and doit_mb acc (mp, mb) =
+    List.fold_left
+      (fun acc item -> doit_mb1 acc (mp, item))
+      acc mb.ms_body
+
+  and doit_mb1 acc (mp, item) =
+    match item with
+    | MI_Module subme ->
+        doit_me acc (EcPath.mqname mp subme.me_name, subme)
+
+    | MI_Variable _ ->
+        acc
+
+    | MI_Function f ->
+        let xp = xpath mp f.f_name in
+        let r  = get_uninit_read_of_fun f in
+        if Ssym.is_empty r then acc else (xp, r) :: acc
+
+  in
+
+  let mp =
+    let margs =
+      List.map
+        (fun (x, _) -> EcPath.mpath_abs x [])
+        me.me_params
+    in EcPath.mpath_crt (EcPath.pqname p me.me_name) margs None
+
+  in List.rev (doit_me [] (mp, me))

--- a/src/ecCoreModules.mli
+++ b/src/ecCoreModules.mli
@@ -1,0 +1,298 @@
+(* --------------------------------------------------------------------
+ * Copyright (c) - 2012--2016 - IMDEA Software Institute
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
+ *
+ * Distributed under the terms of the CeCILL-C-V1 license
+ * -------------------------------------------------------------------- *)
+
+(* -------------------------------------------------------------------- *)
+open EcSymbols
+open EcPath
+open EcTypes
+
+(* -------------------------------------------------------------------- *)
+type lvalue =
+  | LvVar   of (prog_var * ty)
+  | LvTuple of (prog_var * ty) list
+
+val lv_equal     : lvalue -> lvalue -> bool
+val symbol_of_lv : lvalue -> symbol
+val ty_of_lv     : lvalue -> EcTypes.ty
+val lv_of_list   : (prog_var * ty) list -> lvalue option
+
+(* --------------------------------------------------------------------- *)
+type instr = private {
+  i_node : instr_node;
+  i_fv   : int EcIdent.Mid.t;
+  i_tag  : int;
+}
+
+and instr_node =
+  | Sasgn     of lvalue * expr
+  | Srnd      of lvalue * expr
+  | Scall     of lvalue option * xpath * expr list
+  | Sif       of expr * stmt * stmt
+  | Swhile    of expr * stmt
+  | Smatch    of expr * ((EcIdent.t * EcTypes.ty) list * stmt) list
+  | Sassert   of expr
+  | Sabstract of EcIdent.t
+
+and stmt = private {
+  s_node : instr list;
+  s_fv   : int EcIdent.Mid.t;
+  s_tag  : int;
+}
+
+(* -------------------------------------------------------------------- *)
+val i_equal   : instr -> instr -> bool
+val i_compare : instr -> instr -> int
+val i_hash    : instr -> int
+val i_fv      : instr -> int EcIdent.Mid.t
+val i_node    : instr -> instr_node
+
+val s_equal   : stmt -> stmt -> bool
+val s_compare : stmt -> stmt -> int
+val s_hash    : stmt -> int
+val s_fv      : stmt -> int EcIdent.Mid.t
+val s_subst   : e_subst -> stmt -> stmt
+
+(* -------------------------------------------------------------------- *)
+val i_asgn     : lvalue * expr -> instr
+val i_rnd      : lvalue * expr -> instr
+val i_call     : lvalue option * xpath * expr list -> instr
+val i_if       : expr * stmt * stmt -> instr
+val i_while    : expr * stmt -> instr
+val i_match    : expr * ((EcIdent.t * ty) list * stmt) list -> instr
+val i_assert   : expr -> instr
+val i_abstract : EcIdent.t -> instr
+
+val s_asgn     : lvalue * expr -> stmt
+val s_rnd      : lvalue * expr -> stmt
+val s_call     : lvalue option * xpath * expr list -> stmt
+val s_if       : expr * stmt * stmt -> stmt
+val s_while    : expr * stmt -> stmt
+val s_match    : expr * ((EcIdent.t * ty) list * stmt) list -> stmt
+val s_assert   : expr -> stmt
+val s_abstract : EcIdent.t -> stmt
+val s_seq      : stmt -> stmt -> stmt
+val s_empty    : stmt
+
+val stmt  : instr list -> stmt
+val rstmt : instr list -> stmt
+
+(* the following functions raise Not_found if the argument does not match *)
+val destr_asgn   : instr -> lvalue * expr
+val destr_rnd    : instr -> lvalue * expr
+val destr_call   : instr -> lvalue option * xpath * expr list
+val destr_if     : instr -> expr * stmt * stmt
+val destr_while  : instr -> expr * stmt
+val destr_match  : instr -> expr * ((EcIdent.t * ty) list * stmt) list
+val destr_assert : instr -> expr
+
+val is_asgn   : instr -> bool
+val is_rnd    : instr -> bool
+val is_call   : instr -> bool
+val is_if     : instr -> bool
+val is_while  : instr -> bool
+val is_match  : instr -> bool
+val is_assert : instr -> bool
+
+(* -------------------------------------------------------------------- *)
+val get_uninit_read : stmt -> Sx.t
+
+(* -------------------------------------------------------------------- *)
+type funsig = {
+  fs_name   : symbol;
+  fs_arg    : EcTypes.ty;
+  fs_anames : variable list option;
+  fs_ret    : EcTypes.ty;
+}
+
+val fs_equal : funsig -> funsig -> bool
+
+(* -------------------------------------------------------------------- *)
+type 'a use_restr = {
+  ur_pos : 'a option;   (* If not None, can use only element in this set. *)
+  ur_neg : 'a;          (* Cannot use element in this set. *)
+}
+
+val ur_empty : 'a -> 'a use_restr
+val ur_full  : 'a -> 'a use_restr
+val ur_app   : ('a -> 'b) -> 'a use_restr -> 'b use_restr
+val ur_equal : ('a -> 'a -> bool) -> 'a use_restr -> 'a use_restr -> bool
+
+(* Correctly handles the [None] cases for subset comparison. *)
+val ur_pos_subset : ('a -> 'a -> bool) -> 'a option -> 'a option -> bool
+val ur_union :
+  ('a -> 'a -> 'a) ->
+  ('a -> 'a -> 'a) ->
+  'a use_restr -> 'a use_restr -> 'a use_restr
+
+(* -------------------------------------------------------------------- *)
+(* Oracle information of a procedure [M.f]. *)
+module PreOI : sig
+  type 'a t
+
+  val hash : ('a -> int) -> 'a t -> int
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+  val is_in : 'a t -> bool
+
+  val cost_self : 'a t -> [`Bounded of 'a | `Unbounded]
+  val cost : 'a t -> xpath -> [`Bounded of 'a | `Zero | `Unbounded]
+  val cost_calls : 'a t -> [`Bounded of 'a Mx.t | `Unbounded]
+  val costs : 'a t -> [`Bounded of 'a * 'a Mx.t | `Unbounded]
+
+  val allowed : 'a t -> xpath list
+  val allowed_s : 'a t -> Sx.t
+
+  val mk : xpath list -> bool -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
+  (* val change_calls : 'a t -> xpath list -> 'a t *)
+  val filter : (xpath -> bool) -> 'a t -> 'a t
+end
+
+(* -------------------------------------------------------------------- *)
+
+type mr_xpaths = EcPath.Sx.t use_restr
+
+type mr_mpaths = EcPath.Sm.t use_restr
+
+type 'a p_mod_restr = {
+  mr_xpaths : mr_xpaths;
+  mr_mpaths : mr_mpaths;
+  mr_oinfos : 'a PreOI.t Msym.t;
+}
+
+val p_mr_equal :
+  ('a -> 'a -> bool) ->
+  'a p_mod_restr ->
+  'a p_mod_restr ->
+  bool
+
+val p_mr_hash : ('a -> int) -> 'a p_mod_restr -> int
+
+val has_compl_restriction : 'a p_mod_restr -> bool
+
+val mr_xpaths_fv : mr_xpaths -> int EcIdent.Mid.t
+val mr_mpaths_fv : mr_mpaths -> int EcIdent.Mid.t
+
+(* -------------------------------------------------------------------- *)
+(* An oracle in a function provided by a module parameter of a functor *)
+type 'a p_module_type = {          (* Always in eta-normal form *)
+  mt_params : (EcIdent.t * 'a p_module_type) list;
+  mt_name   : EcPath.path;
+  mt_args   : EcPath.mpath list;
+  mt_restr  : 'a p_mod_restr;
+}
+
+type module_sig_body_item = Tys_function of funsig
+
+type module_sig_body = module_sig_body_item list
+
+type 'a p_module_sig = {
+  mis_params : (EcIdent.t * 'a p_module_type) list;
+  mis_body   : module_sig_body;
+  mis_restr  : 'a p_mod_restr;
+}
+
+type 'a p_top_module_sig = {
+  tms_sig  : 'a p_module_sig;
+  tms_loca : is_local;
+}
+
+(* -------------------------------------------------------------------- *)
+(* Simple module signature, without restrictions. *)
+type 'a p_module_smpl_sig = {
+  miss_params : (EcIdent.t * 'a p_module_type) list;
+  miss_body   : module_sig_body;
+}
+
+val sig_smpl_sig_coincide : 'a p_module_sig -> 'b p_module_smpl_sig -> bool
+
+(* -------------------------------------------------------------------- *)
+type uses = {
+  us_calls  : xpath list;
+  us_reads  : Sx.t;
+  us_writes : Sx.t;
+}
+
+val mk_uses : xpath list -> Sx.t -> Sx.t -> uses
+
+type function_def = {
+  f_locals : variable list;
+  f_body   : stmt;
+  f_ret    : EcTypes.expr option;
+  f_uses   : uses;
+}
+
+val fd_equal : function_def -> function_def -> bool
+val fd_hash  : function_def -> int
+
+(* -------------------------------------------------------------------- *)
+type 'a p_function_body =
+| FBdef   of function_def
+| FBalias of xpath
+| FBabs   of 'a PreOI.t
+
+type 'a p_function_ = {
+  f_name   : symbol;
+  f_sig    : funsig;
+  f_def    : 'a p_function_body;
+}
+
+(* -------------------------------------------------------------------- *)
+type abs_uses = {
+  aus_calls  : EcPath.xpath list;
+  aus_reads  : (EcTypes.prog_var * EcTypes.ty) list;
+  aus_writes : (EcTypes.prog_var * EcTypes.ty) list;
+}
+
+type 'a p_module_expr = {
+  me_name     : symbol;
+  me_body     : 'a p_module_body;
+  me_comps    : 'a p_module_comps;
+  me_sig_body : module_sig_body;
+  me_params   : (EcIdent.t * 'a p_module_type) list;
+}
+
+(* Invariant:
+   In an abstract module [ME_Decl mt], [mt] must not be a functor, i.e. it must
+   be fully applied. Therefore, we must have:
+   [List.length mp.mt_params = List.length mp.mt_args]  *)
+and 'a p_module_body =
+  | ME_Alias       of int * EcPath.mpath
+  | ME_Structure   of 'a p_module_structure       (* Concrete modules. *)
+  | ME_Decl        of 'a p_module_type         (* Abstract modules. *)
+
+and 'a p_module_structure = {
+  ms_body      : 'a p_module_item list;
+}
+
+and 'a p_module_item =
+  | MI_Module   of 'a p_module_expr
+  | MI_Variable of variable
+  | MI_Function of 'a p_function_
+
+and 'a p_module_comps = 'a p_module_comps_item list
+
+and 'a p_module_comps_item = 'a p_module_item
+
+type 'a p_top_module_expr = {
+  tme_expr : 'a p_module_expr;
+  tme_loca : locality;
+}
+
+(* -------------------------------------------------------------------- *)
+val p_mty_equal :
+  ('a -> 'a -> bool) ->
+  'a p_module_type ->
+  'a p_module_type ->
+  bool
+
+val p_mty_hash : ('a -> int) -> 'a p_module_type -> int
+
+(* -------------------------------------------------------------------- *)
+val get_uninit_read : stmt -> Ssym.t
+val get_uninit_read_of_fun : _ p_function_ -> Ssym.t
+val get_uninit_read_of_module : path -> _ p_module_expr -> (xpath * Ssym.t) list

--- a/src/ecDecl.mli
+++ b/src/ecDecl.mli
@@ -149,8 +149,28 @@ type axiom = {
 and ax_visibility = [`Visible | `NoSmt | `Hidden]
 
 (* -------------------------------------------------------------------- *)
-val is_axiom : axiom_kind -> bool
-val is_lemma : axiom_kind -> bool
+val is_axiom  : axiom_kind -> bool
+val is_lemma  : axiom_kind -> bool
+
+(* -------------------------------------------------------------------- *)
+type sc_params = (EcIdent.t * ty) list
+
+type pr_params = EcIdent.t list (* type bool *)
+
+(* [axs_params] are the free variables in [as_spec] expressions, i.e. in
+   [EcTypes.expr]. *)
+type ax_schema = {
+  axs_tparams : ty_params;
+  axs_pparams : pr_params;
+  axs_params  : sc_params;
+  axs_loca    : locality;
+  axs_spec    : EcCoreFol.form;
+}
+
+val sc_instantiate :
+  ty_params -> pr_params -> sc_params ->
+  ty list -> EcMemory.memtype -> mem_pr list -> expr list ->
+  EcCoreFol.form -> EcCoreFol.form
 
 (* -------------------------------------------------------------------- *)
 val axiomatized_op :

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -33,6 +33,7 @@ type 'a suspension = {
   sp_params : int * (EcIdent.t * module_type) list;
 }
 
+
 (* -------------------------------------------------------------------- *)
 let check_not_suspended (params, obj) =
   if not (List.for_all (fun x -> x = None) params) then
@@ -82,21 +83,18 @@ module Sip = EcMaps.Set.MakeOfMap(Mip)
 let ippath_as_path (ip : ipath) =
   match ip with IPPath p -> p | _ -> assert false
 
-(* -------------------------------------------------------------------- *)
-type varbind = {
-  vb_type  : EcTypes.ty;
-  vb_kind  : [`Var of EcTypes.pvar_kind | `Proj of int];
-}
+type glob_var_bind = EcTypes.ty
 
 type mc = {
   mc_parameters : ((EcIdent.t * module_type) list) option;
-  mc_variables  : (ipath * varbind) MMsym.t;
+  mc_variables  : (ipath * glob_var_bind) MMsym.t;
   mc_functions  : (ipath * function_) MMsym.t;
   mc_modules    : (ipath * (module_expr * locality option)) MMsym.t;
   mc_modsigs    : (ipath * top_module_sig) MMsym.t;
   mc_tydecls    : (ipath * EcDecl.tydecl) MMsym.t;
   mc_operators  : (ipath * EcDecl.operator) MMsym.t;
   mc_axioms     : (ipath * EcDecl.axiom) MMsym.t;
+  mc_schemas    : (ipath * EcDecl.ax_schema) MMsym.t;
   mc_theories   : (ipath * ctheory) MMsym.t;
   mc_typeclasses: (ipath * typeclass) MMsym.t;
   mc_rwbase     : (ipath * path) MMsym.t;
@@ -108,29 +106,82 @@ type use = {
   us_gl : Sid.t;
 }
 
+let use_union us1 us2 =
+  { us_pv = Mx.union  (fun _ ty _ -> Some ty) us1.us_pv us2.us_pv;
+    us_gl = Sid.union us1.us_gl us2.us_gl; }
+
+let use_empty = { us_pv = Mx.empty; us_gl = Sid.empty; }
+
 type env_norm = {
-  norm_mp   : EcPath.mpath Mm.t;
-  norm_xpv  : EcPath.xpath Mx.t;   (* for global program variable *)
-  norm_xfun : EcPath.xpath Mx.t;   (* for fun and local program variable *)
-  mod_use   : use Mm.t;
-  get_restr : use Mm.t;
+  norm_mp       : EcPath.mpath Mm.t;
+  norm_xpv      : EcPath.xpath Mx.t;   (* for global program variable *)
+  norm_xfun     : EcPath.xpath Mx.t;   (* for fun and local program variable *)
+  mod_use       : use Mm.t;
+  get_restr_use : (use EcModules.use_restr) Mm.t;
 }
 
 (* -------------------------------------------------------------------- *)
-type red_topsym = [ `Path of path | `Tuple ]
+type red_topsym = [
+  | `Path of path
+  | `Tuple
+  | `Cost of [`Path of path | `Tuple]
+]
 
 module Mrd = EcMaps.Map.Make(struct
   type t = red_topsym
 
-  let compare (p1 : t) (p2 : t) =
+  let rec compare (p1 : t) (p2 : t) =
     match p1, p2 with
     | `Path p1, `Path p2 ->  EcPath.p_compare p1 p2
     | `Tuple  , `Tuple   ->  0
-    | `Tuple  , `Path _  -> -1
-    | `Path _ , `Tuple   ->  1
+    | `Cost p1, `Cost p2 ->
+      compare (p1 :> red_topsym) (p2 :> red_topsym)
+    | `Tuple  , `Path _
+    | `Cost _ , `Path _
+    | `Cost _ , `Tuple   -> -1
+    | `Path _ , `Tuple
+    | `Path _ , `Cost _
+    | `Tuple  , `Cost _  ->  1
 end)
 
 (* -------------------------------------------------------------------- *)
+
+module Mmem : sig
+  type 'a t
+  val empty : 'a t
+  val all   : 'a t -> (EcIdent.t * 'a) list
+  val byid  : EcIdent.t -> 'a t -> 'a
+  val bysym : EcSymbols.symbol -> 'a t -> EcIdent.t * 'a
+  val add   : EcIdent.t -> 'a -> 'a t -> 'a t
+end = struct
+
+  type 'a t = {
+      m_s : memory Msym.t;
+      m_id : 'a Mid.t;
+    }
+
+  let empty = {
+      m_s = Msym.empty;
+      m_id = Mid.empty;
+    }
+
+  let all m = Mid.bindings m.m_id
+
+  let byid id m = Mid.find id m.m_id
+
+  let bysym s m =
+    let id = Msym.find s m.m_s in
+    id, byid id m
+
+  let add id a m = {
+      m_s = Msym.add (EcIdent.name id) id m.m_s;
+      m_id = Mid.add id a m.m_id
+    }
+end
+
+
+(* -------------------------------------------------------------------- *)
+
 type preenv = {
   env_top      : EcPath.path option;
   env_gstate   : EcGState.gstate;
@@ -138,7 +189,7 @@ type preenv = {
   env_current  : mc;
   env_comps    : mc Mip.t;
   env_locals   : (EcIdent.t * EcTypes.ty) MMsym.t;
-  env_memories : EcMemory.memenv MMsym.t;
+  env_memories : EcMemory.memtype Mmem.t;
   env_actmem   : EcMemory.memory option;
   env_abs_st   : EcModules.abs_uses Mid.t;
   env_tci      : ((ty_params * ty) * tcinstance) list;
@@ -154,10 +205,14 @@ type preenv = {
 
 and escope = {
   ec_path  : EcPath.path;
-  ec_scope : [ `Theory
-             | `Module of EcPath.mpath
-             | `Fun    of EcPath.xpath ];
+  ec_scope : scope;
 }
+
+and scope = [
+  | `Theory
+  | `Module of EcPath.mpath
+  | `Fun    of EcPath.xpath
+]
 
 and tcinstance = [
   | `Ring    of EcDecl.ring
@@ -191,6 +246,9 @@ let xroot (env : env) =
   | `Fun x -> Some x
   | _ -> None
 
+let scope (env : env) =
+  env.env_scope.ec_scope
+
 (* -------------------------------------------------------------------- *)
 let astop (env : env) =
   { env with env_top = Some (root env); }
@@ -217,6 +275,7 @@ let empty_mc params = {
   mc_tydecls    = MMsym.empty;
   mc_operators  = MMsym.empty;
   mc_axioms     = MMsym.empty;
+  mc_schemas    = MMsym.empty;
   mc_theories   = MMsym.empty;
   mc_variables  = MMsym.empty;
   mc_functions  = MMsym.empty;
@@ -231,7 +290,7 @@ let empty_norm_cache =
     norm_xpv  = Mx.empty;
     norm_xfun = Mx.empty;
     mod_use   = Mm.empty;
-    get_restr = Mm.empty; }
+    get_restr_use = Mm.empty; }
 
 (* -------------------------------------------------------------------- *)
 let empty gstate =
@@ -248,7 +307,7 @@ let empty gstate =
     env_current  = env_current;
     env_comps    = Mip.singleton (IPPath path) (empty_mc None);
     env_locals   = MMsym.empty;
-    env_memories = MMsym.empty;
+    env_memories = Mmem.empty;
     env_actmem   = None;
     env_abs_st   = Mid.empty;
     env_tci      = [];
@@ -335,7 +394,7 @@ module MC = struct
       | (p, `Dn q) -> (p, Some q)
 
   (* ------------------------------------------------------------------ *)
-  let _downpath_for_modcp isvar ~local ~spsc env p args =
+  let _downpath_for_modcp isvar ~spsc env p args =
     let prefix =
       let prefix_of_mtop = function
         | `Concrete (p1, _) -> Some p1
@@ -365,21 +424,10 @@ module MC = struct
                 | None -> assert false
                 | Some q -> begin
                     let ap =
-                      if local then
-                        let vname = EcPath.basename q in
-                        let fpath = oget (EcPath.prefix q) in
-                        let fname = EcPath.basename fpath in
-                          EcPath.xpath
-                            (EcPath.mpath_crt
-                               p (if isvar && not local then [] else List.map EcPath.mident n)
-                               (EcPath.prefix fpath))
-                            (EcPath.pqname (EcPath.psymbol fname) vname)
-                      else
                         EcPath.xpath
-                          (EcPath.mpath_crt
-                             p (if isvar && not local then [] else List.map EcPath.mident n)
+                          (EcPath.mpath_crt p (if isvar then [] else List.map EcPath.mident n)
                              (EcPath.prefix q))
-                          (EcPath.psymbol (EcPath.basename q))
+                          (EcPath.basename q)
                     in
                       (ap, odfl false (prefix |> omap (EcPath.p_equal p)))
                 end
@@ -394,7 +442,7 @@ module MC = struct
                     EcPath.xpath
                       (EcPath.mpath_abs m
                          (if isvar then [] else List.map EcPath.mident n))
-                      (EcPath.psymbol x)
+                      x
                   in
                     (ap, false)
 
@@ -407,7 +455,7 @@ module MC = struct
       assert false
 
   let _downpath_for_var = _downpath_for_modcp true
-  let _downpath_for_fun = _downpath_for_modcp false ~local:false
+  let _downpath_for_fun = _downpath_for_modcp false
 
   (* ------------------------------------------------------------------ *)
   let _downpath_for_mod spsc env p args =
@@ -464,6 +512,7 @@ module MC = struct
   let _downpath_for_modsig    = _downpath_for_th
   let _downpath_for_operator  = _downpath_for_th
   let _downpath_for_axiom     = _downpath_for_th
+  let _downpath_for_schema    = _downpath_for_th
   let _downpath_for_typeclass = _downpath_for_th
   let _downpath_for_rwbase    = _downpath_for_th
 
@@ -596,12 +645,8 @@ module MC = struct
   let lookup_var qnx env =
     match lookup (fun mc -> mc.mc_variables) qnx env with
     | None -> lookup_error (`QSymbol qnx)
-    | Some (p, (args, obj)) ->
-      let local =
-        match obj.vb_kind with
-        | `Var EcTypes.PVglob -> false
-        | `Var EcTypes.PVloc | `Proj _ -> true in
-      (_downpath_for_var ~local ~spsc:false env p args, obj)
+    | Some (p, (args, ty)) ->
+      (_downpath_for_var ~spsc:false env p args, ty)
 
   let _up_var candup mc x obj =
     if not candup && MMsym.last x mc.mc_variables <> None then
@@ -635,6 +680,7 @@ module MC = struct
   let _up_mod candup mc x obj =
     if not candup && MMsym.last x mc.mc_modules <> None then
       raise (DuplicatedBinding x);
+
     { mc with mc_modules = MMsym.add x obj mc.mc_modules }
 
   let import_mod p mod_ env =
@@ -659,6 +705,24 @@ module MC = struct
   let import_axiom p ax env =
     import (_up_axiom true) (IPPath p) ax env
 
+  (* -------------------------------------------------------------------- *)
+  let lookup_schema qnx env =
+    match lookup (fun mc -> mc.mc_schemas) qnx env with
+    | None -> lookup_error (`QSymbol qnx)
+    | Some (p, (args, obj)) -> (_downpath_for_schema env p args, obj)
+
+  let lookup_schemas qnx env =
+    List.map
+      (fun (p, (args, obj)) -> (_downpath_for_schema env p args, obj))
+      (lookup_all (fun mc -> mc.mc_schemas) qnx env)
+
+  let _up_schema candup mc x obj =
+    if not candup && MMsym.last x mc.mc_schemas <> None then
+      raise (DuplicatedBinding x);
+    { mc with mc_schemas = MMsym.add x obj mc.mc_schemas }
+
+  let import_schema p sc env =
+    import (_up_schema true) (IPPath p) sc env
 
   (* -------------------------------------------------------------------- *)
   let lookup_operator qnx env =
@@ -699,8 +763,7 @@ module MC = struct
           ax_tparams    = tv;
           ax_spec       = cl;
           ax_loca       = (snd obj).op_loca;
-          ax_visibility = `Visible;
-        } in
+          ax_visibility = `Visible; } in
       (name, (axp, ax))) ax in
 
     List.fold_left (fun mc -> curry (_up_axiom candup mc)) mc ax
@@ -959,7 +1022,7 @@ module MC = struct
 
     let mc1_of_module (mc : mc) = function
       | MI_Module subme ->
-          assert (subme.me_sig.mis_params = []);
+          assert (subme.me_params = []);
 
           let (subp2, mep) = subp2 subme.me_name in
           let submcs = mc_of_module_r (p1, args, Some subp2, None) subme in
@@ -969,10 +1032,7 @@ module MC = struct
 
       | MI_Variable v ->
           let (_subp2, mep) = subp2 v.v_name in
-          let vty  =
-            { vb_type = v.v_type;
-              vb_kind = `Var PVglob; }
-          in
+          let vty  = v.v_type in
             (_up_var false mc v.v_name (IPPath mep, vty), None)
 
       | MI_Function f ->
@@ -983,7 +1043,7 @@ module MC = struct
     let (mc, submcs) =
       List.map_fold mc1_of_module
         (empty_mc
-           (if p2 = None then Some me.me_sig.mis_params else None))
+           (if p2 = None then Some me.me_params else None))
         me.me_comps
     in
       ((me.me_name, mc), List.rev_pmap (fun x -> x) submcs)
@@ -992,7 +1052,7 @@ module MC = struct
     match env.env_scope.ec_scope with
     | `Theory ->
         let p1   = EcPath.pqname (root env) me.me_name
-        and args = me.me_sig.mis_params in
+        and args = me.me_params in
         mc_of_module_r (p1, args, None, Some lc) me
 
     | `Module mpath -> begin
@@ -1017,11 +1077,7 @@ module MC = struct
       | MI_Module _ -> assert false
 
       | MI_Variable v ->
-          let vty =
-            { vb_type = v.v_type;
-              vb_kind = `Var PVglob; }
-          in
-            _up_var false mc v.v_name (xpath v.v_name, vty)
+          _up_var false mc v.v_name (xpath v.v_name, v.v_type)
 
 
       | MI_Function f ->
@@ -1029,7 +1085,7 @@ module MC = struct
     in
       List.fold_left
         mc1_of_module
-        (empty_mc (Some me.me_sig.mis_params))
+        (empty_mc (Some me.me_params))
         me.me_comps
 
   (* ------------------------------------------------------------------ *)
@@ -1051,11 +1107,14 @@ module MC = struct
       | Th_axiom (xax, ax) ->
           (add2mc _up_axiom xax ax mc, None)
 
+      | Th_schema (x, schema) ->
+          (add2mc _up_schema x schema mc, None)
+
       | Th_modtype (xmodty, modty) ->
           (add2mc _up_modty xmodty modty mc, None)
 
       | Th_module { tme_expr = subme; tme_loca = lc; } ->
-          let args = subme.me_sig.mis_params in
+          let args = subme.me_params in
           let submcs =
             mc_of_module_r (expath subme.me_name, args, None, Some lc) subme
           in
@@ -1143,6 +1202,9 @@ module MC = struct
   and bind_axiom x ax env =
     bind _up_axiom x ax env
 
+  and bind_schema x ax env =
+    bind _up_schema x ax env
+
   and bind_operator x op env =
     bind _up_operator x op env
 
@@ -1191,7 +1253,7 @@ let enter mode (name : symbol) (env : env) =
             env_item  = []; }
 
   | `Fun, `Module mpath ->
-      let xpath = EcPath.xpath_fun mpath name in
+      let xpath = EcPath.xpath mpath name in
       let env   = MC.bind_mc name (empty_mc None) env in (* FIXME: remove *)
         { env with
             env_scope = { ec_path = path; ec_scope = `Fun xpath; };
@@ -1208,22 +1270,15 @@ exception MEError of meerror
 
 (* -------------------------------------------------------------------- *)
 module Memory = struct
-  let all env =
-    MMsym.fold (fun _ l all -> List.rev_append l all) env.env_memories []
+  let all env = Mmem.all env.env_memories
 
   let byid (me : memory) (env : env) =
-    let memories = MMsym.all (EcIdent.name me) env.env_memories in
-    let memories =
-      List.filter
-        (fun me' -> EcIdent.id_equal me (EcMemory.memory me'))
-        memories
-    in
-      match memories with
-      | []     -> None
-      | m :: _ -> Some m
+    try Some (me, Mmem.byid me env.env_memories)
+    with Not_found -> None
 
   let lookup (me : symbol) (env : env) =
-    MMsym.last me env.env_memories
+    try Some (Mmem.bysym me env.env_memories)
+    with Not_found -> None
 
   let set_active (me : memory) (env : env) =
     match byid me env with
@@ -1236,16 +1291,15 @@ module Memory = struct
   let current (env : env) =
     match env.env_actmem with
     | None    -> None
-    | Some me -> Some (oget (byid me env))
+    | Some me -> byid me env
+
+  let update (me: EcMemory.memenv) (env : env) =
+    { env with env_memories = Mmem.add (fst me) (snd me) env.env_memories; }
 
   let push (me : EcMemory.memenv) (env : env) =
+    (* TODO : A: *)
     (* FIXME: assert (byid (EcMemory.memory me) env = None); *)
-
-    let id = EcMemory.memory me in
-    let maps =
-      MMsym.add (EcIdent.name id) me env.env_memories
-    in
-      { env with env_memories = maps }
+    update me env
 
   let push_all memenvs env =
     List.fold_left
@@ -1255,6 +1309,7 @@ module Memory = struct
   let push_active memenv env =
     set_active (EcMemory.memory memenv)
       (push memenv env)
+
 end
 
 (* -------------------------------------------------------------------- *)
@@ -1268,19 +1323,17 @@ let ipath_of_mpath (p : mpath) =
         (IPPath pr, ((EcPath.p_size p1)-1, p.EcPath.m_args))
 
 let ipath_of_xpath (p : xpath) =
-  match p.EcPath.x_sub.EcPath.p_node with
-  | EcPath.Psymbol x ->
-      let xt p =
-        match p with
-        | IPPath p -> Some (IPPath (EcPath.pqname p x))
-        | IPIdent (m, None) -> Some (IPIdent (m, Some (EcPath.psymbol x)))
-        | _ -> None
-      in
+  let x = p.EcPath.x_sub in
 
-      let (p, (i, a)) = ipath_of_mpath p.EcPath.x_top in
-        (xt p) |> omap (fun p -> (p, (i+1, a)))
+  let xt p =
+    match p with
+    | IPPath p -> Some (IPPath (EcPath.pqname p x))
+    | IPIdent (m, None) -> Some (IPIdent (m, Some (EcPath.psymbol x)))
+    | _ -> None
+  in
 
-  | _ -> None
+  let (p, (i, a)) = ipath_of_mpath p.EcPath.x_top in
+  (xt p) |> omap (fun p -> (p, (i+1, a)))
 
 (* -------------------------------------------------------------------- *)
 let try_lf f =
@@ -1438,9 +1491,11 @@ module Reduction = struct
 
     let p =
       match rule.rl_ptn with
-      | Rule (`Op p , _) -> `Path (fst p)
-      | Rule (`Tuple, _) -> `Tuple
-      | Var _ | Int _ -> assert false in
+      | Rule (`Op p, _)               -> `Path (fst p)
+      | Rule (`Tuple, _)              -> `Tuple
+      | Cost (_, _, Rule (`Op p, _))  -> `Cost (`Path (fst p))
+      | Cost (_, _, Rule (`Tuple, _)) -> `Cost `Tuple
+      | Cost _ | Var _ | Int _        -> assert false in
 
     Mrd.change (fun rls ->
       let { ri_priomap } =
@@ -1708,63 +1763,46 @@ module Fun = struct
     let ip = fst (oget (ipath_of_xpath path)) in
       MC.import_fun ip obj env
 
-  let add_in_memenv memenv vd =
-    EcMemory.bind vd.v_name vd.v_type memenv
+  let adds_in_memenv memenv vd = EcMemory.bindall vd memenv
+  let add_in_memenv memenv vd = adds_in_memenv memenv [vd]
 
-  let adds_in_memenv = List.fold_left add_in_memenv
-
-  let addproj_in_memenv mem l =
-    let n = List.length l in
-    List.fold_lefti
-      (fun mem i vd -> EcMemory.bind_proj i n vd.v_name vd.v_type mem) mem l
-
-  let actmem_pre me path fun_ =
-    let mem = EcMemory.empty_local me path in
-    let mem = add_in_memenv mem {v_name = "arg"; v_type = fun_.f_sig.fs_arg } in
+  let add_params mem fun_ =
+    let ty = fun_.f_sig.fs_arg in
     match fun_.f_sig.fs_anames with
-    | None -> mem
-    | Some l -> addproj_in_memenv mem l
+    | None   -> add_in_memenv mem {v_name = "_"; v_type = ty}
+    | Some l -> adds_in_memenv mem l
 
+  let actmem_pre me fun_ =
+    let mem = EcMemory.empty_local ~witharg:true me in
+    add_params mem fun_
 
-  let actmem_post me path fun_ =
-    let mem = EcMemory.empty_local me path in
-    add_in_memenv mem {v_name = "res"; v_type = fun_.f_sig.fs_ret}
+  let actmem_post me fun_ =
+    let mem = EcMemory.empty_local ~witharg:false me in
+    add_in_memenv mem {v_name = res_symbol; v_type = fun_.f_sig.fs_ret}
 
-  let actmem_body me path fun_ =
+  let actmem_body me fun_ =
     match fun_.f_def with
-    | FBabs _ -> assert false (* FIXME error message *)
+    | FBabs _   -> assert false (* FIXME error message *)
     | FBalias _ -> assert false (* FIXME error message *)
-    | FBdef fd ->
-      let mem = EcMemory.empty_local me path in
-      let mem = add_in_memenv mem {v_name="arg"; v_type=fun_.f_sig.fs_arg} in
-      let mem =
-        match fun_.f_sig.fs_anames with
-        | None -> mem
-        | Some l -> adds_in_memenv mem l in
+    | FBdef fd   ->
+      let mem = EcMemory.empty_local ~witharg:false me in
+      let mem = add_params mem fun_ in
       (fun_.f_sig,fd), adds_in_memenv mem fd.f_locals
 
-  let inv_memory side env =
-    let path  = mroot env in
-    let xpath = EcPath.xpath_fun path "" in (* dummy value *)
+  let inv_memory side =
     let id    = if side = `Left then EcCoreFol.mleft else EcCoreFol.mright in
-    EcMemory.empty_local id xpath
+    EcMemory.abstract id
 
   let inv_memenv env =
-    let path  = mroot env in
-    let xpath = EcPath.xpath_fun path "" in (* dummy value *)
-    let meml  = EcMemory.empty_local EcCoreFol.mleft xpath in
-    let memr  = EcMemory.empty_local EcCoreFol.mright xpath in
-    Memory.push_all [meml;memr] env
+    Memory.push_all [inv_memory `Left; inv_memory `Rigth] env
 
   let inv_memenv1 env =
-    let path  = mroot env in
-    let xpath = EcPath.xpath_fun path "" in (* dummy value *)
-    let mem  = EcMemory.empty_local EcCoreFol.mhr xpath in
+    let mem  = EcMemory.abstract EcCoreFol.mhr in
     Memory.push_active mem env
 
   let prF_memenv m path env =
     let fun_ = by_xpath path env in
-    actmem_post m path fun_
+    actmem_post m fun_
 
   let prF path env =
     let post = prF_memenv EcCoreFol.mhr path env in
@@ -1773,8 +1811,8 @@ module Fun = struct
   let hoareF_memenv path env =
     let (ip, _) = oget (ipath_of_xpath path) in
     let fun_ = snd (oget (by_ipath ip env)) in
-    let pre  = actmem_pre EcCoreFol.mhr path fun_ in
-    let post = actmem_post EcCoreFol.mhr path fun_ in
+    let pre  = actmem_pre EcCoreFol.mhr fun_ in
+    let post = actmem_post EcCoreFol.mhr fun_ in
     pre, post
 
   let hoareF path env =
@@ -1783,7 +1821,7 @@ module Fun = struct
 
   let hoareS path env =
     let fun_ = by_xpath path env in
-    let fd, memenv = actmem_body EcCoreFol.mhr path fun_ in
+    let fd, memenv = actmem_body EcCoreFol.mhr fun_ in
     memenv, fd, Memory.push_active memenv env
 
   let equivF_memenv path1 path2 env =
@@ -1792,10 +1830,10 @@ module Fun = struct
 
     let fun1 = snd (oget (by_ipath ip1 env)) in
     let fun2 = snd (oget (by_ipath ip2 env)) in
-    let pre1 = actmem_pre EcCoreFol.mleft path1 fun1 in
-    let pre2 = actmem_pre EcCoreFol.mright path2 fun2 in
-    let post1 = actmem_post EcCoreFol.mleft path1 fun1 in
-    let post2 = actmem_post EcCoreFol.mright path2 fun2 in
+    let pre1 = actmem_pre EcCoreFol.mleft fun1 in
+    let pre2 = actmem_pre EcCoreFol.mright fun2 in
+    let post1 = actmem_post EcCoreFol.mleft fun1 in
+    let post2 = actmem_post EcCoreFol.mright fun2 in
     (pre1,pre2), (post1,post2)
 
   let equivF path1 path2 env =
@@ -1806,60 +1844,27 @@ module Fun = struct
   let equivS path1 path2 env =
     let fun1 = by_xpath path1 env in
     let fun2 = by_xpath path2 env in
-    let fd1, mem1 = actmem_body EcCoreFol.mleft path1 fun1 in
-    let fd2, mem2 = actmem_body EcCoreFol.mright path2 fun2 in
+    let fd1, mem1 = actmem_body EcCoreFol.mleft fun1 in
+    let fd2, mem2 = actmem_body EcCoreFol.mright fun2 in
     mem1, fd1, mem2, fd2, Memory.push_all [mem1; mem2] env
 end
 
 (* -------------------------------------------------------------------- *)
 module Var = struct
-  type t = varbind
+  type t = glob_var_bind
 
-  let by_xpath_r (spsc : bool) (p : xpath) (env : env) =
+    let by_xpath_r (spsc : bool) (p : xpath) (env : env) =
     match ipath_of_xpath p with
-    | None -> begin
-      match p.EcPath.x_sub.EcPath.p_node with
-      | EcPath.Pqname ({ p_node = EcPath.Psymbol f }, x) -> begin
-        let mp = EcPath.mpath p.EcPath.x_top.EcPath.m_top [] in
-        let fp = EcPath.xpath_fun mp f in
-        let f  = Fun.by_xpath_r ~susp:true ~spsc fp env in
-        if x = "arg" then {vb_type = f.f_sig.fs_arg; vb_kind = `Var PVloc }
-        else
-          try
-            begin match f.f_sig.fs_anames with
-            | None -> raise Not_found
-            | Some l ->
-              let v = List.find (fun v -> v.v_name = x) l in
-              { vb_type = v.v_type; vb_kind = `Var PVloc; }
-            end
-          with Not_found -> begin
-            match f.f_def with
-            | FBdef def -> begin
-              try
-                let v = List.find (fun v -> v.v_name = x) def.f_locals in
-                { vb_type = v.v_type; vb_kind = `Var PVloc; }
-              with Not_found -> lookup_error (`XPath p)
-            end
-            | FBabs _ | FBalias _ -> lookup_error (`XPath p)
-          end
-      end
-      | _ -> lookup_error (`XPath p)
-    end
-
-    | Some (ip, (i, _args)) -> begin
-        match MC.by_path (fun mc -> mc.mc_variables) ip env with
-        | None -> lookup_error (`XPath p)
-        | Some (params, o) ->
-           let local =
-             match o.vb_kind with
-             | `Var EcTypes.PVglob -> false
-             | `Var EcTypes.PVloc | `Proj _ -> true in
-           let ((spi, _params), _) =
-             MC._downpath_for_var ~local ~spsc env ip params in
-           if i <> spi then
-             assert false;
-           o
-    end
+    | None -> lookup_error (`XPath p)
+    | Some (ip, (i, _args)) ->
+      match MC.by_path (fun mc -> mc.mc_variables) ip env with
+      | None -> lookup_error (`XPath p)
+      | Some (params, ty) ->
+        let ((spi, _params), _) =
+          MC._downpath_for_var ~spsc env ip params in
+        if i <> spi then
+          assert false;
+        ty
 
   let by_xpath (p : xpath) (env : env) =
     by_xpath_r true p env
@@ -1888,54 +1893,43 @@ module Var = struct
       match fst qname with
       | [] ->
           let memenv = oget (Memory.byid side env) in
-          if EcMemory.memtype memenv = None then None
-          else
-            let mp = EcMemory.xpath memenv in
-            begin match EcMemory.lookup (snd qname) memenv with
-            | None    -> None
-            | Some (None,ty) ->
-              let pv = pv_loc mp (snd qname) in
-              Some (`Var pv, ty)
-            | Some (Some i, ty) ->
-              let pv = pv_arg mp in
-              let fdef = Fun.by_xpath mp env in
-              Some (`Proj (pv,fdef.f_sig.fs_arg, i), ty)
-            end
-
+          begin match EcMemory.lookup_me (snd qname) memenv with
+          | Some (v, Some pa, _) -> Some (`Proj(pv_arg, pa), v.v_type)
+          | Some (v, None, _)    -> Some (`Var (pv_loc v.v_name), v.v_type)
+          | None                 -> None
+          end
       | _ -> None
     in
     match obind inmem side with
     | None ->
-        (* TODO FIXME, suspended for local program variable *)
-      let (((_, _), p), x) = MC.lookup_var qname env in
-      let k =
-        match x.vb_kind with
-        | `Var k -> k
-        | _ -> assert false (* PY : FIXME *) in
-      (`Var (pv p k), x.vb_type)
+      let (((_, _), p), ty) = MC.lookup_var qname env in
+      (`Var (pv_glob p), ty)
 
     | Some pvt -> pvt
 
   let lookup_progvar_opt ?side name env =
     try_lf (fun () -> lookup_progvar ?side name env)
 
-  let bind name pvkind ty env =
-    let vb = { vb_type = ty; vb_kind = `Var pvkind; } in
-    MC.bind_var name vb env
+  let bind_pvglob name ty env =
+    MC.bind_var name ty env
 
-  let bindall bindings pvkind env =
+  let bindall_pvglob bindings env =
     List.fold_left
-      (fun env (name, ty) -> bind name pvkind ty env)
+      (fun env (name, ty) -> bind_pvglob name ty env)
       env bindings
 
-   let bind_local name ty env =
-     let s = EcIdent.name name in
-       { env with
-           env_locals = MMsym.add s (name, ty) env.env_locals }
+  exception DuplicatedLocalBinding of EcIdent.t
 
-   let bind_locals bindings env =
+   let bind_local ?uniq:(uniq=false) name ty env =
+     let s = EcIdent.name name in
+     if uniq && MMsym.all s env.env_locals <> [] then
+       raise (DuplicatedLocalBinding name);
+     { env with
+       env_locals = MMsym.add s (name, ty) env.env_locals }
+
+   let bind_locals ?uniq:(uniq=false) bindings env =
      List.fold_left
-       (fun env (name, ty) -> bind_local name ty env)
+       (fun env (name, ty) -> bind_local ~uniq:uniq name ty env)
        env bindings
 
 end
@@ -1959,7 +1953,9 @@ module Mod = struct
   type spt = mpath * module_expr suspension * locality option
 
   let unsuspend_r f istop (i, args) (spi, params) o =
-    if i <> spi || List.length args > List.length params then
+    if List.length args > List.length params then
+      assert false;
+    if i <> spi then
       assert false;
     if (not istop && List.length args <> List.length params) then
       assert false;
@@ -1973,30 +1969,16 @@ module Mod = struct
     in
       f s o
 
-  let clearparams n sig_ =
-    let used, remaining = List.takedrop n sig_.mis_params in
+  let clearparams n params =
+    let _, remaining = List.takedrop n params in
+    remaining
 
-    let keepcall =
-      let used = EcIdent.Sid.of_list (List.map fst used) in
-        fun xp ->
-          match xp.EcPath.x_top.EcPath.m_top with
-          | `Local id -> not (EcIdent.Sid.mem id used)
-          | _ -> true
-    in
-
-    { mis_params = remaining;
-      mis_body   =
-        List.map
-          (function Tys_function (s, oi) ->
-            Tys_function (s, { oi_calls = List.filter keepcall oi.oi_calls;
-                               oi_in    = oi.oi_in; }))
-          sig_.mis_body }
 
   let unsuspend istop (i, args) (spi, params) me =
     let me =
       match args with
       | [] -> me
-      | _  -> { me with me_sig = clearparams (List.length args) me.me_sig }
+      | _  -> { me with me_params = clearparams (List.length args) me.me_params }
     in
       unsuspend_r EcSubst.subst_module istop (i, args) (spi, params) me
 
@@ -2014,7 +1996,7 @@ module Mod = struct
           lookup_error (`MPath p)
 
       | Some (params, (o, lc)) ->
-          let ((spi, params), op) = MC._downpath_for_mod false env ip params in
+          let ((spi, params), op) = MC._downpath_for_mod true env ip params in
           let (params, istop) =
             match op.EcPath.m_top with
             | `Concrete (p, Some _) ->
@@ -2023,11 +2005,11 @@ module Mod = struct
 
             | `Concrete (p, None) ->
                 assert ((params = []) || ((spi+1) = EcPath.p_size p));
-                ((if args = [] then [] else o.me_sig.mis_params), true)
+                ((if args = [] then [] else o.me_params), true)
 
             | `Local _m ->
                 assert ((params = []) || spi = 0);
-                ((if args = [] then [] else o.me_sig.mis_params), true)
+                ((if args = [] then [] else o.me_params), true)
           in
             (unsuspend istop (i, args) (spi, params) o, lc)
 
@@ -2063,8 +2045,10 @@ module Mod = struct
     let update_id id mods =
       let update me =
         match me.me_body with
-        | ME_Decl (mt, (rx2, r2)) ->
-          { me with me_body = ME_Decl (mt, (Sx.union xs rx2, r2)) }
+        | ME_Decl ({ mt_restr } as mt) ->
+          let mt_restr =
+            mr_add_restr mt_restr (ur_empty xs) (ur_empty Sm.empty) in
+          { me with me_body = ME_Decl { mt with mt_restr } }
         | _ -> me
       in
       MMsym.map_at
@@ -2080,10 +2064,9 @@ module Mod = struct
         Sid.fold update_id env.env_modlcs
           env.env_current.mc_modules; } in
     let en = !(env.env_norm) in
-    let norm = { en with get_restr = Mm.empty } in
+    let norm = { en with get_restr_use = Mm.empty } in
     { env with env_current = envc;
-      env_norm = ref norm;
-    }
+      env_norm = ref norm; }
 
   let rec vars_me mp xs me =
     vars_mb (EcPath.mqname mp me.me_name) xs me.me_body
@@ -2092,9 +2075,11 @@ module Mod = struct
     | ME_Alias _ | ME_Decl _ -> xs
     | ME_Structure ms ->
       List.fold_left (vars_item mp) xs ms.ms_body
+
   and vars_item mp xs = function
     | MI_Module me  -> vars_me mp xs me
-    | MI_Variable v -> Sx.add (EcPath.xpath_fun mp v.v_name) xs
+    (* FIXME:MERGE-COST *)
+    | MI_Variable v -> Sx.add (EcPath.xpath mp v.v_name) xs
     | MI_Function _ -> xs
 
   let add_restr_to_declared p me env =
@@ -2114,7 +2099,7 @@ module Mod = struct
           env_norm = ref !(env.env_norm); } in
     add_restr_to_declared (root env) me env
 
-  let me_of_mt env name modty restr =
+  let me_of_mt env name modty =
     let modsig =
       let modsig =
         match
@@ -2130,10 +2115,10 @@ module Mod = struct
       EcSubst.subst_modsig
         ~params:(List.map fst modty.mt_params) (EcSubst.empty ()) modsig.tms_sig
     in
-    module_expr_of_module_sig name modty modsig restr
+    module_expr_of_module_sig name modty modsig
 
-  let bind_local name modty restr env =
-    let me = me_of_mt env name modty restr in
+  let bind_local name modty env =
+    let me = me_of_mt env name modty in
     let path  = IPIdent (name, None) in
     let comps = MC.mc_of_module_param name me in
 
@@ -2150,15 +2135,43 @@ module Mod = struct
     in
       env
 
-  let declare_local id modty restr env =
-    { (bind_local id modty restr env) with
+  let declare_local id modty env =
+    { (bind_local id modty env) with
         env_modlcs = Sid.add id env.env_modlcs; }
+
+  let add_restr_to_locals (rx : Sx.t use_restr) (rm : Sm.t use_restr) env =
+
+    let update_id id mods =
+      let update me =
+        match me.me_body with
+        | ME_Decl mt ->
+          let mr = mr_add_restr mt.mt_restr rx rm in
+          { me with me_body = ME_Decl { mt with mt_restr = mr } }
+        | _ -> me
+      in
+      MMsym.map_at
+        (List.map
+           (fun (ip, (me, lc)) ->
+             if   ip = IPIdent (id, None)
+             then (ip, (update me, lc))
+             else (ip, (me, lc))))
+        (EcIdent.name id) mods
+    in
+    let envc =
+      let mc_modules =
+        Sid.fold update_id env.env_modlcs
+          env.env_current.mc_modules
+      in { env.env_current with mc_modules } in
+    let en = !(env.env_norm) in
+    let norm = { en with get_restr_use = Mm.empty } in
+    { env with env_current = envc;
+      env_norm = ref norm; }
 
   let is_declared id env = Sid.mem id env.env_modlcs
 
   let bind_locals bindings env =
     List.fold_left
-      (fun env (name, me) -> bind_local name me (Sx.empty,Sm.empty) env)
+      (fun env (name, me) -> bind_local name me env)
       env bindings
 
   let enter name params env =
@@ -2168,7 +2181,7 @@ module Mod = struct
   let add_mod_binding bd env =
     let do1 env (x,gty) =
       match gty with
-      | GTmodty (p, r) -> bind_local x p r env
+      | GTmodty p -> bind_local x p env
       | _ -> env
     in
       List.fold_left do1 env bd
@@ -2176,9 +2189,9 @@ module Mod = struct
   let import_vars env p =
     let do1 env = function
       | MI_Variable v ->
-        let vp  = EcPath.xpath p (EcPath.psymbol v.v_name) in
+        let vp  = EcPath.xpath p v.v_name in
         let ip  = fst (oget (ipath_of_xpath vp)) in
-        let obj = { vb_type = v.v_type; vb_kind = `Var PVglob; } in
+        let obj = v.v_type in
         MC.import_var ip obj env
 
       | _ -> env
@@ -2199,7 +2212,7 @@ module NormMp = struct
     let (ip, (i, args)) = ipath_of_mpath p in
     match Mod.by_ipath_r true ip env with
     | Some ((spi, params), ({ me_body = ME_Alias (arity,alias) } as m, _)) ->
-      assert (m.me_sig.mis_params = [] && arity = 0);
+      assert (m.me_params = [] && arity = 0);
       let p =
         Mod.unsuspend_r EcSubst.subst_mpath
           true (i, args) (spi, params) alias
@@ -2236,7 +2249,7 @@ module NormMp = struct
         let nargs = List.length args in
         if arity <= nargs then
           let args, extra = List.takedrop arity args in
-          let params = List.take arity me.me_sig.mis_params in
+          let params = List.take arity me.me_params in
           let s =
             List.fold_left2
               (fun s (x, _) a -> EcSubst.add_module s x a)
@@ -2263,7 +2276,7 @@ module NormMp = struct
           let (ip, (i, args)) = ipath_of_mpath p in
           match Mod.by_ipath_r true ip env with
           | Some ((spi, params), ({ me_body = ME_Alias (_,alias) } as m, _)) ->
-            assert (m.me_sig.mis_params = []);
+            assert (m.me_params = []);
             let p =
               Mod.unsuspend_r EcSubst.subst_mpath
                 false (i, args) (spi, params) alias
@@ -2288,16 +2301,11 @@ module NormMp = struct
   let rec norm_xfun env p =
     try Mx.find p !(env.env_norm).norm_xfun with Not_found ->
       let res =
-        match p.x_sub.p_node with
-        | Pqname(pf,x) ->
-          let pf = norm_xfun env (EcPath.xpath p.x_top pf) in
-          EcPath.xpath pf.x_top (EcPath.pqname pf.x_sub x)
-        | _ ->
-          let mp = norm_mpath env p.x_top in
-          let pf = EcPath.xpath mp p.x_sub in
-          match Fun.by_xpath_opt pf env with (* TODO B:use by_xpath_r *)
-          | Some {f_def = FBalias xp} -> norm_xfun env xp
-          | _ -> pf in
+        let mp = norm_mpath env p.x_top in
+        let pf = EcPath.xpath mp p.x_sub in
+        match Fun.by_xpath_opt pf env with (* TODO B:use by_xpath_r *)
+        | Some {f_def = FBalias xp} -> norm_xfun env xp
+        | _ -> pf in
       let en = !(env.env_norm) in
       env.env_norm := { en with norm_xfun = Mx.add p res en.norm_xfun };
       res
@@ -2314,7 +2322,7 @@ module NormMp = struct
         let res = xp_glob xp in
         res
       | Some (me, _) ->
-        let params = me.me_sig.mis_params in
+        let params = me.me_params in
         let env', mp =
           if params = [] then env, mp
           else
@@ -2322,32 +2330,43 @@ module NormMp = struct
             EcPath.m_apply mp (List.map (fun (id,_)->EcPath.mident id) params)in
         let mp = norm_mpath env' mp in
         let xp = EcPath.xpath mp p.x_sub in
-        let res = (pv_glob xp).pv_name in
+        let res = xp_glob xp in
         let en = !(env.env_norm) in
         env.env_norm := { en with norm_xpv = Mx.add p res en.norm_xpv };
         res
 
-  let use_empty = { us_pv = Mx.empty; us_gl = Sid.empty }
   let use_equal us1 us2 =
     Mx.equal (fun _ _ -> true) us1.us_pv us2.us_pv &&
       Sid.equal us1.us_gl us2.us_gl
 
-  let use_union us1 us2 =
-    { us_pv = Mx.union  (fun _ ty _ -> Some ty) us1.us_pv us2.us_pv;
-      us_gl = Sid.union us1.us_gl us2.us_gl }
-  let use_mem_xp xp us = Mx.mem xp us.us_pv
-  let use_mem_gl mp us =
+  let mem_xp x us = Mx.mem x us.us_pv
+
+  (* Return [true] if [x] is forbidden in [restr]. *)
+  let use_mem_xp x (restr : use use_restr) =
+    let bneg = mem_xp x restr.ur_neg
+    and bpos = match restr.ur_pos with
+      | None -> false
+      | Some sp -> not (mem_xp x sp) in
+    bneg || bpos
+
+  let mem_gl mp us =
     assert (mp.m_args = []);
     match mp.m_top with
     | `Local id -> Sid.mem id us.us_gl
     | _ -> assert false
 
+  let use_mem_gl m restr =
+    let bneg = mem_gl m restr.ur_neg
+    and bpos = match restr.ur_pos with
+      | None -> false
+      | Some sp -> not (mem_gl m sp) in
+    bneg || bpos
+
   let add_var env xp us =
     let xp = xp_glob xp in
     let xp = norm_xpv env xp in
-    let vb = Var.by_xpath xp env in
-    let pv = EcTypes.pv_glob xp in
-    { us with us_pv = Mx.add pv.pv_name vb.vb_type us.us_pv }
+    let ty = Var.by_xpath xp env in
+    { us with us_pv = Mx.add xp ty us.us_pv }
 
   let add_glob id us =
     { us with us_gl = Sid.add id us.us_gl }
@@ -2368,23 +2387,51 @@ module NormMp = struct
           let vars = Sx.union f_uses.us_reads f_uses.us_writes in
           let us = Sx.fold (add_var env) vars us in
           List.fold_left fun_use us f_uses.us_calls
+
         | FBabs oi ->
-          let id =
-            match f.x_top.m_top with
-            | `Local id -> id
-            | _ -> assert false in
-          let us = add_glob_except rm id us in
-          List.fold_left fun_use us oi.oi_calls
+            let id =
+              match f.x_top.m_top with
+              | `Local id -> id
+              | _ -> assert false in
+            let us = add_glob_except rm id us in
+            List.fold_left fun_use us (OI.allowed oi)
+
         | FBalias _ -> assert false in
     fun_use
 
   let fun_use env xp =
     gen_fun_use env (ref Sx.empty) Sid.empty use_empty xp
 
-  let mod_use env mp =
+  (* The four functions below are used in mod_use_top and item_use. *)
+  let rec mod_use env rm fdone us mp =
     let mp = norm_mpath env mp in
     let me, _ = Mod.by_mpath mp env in
-    let params = me.me_sig.mis_params in
+    assert (me.me_params = []);
+    body_use env rm fdone mp us me.me_comps me.me_body
+
+  and item_use env rm fdone mp us item =
+    match item with
+    | MI_Module me -> mod_use env rm fdone us (EcPath.mqname mp me.me_name)
+    | MI_Variable v -> add_var env (xpath mp v.v_name) us
+    | MI_Function f -> fun_use_aux env rm fdone us (xpath mp f.f_name)
+
+  and body_use env rm fdone mp us comps body =
+    match body with
+    | ME_Alias _ -> assert false
+    | ME_Decl _ ->
+      let id = match mp.m_top with `Local id -> id | _ -> assert false in
+      let us = add_glob_except rm id us in
+      List.fold_left (item_use env rm fdone mp) us comps
+    | ME_Structure ms ->
+      List.fold_left (item_use env rm fdone mp) us ms.ms_body
+
+  and fun_use_aux env rm fdone us f =
+    gen_fun_use env fdone rm us f
+
+  let mod_use_top env mp =
+    let mp = norm_mpath env mp in
+    let me, _ = Mod.by_mpath mp env in
+    let params = me.me_params in
     let rm =
       List.fold_left (fun rm (id,_) -> Sid.add id rm) Sid.empty params in
     let env' = Mod.bind_locals params env in
@@ -2394,61 +2441,144 @@ module NormMp = struct
 
     let fdone = ref Sx.empty in
 
-    let rec mod_use us mp =
-      let mp = norm_mpath env' mp in
-      let me, _ = Mod.by_mpath mp env' in
-      assert (me.me_sig.mis_params = []);
-      body_use mp us me.me_comps me.me_body
-
-    and body_use mp us comps body =
-      match body with
-      | ME_Alias _ -> assert false
-      | ME_Decl _ ->
-        let id = match mp.m_top with `Local id -> id | _ -> assert false in
-        let us = add_glob_except rm id us in
-        List.fold_left (item_use mp) us comps
-      | ME_Structure ms ->
-        List.fold_left (item_use mp) us ms.ms_body
-
-    and item_use mp us item =
-      match item with
-      | MI_Module me -> mod_use us (EcPath.mqname mp me.me_name)
-      | MI_Variable v -> add_var env' (xpath_fun mp v.v_name) us
-      | MI_Function f -> fun_use us (xpath_fun mp f.f_name)
-
-    and fun_use us f = gen_fun_use env' fdone rm us f in
-
-    mod_use use_empty mp'
+    mod_use env' rm fdone use_empty mp'
 
   let mod_use env mp =
     try Mm.find mp !(env.env_norm).mod_use with Not_found ->
-      let res = mod_use env mp in
+      let res = mod_use_top env mp in
       let en = !(env.env_norm) in
       env.env_norm := { en with mod_use = Mm.add mp res en.mod_use };
       res
 
-  let norm_restr env (rx,r) =
-    let restr = Sx.fold (fun xp r -> add_var env xp r) rx use_empty in
-    Sm.fold (fun mp r -> use_union r (mod_use env mp)) r restr
+  let item_use env mp item =
+    item_use env Sid.empty (ref Sx.empty) mp use_empty item
 
-  let get_restr env mp =
-    try Mm.find mp !(env.env_norm).get_restr with Not_found ->
+  let restr_use env (mr : mod_restr) =
+    let get_use sx sm =
+      Sx.fold (fun xp r -> add_var env xp r) sx use_empty
+      |> Sm.fold (fun mp r -> use_union r (mod_use env mp)) sm in
+
+    (* If any of the two positive restrictions is [None], then anything is
+       allowed. *)
+    let ur_pos = match mr.mr_xpaths.ur_pos, mr.mr_mpaths.ur_pos with
+      | None, _ | _, None -> None
+      | Some sx, Some sm -> some @@ get_use sx sm in
+
+    { ur_pos = ur_pos;
+      ur_neg = get_use mr.mr_xpaths.ur_neg mr.mr_mpaths.ur_neg; }
+
+  let get_restr_use env mp =
+    try Mm.find mp !(env.env_norm).get_restr_use with Not_found ->
       let res =
         match (fst (Mod.by_mpath mp env)).me_body with
-        | EcModules.ME_Decl(_,restr) -> norm_restr env restr
+        | EcModules.ME_Decl mt -> restr_use env mt.mt_restr
         | _ -> assert false in
       let en = !(env.env_norm) in
-      env.env_norm := { en with get_restr = Mm.add mp res en.get_restr };
+      env.env_norm := { en with
+                        get_restr_use = Mm.add mp res en.get_restr_use };
       res
 
-  let equal_restr env r1 r2 = use_equal (norm_restr env r1) (norm_restr env r2)
+  let get_restr_me env me mp =
+    match me.me_body with
+    | EcModules.ME_Decl mt ->
+      (* As an invariant, we have that [mt] is fully applied. *)
+      assert (List.length mt.mt_params = List.length mt.mt_args);
+
+      (* We need to clear the oracle restriction using [me] params *)
+      let keep =
+        List.fold_left (fun k (x,_) ->
+            EcPath.Sm.add (EcPath.mident x) k) EcPath.Sm.empty me.me_params in
+      let keep_info f =
+        EcPath.Sm.mem (f.EcPath.x_top) keep in
+      let do1 oi = OI.filter keep_info oi in
+
+      { mt.mt_restr with
+        mr_oinfos = Msym.map do1 mt.mt_restr.mr_oinfos }
+
+    | _ ->
+      (* We compute the oracle call information. *)
+      let mparams =
+        List.fold_left (fun mparams (id,_) ->
+            Sm.add (EcPath.mident id) mparams) Sm.empty me.me_params in
+
+      let env = List.fold_left (fun env (x,mt) ->
+          Mod.bind_local x mt env
+        ) env me.me_params in
+
+      let comp_oi oi it = match it with
+        | MI_Module  _ | MI_Variable _ -> oi
+        | MI_Function f ->
+          let rec f_call c f =
+            let f = norm_xfun env f in
+            if EcPath.Sx.mem f c then c
+            else
+              let c = EcPath.Sx.add f c in
+              let fun_ = Fun.by_xpath f env in
+              match fun_.f_def with
+              | FBalias _ -> assert false
+              | FBdef def -> List.fold_left f_call c def.f_uses.us_calls
+              | FBabs oi  ->
+                List.fold_left f_call c (OI.allowed oi) in
+
+          let all_calls =
+            match f.f_def with
+            | FBalias f -> f_call EcPath.Sx.empty f
+            | FBdef def ->
+              List.fold_left f_call EcPath.Sx.empty def.f_uses.us_calls
+            | FBabs oi ->
+              List.fold_left f_call EcPath.Sx.empty (OI.allowed oi) in
+          let filter f =
+            let ftop = EcPath.m_functor f.EcPath.x_top in
+            Sm.mem ftop mparams in
+          let calls = List.filter filter (EcPath.Sx.elements all_calls) in
+
+          Msym.add f.f_name (OI.mk calls true `Unbounded) oi in
+
+      let oi = List.fold_left comp_oi Msym.empty me.me_comps in
+
+      (* We compute the postive restriction *)
+      let use = mod_use env mp in
+
+      let sx = EcPath.Mx.map (fun _ -> ()) use.us_pv in
+      let ur_xpaths = { ur_pos = Some sx;
+                        ur_neg = Sx.empty; } in
+
+      let sm = Sid.fold (fun m sm ->
+          Sm.add (EcPath.mident m) sm
+        ) use.us_gl Sm.empty in
+      let ur_mpaths = { ur_pos = Some sm;
+                      ur_neg = Sm.empty; } in
+
+      { mr_xpaths = ur_xpaths;
+        mr_mpaths = ur_mpaths;
+        mr_oinfos = oi; }
+
+  let get_restr env mp =
+    let mp = norm_mpath env mp in
+    let me, _ = Mod.by_mpath mp env in
+    get_restr_me env me mp
+
+  let equal_restr (f_equiv : form -> form -> bool) env r1 r2 =
+    let us1,us2 = restr_use env r1, restr_use env r2 in
+    ur_equal use_equal us1 us2
+    && Msym.equal (PreOI.equal f_equiv) r1.mr_oinfos r2.mr_oinfos
+
+
+  let sig_of_mp env mp =
+    let mp = norm_mpath env mp in
+    let me, _ = Mod.by_mpath mp env in
+
+    { mis_params = me.me_params;
+      mis_body = me.me_sig_body;
+      mis_restr = get_restr_me env me mp }
 
   let norm_pvar env pv =
-    let p =
-      if pv.pv_kind = PVglob then norm_xpv env pv.pv_name
-      else norm_xfun env pv.pv_name in
-    if   x_equal p pv.pv_name then pv
-    else EcTypes.pv p pv.pv_kind
+    match pv with
+    | PVloc _ -> pv
+    | PVglob xp ->
+      let p = norm_xpv env xp in
+      if   x_equal p xp then pv
+      else EcTypes.pv_glob p
 
   let globals env m mp =
     let us = mod_use env mp in
@@ -2485,14 +2615,7 @@ module NormMp = struct
         match gty with
         | GTty ty -> GTty (norm_ty env ty)
         | GTmodty _ -> gty
-        | GTmem None -> gty
-        | GTmem (Some mt) ->
-          let me =
-            EcMemory.empty_local id (norm_xfun env (EcMemory.lmt_xpath mt)) in
-          let me = Msym.fold (fun id (p,ty) me ->
-            EcMemory.bindp id p (norm_ty env ty) me)
-              (EcMemory.lmt_bindings mt) me  in
-          GTmem (snd me) in
+        | GTmem mt -> GTmem (mt_subst (norm_ty env) mt) in
       id,gty in
 
     let has_mod b =
@@ -2524,12 +2647,37 @@ module NormMp = struct
           if hf.hf_pr == pre' && hf.hf_f == p' && hf.hf_po == post' then f else
           f_hoareF pre' p' post'
 
+        | FcHoareF chf ->
+          let pre' = aux chf.chf_pr and p' = norm_xfun env chf.chf_f
+          and post' = aux chf.chf_po in
+          let c_self' = aux chf.chf_co.c_self in
+          let c_calls' = Mx.fold (fun f c calls ->
+              let f' = f        (* not normalized. *)
+              and c' = call_bound_r (aux c.cb_cost) (aux c.cb_called) in
+              Mx.change (fun old -> assert (old = None); Some c') f' calls
+            ) chf.chf_co.c_calls Mx.empty in
+          if chf.chf_pr == pre' && chf.chf_f == p' &&
+             chf.chf_po == post' && chf.chf_co.c_self == c_self' &&
+             Mx.equal (fun a b -> a == b) chf.chf_co.c_calls c_calls'
+          then f else
+            let calls' = cost_r c_self' c_calls' in
+            f_cHoareF pre' p' post' calls'
+
+        (* TODO: missing cases: FbdHoareF and every F*HoareS *)
+
         | FequivF ef ->
           let pre' = aux ef.ef_pr and l' = norm_xfun env ef.ef_fl
           and r' = norm_xfun env ef.ef_fr and post' = aux ef.ef_po in
           if ef.ef_pr == pre' && ef.ef_fl == l' &&
             ef.ef_fr == r' && ef.ef_po == post' then f else
           f_equivF pre' l' r' post'
+
+        | Fcoe coe ->
+          let coe' = {
+            coe_mem  = coe.coe_mem;
+            coe_pre  = aux coe.coe_pre;
+            coe_e    = coe.coe_e;
+          } in FSmart.f_coe (f, coe) coe'
 
         | Fpr pr ->
           let pr' = {
@@ -2539,7 +2687,8 @@ module NormMp = struct
             pr_event = aux pr.pr_event;
           } in FSmart.f_pr (f, pr) pr'
 
-        | _ -> EcCoreFol.f_map norm_ty1 aux f) in
+        | _ ->
+          EcCoreFol.f_map norm_ty1 aux f) in
     norm_form
 
   let norm_op env op =
@@ -2563,6 +2712,9 @@ module NormMp = struct
 
   let norm_ax env ax =
     { ax with ax_spec = norm_form env ax.ax_spec }
+
+  let norm_sc env sc =
+    { sc with axs_spec = norm_form env sc.axs_spec }
 
   let is_abstract_fun f env =
     let f = norm_xfun env f in
@@ -2615,7 +2767,8 @@ module ModTy = struct
     (* eta-normal form *)
     { mt_params = sig_.mis_params;
       mt_name   = p;
-      mt_args   = List.map (EcPath.mident -| fst) sig_.mis_params; }
+      mt_args   = List.map (EcPath.mident -| fst) sig_.mis_params;
+      mt_restr  = sig_.mis_restr; }
 
   let bind ?(import = import0) name modty env =
     let env = if import.im_immediate then MC.bind_modty name modty env else env in
@@ -2624,7 +2777,7 @@ module ModTy = struct
 
   exception ModTypeNotEquiv
 
-  let rec mod_type_equiv (env : env) (mty1 : module_type) (mty2 : module_type) =
+  let rec mod_type_equiv (f_equiv : form -> form -> bool) env mty1 mty2 =
     if not (EcPath.p_equal mty1.mt_name mty2.mt_name) then
       raise ModTypeNotEquiv;
 
@@ -2633,12 +2786,15 @@ module ModTy = struct
     if List.length mty1.mt_args <> List.length mty2.mt_args then
       raise ModTypeNotEquiv;
 
+    if not (NormMp.equal_restr f_equiv env mty1.mt_restr mty2.mt_restr) then
+      raise ModTypeNotEquiv;
+
     let subst =
       List.fold_left2
         (fun subst (x1, p1) (x2, p2) ->
           let p1 = EcSubst.subst_modtype subst p1 in
           let p2 = EcSubst.subst_modtype subst p2 in
-            mod_type_equiv env p1 p2;
+            mod_type_equiv f_equiv env p1 p2;
             EcSubst.add_module subst x1 (EcPath.mident x2))
         (EcSubst.empty ()) mty1.mt_params mty2.mt_params
     in
@@ -2652,12 +2808,12 @@ module ModTy = struct
             mty1.mt_args mty2.mt_args) then
       raise ModTypeNotEquiv
 
-  let mod_type_equiv env mty1 mty2 =
-    try  mod_type_equiv env mty1 mty2; true
+  let mod_type_equiv (f_equiv : form -> form -> bool) env mty1 mty2 =
+    try  mod_type_equiv f_equiv env mty1 mty2; true
     with ModTypeNotEquiv -> false
 
   let has_mod_type (env : env) (dst : module_type list) (src : module_type) =
-    List.exists (mod_type_equiv env src) dst
+    List.exists (mod_type_equiv f_equal env src) dst
 
   let sig_of_mt env (mt:module_type) =
     let { tms_sig = sig_ } = by_path mt.mt_name env in
@@ -2667,17 +2823,19 @@ module ModTy = struct
     let items =
       EcSubst.subst_modsig_body subst sig_.mis_body in
     let params = mt.mt_params in
+
     let keep =
       List.fold_left (fun k (x,_) ->
         EcPath.Sm.add (EcPath.mident x) k) EcPath.Sm.empty params in
     let keep_info f =
       EcPath.Sm.mem (f.EcPath.x_top) keep in
-    let do1 = function
-      | Tys_function(s,oi) ->
-        Tys_function(s,{oi_calls = List.filter keep_info oi.oi_calls;
-                        oi_in = oi.oi_in}) in
+    let do1 oi = OI.filter keep_info oi in
+    let restr = { mt.mt_restr with
+                  mr_oinfos = Msym.map do1 mt.mt_restr.mr_oinfos } in
+
     { mis_params = params;
-      mis_body   = List.map do1 items }
+      mis_body   = items;
+      mis_restr  = restr; }
 end
 
 (* -------------------------------------------------------------------- *)
@@ -2755,8 +2913,20 @@ module Op = struct
     try  EcDecl.is_rcrd (by_path p env)
     with LookupFailure _ -> false
 
-  let is_dtype_ctor env p =
-    try  EcDecl.is_ctor (by_path p env)
+  let is_dtype_ctor ?nargs env p =
+    try
+      match (by_path p env).op_kind with
+      | OB_oper (Some (OP_Constr (pt,i))) ->
+        begin
+          match nargs with
+          | None -> true
+          | Some nargs ->
+            let tyv = Ty.by_path pt env in
+            let tyv = oget (EcDecl.tydecl_as_datatype tyv) in
+            let ctor_ty = snd (List.nth tyv.tydt_ctors i) in
+            List.length ctor_ty = nargs
+        end
+      | _ -> false
     with LookupFailure _ -> false
 
   let is_fix_def env p =
@@ -2836,6 +3006,83 @@ module Ax = struct
 
   let all ?check ?name (env : env) =
     gen_all (fun mc -> mc.mc_axioms) MC.lookup_axioms ?check ?name env
+end
+
+
+(* -------------------------------------------------------------------- *)
+module Schema = struct
+  type t = ax_schema
+
+  let by_path_opt (p : EcPath.path) (env : env) =
+    omap
+      check_not_suspended
+      (MC.by_path (fun mc -> mc.mc_schemas) (IPPath p) env)
+
+  let by_path (p : EcPath.path) (env : env) =
+    match by_path_opt p env with
+    | None -> lookup_error (`Path p)
+    | Some obj -> obj
+
+  let add (p : EcPath.path) (env : env) =
+    let obj = by_path p env in
+      MC.import_schema p obj env
+
+  let lookup qname (env : env) =
+    MC.lookup_schema qname env
+
+  let lookup_opt name env =
+    try_lf (fun () -> lookup name env)
+
+  let lookup_path name env =
+    fst (lookup name env)
+
+  let bind ?(import = import0) name ax env =
+    let ax = NormMp.norm_sc env ax in
+    let env = MC.bind_schema name ax env in
+    { env with env_item = mkitem import (Th_schema (name, ax)) :: env.env_item }
+
+  let rebind name ax env =
+    MC.bind_schema name ax env
+
+  let instanciate p tys (mt : EcMemory.memtype) ps es env =
+    match by_path_opt p env with
+    | Some ({ axs_spec = f } as sc) ->
+      EcDecl.sc_instantiate
+        sc.axs_tparams sc.axs_pparams sc.axs_params
+        tys mt ps es f
+
+    | _ -> raise (LookupFailure (`Path p))
+
+  let iter ?name f (env : env) =
+    match name with
+    | Some name ->
+      let scs = MC.lookup_schemas name env in
+      List.iter (fun (p,sc) -> f p sc) scs
+
+    | None ->
+        Mip.iter
+          (fun _ mc -> MMsym.iter
+            (fun _ (ip, sc) ->
+              match ip with IPPath p -> f p sc | _ -> ())
+            mc.mc_schemas)
+          env.env_comps
+
+  let all ?(check = fun _ _ -> true) ?name (env : env) =
+    match name with
+    | Some name ->
+        let scs = MC.lookup_schemas name env in
+        List.filter (fun (p, sc) -> check p sc) scs
+
+    | None ->
+        Mip.fold (fun _ mc aout ->
+          MMsym.fold (fun _ schemas aout ->
+            List.fold_right (fun (ip, sc) aout ->
+              match ip with
+              | IPPath p -> if check p sc then (p, sc) :: aout else aout
+              | _ -> aout)
+              schemas aout)
+            mc.mc_schemas aout)
+          env.env_comps []
 end
 
 (* -------------------------------------------------------------------- *)
@@ -3056,6 +3303,9 @@ module Theory = struct
             then MC.import_axiom (xpath x) ax env
             else env
 
+        | Th_schema (x, schema) ->
+            MC.import_schema (xpath x) schema env
+
         | Th_modtype (x, mty) ->
             MC.import_modty (xpath x) mty env
 
@@ -3218,7 +3468,7 @@ let initial gstate = empty gstate
 
 (* -------------------------------------------------------------------- *)
 type ebinding = [
-  | `Variable  of EcTypes.pvar_kind * EcTypes.ty
+  | `Variable  of EcTypes.ty
   | `Function  of function_
   | `Module    of module_expr
   | `ModType   of module_sig
@@ -3227,10 +3477,10 @@ type ebinding = [
 (*  FIXME section :  Global ? *)
 let bind1 ((x, eb) : symbol * ebinding) (env : env) =
   match eb with
-  | `Variable v -> Var   .bind x (fst v) (snd v) env
-  | `Function f -> Fun   .bind x f env
-  | `Module   m -> Mod   .bind x {tme_expr = m; tme_loca = `Global} env
-  | `ModType  i -> ModTy .bind x {tms_sig  = i; tms_loca = `Global} env
+  | `Variable ty -> Var   .bind_pvglob x ty env
+  | `Function f  -> Fun   .bind x f env
+  | `Module   m  -> Mod   .bind x {tme_expr = m; tme_loca = `Global} env
+  | `ModType  i  -> ModTy .bind x {tms_sig  = i; tms_loca = `Global} env
 
 let bindall (items : (symbol * ebinding) list) (env : env) =
   List.fold_left ((^~) bind1) env items
@@ -3286,12 +3536,12 @@ module LDecl = struct
         LD_var (s.fs_ty ty, body |> omap (Fsubst.f_subst s))
 
     | LD_mem mt ->
-        let mt = EcMemory.mt_substm s.fs_sty.ts_p s.fs_mp s.fs_ty mt
+        let mt = EcMemory.mt_subst s.fs_ty mt
         in LD_mem mt
 
-    | LD_modty (p, r) ->
-        let (p, r) = gty_as_mod (Fsubst.gty_subst s (GTmodty (p, r)))
-        in LD_modty (p, r)
+    | LD_modty p ->
+        let p = gty_as_mod (Fsubst.subst_gty s (GTmodty p))
+        in LD_modty p
 
     | LD_hyp f ->
         LD_hyp (Fsubst.f_subst s f)
@@ -3309,14 +3559,17 @@ module LDecl = struct
       EcMemory.mt_fv mt
   | LD_hyp f ->
       f.f_fv
-  | LD_modty (p, r) ->
-      gty_fv (GTmodty(p,r))
+  | LD_modty p ->
+      gty_fv (GTmodty p)
   | LD_abs_st us ->
-      let add fv (x,_) =  EcPath.x_fv fv x.pv_name in
-      let fv = Mid.empty in
-      let fv = List.fold_left add fv us.aus_reads in
-      let fv = List.fold_left add fv us.aus_writes in
-      List.fold_left EcPath.x_fv fv us.aus_calls
+    let add fv (x,_) = match x with
+      | PVglob x -> EcPath.x_fv fv x
+      | PVloc _ -> fv in
+
+    let fv = Mid.empty in
+    let fv = List.fold_left add fv us.aus_reads in
+    let fv = List.fold_left add fv us.aus_writes in
+    List.fold_left EcPath.x_fv fv us.aus_calls
 
   (* ------------------------------------------------------------------ *)
   let by_name s hyps =
@@ -3360,7 +3613,7 @@ module LDecl = struct
     with LdeclError (LookupError _) -> false
 
   let has_inld s = function
-    | LD_mem (Some lmt) -> Msym.mem s (lmt_bindings lmt)
+    | LD_mem mt -> is_bound s mt
     | _ -> false
 
   let has_name ?(dep = false) s hyps =
@@ -3427,7 +3680,7 @@ module LDecl = struct
     match k with
     | LD_var (ty, _)  -> Var.bind_local x ty env
     | LD_mem mt       -> Memory.push (x, mt) env
-    | LD_modty (i, r) -> Mod.bind_local x i r env
+    | LD_modty i -> Mod.bind_local x i env
     | LD_hyp   _      -> env
     | LD_abs_st us    -> AbsStmt.bind x us env
 
@@ -3546,3 +3799,6 @@ module LDecl = struct
   let inv_memenv1 lenv =
     { lenv with le_env = Fun.inv_memenv1 lenv.le_env }
 end
+
+
+let pp_debug_form = ref (fun _env _fmt _f -> assert false)

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -23,19 +23,19 @@ type 'a suspension = {
 }
 
 (* -------------------------------------------------------------------- *)
-type varbind = {
-  vb_type  : EcTypes.ty;
-  vb_kind  :  [ `Proj of int | `Var of EcTypes.pvar_kind ];
-}
-
-(* -------------------------------------------------------------------- *)
 type env
+type scope = [
+  | `Theory
+  | `Module of EcPath.mpath
+  | `Fun    of EcPath.xpath
+]
 
 val initial : EcGState.gstate -> env
 val root    : env -> EcPath.path
 val mroot   : env -> EcPath.mpath
 val xroot   : env -> EcPath.xpath option
 val astop   : env -> env
+val scope   : env -> scope
 
 (* -------------------------------------------------------------------- *)
 val gstate : env -> EcGState.gstate
@@ -97,7 +97,6 @@ module Fun : sig
   val add   : xpath -> env -> env
 
   (* ------------------------------------------------------------------ *)
-  (* FIXME: what are these functions for? *)
   val prF_memenv : EcMemory.memory -> xpath -> env -> memenv
 
   val prF : xpath -> env -> env
@@ -108,9 +107,10 @@ module Fun : sig
 
   val hoareS : xpath -> env -> memenv * (funsig * function_def) * env
 
-  val actmem_post :  memory -> xpath -> function_ -> memenv
+  val actmem_body :  memory -> function_ -> (funsig * function_def) * memenv
+  val actmem_post :  memory -> function_ -> memenv
 
-  val inv_memory : [`Left|`Right] -> env -> memenv
+  val inv_memory : [`Left|`Right] -> memenv
 
   val inv_memenv : env -> env
 
@@ -125,7 +125,7 @@ end
 
 (* -------------------------------------------------------------------- *)
 module Var : sig
-  type t = varbind
+  type t = EcTypes.ty
 
   val by_xpath     : xpath -> env -> t
   val by_xpath_opt : xpath -> env -> t option
@@ -136,21 +136,22 @@ module Var : sig
   val lookup_local_opt : symbol -> env -> (EcIdent.t * EcTypes.ty) option
 
   val lookup_progvar     : ?side:memory -> qsymbol -> env ->
-    ([`Proj of EcTypes.prog_var * EcTypes.ty * (int*int) | `Var of EcTypes.prog_var ] *
+    ([`Proj of EcTypes.prog_var * proj_arg | `Var of EcTypes.prog_var ] *
      EcTypes.ty)
   val lookup_progvar_opt : ?side:memory -> qsymbol -> env ->
-    ([`Proj of EcTypes.prog_var * EcTypes.ty * (int*int) | `Var of EcTypes.prog_var ] *
+    ([`Proj of EcTypes.prog_var * proj_arg | `Var of EcTypes.prog_var ] *
      EcTypes.ty) option
 
+  exception DuplicatedLocalBinding of EcIdent.t
+
   (* Locals binding *)
-  val bind_local  : EcIdent.t -> EcTypes.ty -> env -> env
-  val bind_locals : (EcIdent.t * EcTypes.ty) list -> env -> env
+  val bind_local  : ?uniq:bool -> EcIdent.t -> EcTypes.ty -> env -> env
+  val bind_locals : ?uniq:bool -> (EcIdent.t * EcTypes.ty) list -> env -> env
 
   (* Program variables binding *)
-  val bind    : symbol -> pvar_kind -> EcTypes.ty -> env -> env
-  val bindall : (symbol * EcTypes.ty) list -> pvar_kind -> env -> env
+  val bind_pvglob    : symbol -> EcTypes.ty -> env -> env
+  val bindall_pvglob : (EcSymbols.symbol * EcTypes.ty) list -> env -> env
 
-  val add : xpath -> env -> env
 end
 
 (* -------------------------------------------------------------------- *)
@@ -173,6 +174,31 @@ module Ax : sig
 end
 
 (* -------------------------------------------------------------------- *)
+module Schema : sig
+  type t = ax_schema
+
+  val by_path     : path -> env -> t
+  val by_path_opt : path -> env -> t option
+  val lookup      : qsymbol -> env -> path * t
+  val lookup_opt  : qsymbol -> env -> (path * t) option
+  val lookup_path : qsymbol -> env -> path
+
+  val add  : path -> env -> env
+  val bind : ?import:EcTheory.import -> symbol -> ax_schema -> env -> env
+
+  val iter : ?name:qsymbol -> (path -> ax_schema -> unit) -> env -> unit
+
+  val all :
+    ?check:(path -> ax_schema -> bool) -> ?name:qsymbol -> env -> (path * t) list
+
+  val instanciate :
+    path ->
+    EcTypes.ty list -> EcMemory.memtype ->
+    mem_pr list -> EcTypes.expr list ->
+    env -> form
+end
+
+(* -------------------------------------------------------------------- *)
 module Mod : sig
   type t   = top_module_expr
   type lkt = module_expr * locality option
@@ -190,9 +216,12 @@ module Mod : sig
   val bind  : ?import:import -> symbol -> t -> env -> env
   val enter : symbol -> (EcIdent.t * module_type) list -> env -> env
 
-  val bind_local    : EcIdent.t -> module_type -> mod_restr -> env -> env
-  val declare_local : EcIdent.t -> module_type -> mod_restr -> env -> env
+  val bind_local    : EcIdent.t -> module_type -> env -> env
+  val bind_locals   : (EcIdent.t * module_type) list -> env -> env
+  val declare_local : EcIdent.t -> module_type -> env -> env
   val is_declared   : EcIdent.t -> env -> bool
+
+  val add_restr_to_locals : Sx.t use_restr -> Sm.t use_restr -> env -> env
 
   val import_vars : env -> mpath -> env
 
@@ -217,7 +246,8 @@ module ModTy : sig
   val add  : path -> env -> env
   val bind : ?import:import -> symbol -> t -> env -> env
 
-  val mod_type_equiv : env -> module_type -> module_type -> bool
+  val mod_type_equiv :
+    (form -> form -> bool) -> env -> module_type -> module_type -> bool
   val has_mod_type : env -> module_type list -> module_type -> bool
   val sig_of_mt :  env -> module_type -> module_sig
 end
@@ -228,20 +258,29 @@ type use = {
   us_gl : EcIdent.Sid.t;
 }
 
+val use_empty : use
+val use_union : use -> use -> use
+
 module NormMp : sig
-  val norm_mpath : env -> mpath -> mpath
-  val norm_xfun  : env -> xpath -> xpath
-  val norm_pvar  : env -> EcTypes.prog_var -> EcTypes.prog_var
-  val norm_form  : env -> form -> form
-  val mod_use    : env -> mpath -> use
-  val fun_use    : env -> xpath -> use
-  val norm_restr : env -> mod_restr  -> use
-  val equal_restr : env -> mod_restr -> mod_restr -> bool
-  val get_restr  : env -> mpath -> use
-  val use_mem_xp : xpath -> use -> bool
-  val use_mem_gl : mpath -> use -> bool
-  val norm_glob  : env -> EcMemory.memory -> mpath -> form
-  val norm_tglob : env -> mpath -> EcTypes.ty
+  val norm_mpath    : env -> mpath -> mpath
+  val norm_xfun     : env -> xpath -> xpath
+  val norm_pvar     : env -> EcTypes.prog_var -> EcTypes.prog_var
+  val norm_form     : env -> form -> form
+  val mod_use       : env -> mpath -> use
+  val fun_use       : env -> xpath -> use
+  val restr_use     : env -> mod_restr -> use use_restr
+  val get_restr_use : env -> mpath -> use use_restr
+  val get_restr_me  : env -> module_expr -> mpath -> mod_restr
+  val get_restr     : env -> mpath -> mod_restr
+
+  val sig_of_mp     : env -> mpath -> module_sig
+
+  (* Return [true] if [x] is forbidden in [restr]. *)
+  val use_mem_xp    : xpath -> use use_restr -> bool
+  val use_mem_gl    : mpath -> use use_restr -> bool
+
+  val norm_glob     : env -> EcMemory.memory -> mpath -> form
+  val norm_tglob    : env -> mpath -> EcTypes.ty
   val tglob_reducible : env -> mpath -> bool
   val is_abstract_fun : xpath -> env -> bool
   val x_equal         : env -> xpath -> xpath -> bool
@@ -295,7 +334,7 @@ module Op : sig
 
   val is_projection  : env -> path -> bool
   val is_record_ctor : env -> path -> bool
-  val is_dtype_ctor  : env -> path -> bool
+  val is_dtype_ctor  : ?nargs:int -> env -> path -> bool
   val is_fix_def     : env -> path -> bool
   val is_abbrev      : env -> path -> bool
   val is_prind       : env -> path -> bool
@@ -383,7 +422,11 @@ end
 (* -------------------------------------------------------------------- *)
 module Reduction : sig
   type rule   = EcTheory.rule
-  type topsym = [ `Path of path | `Tuple ]
+  type topsym = [
+    | `Path of path
+    | `Tuple
+    | `Cost of [`Path of path | `Tuple]
+  ]
 
   val add1 : path * rule_option * rule option -> env -> env
   val add  : ?import:import -> (path * rule_option * rule option) list -> env -> env
@@ -409,7 +452,7 @@ end
 
 (* -------------------------------------------------------------------- *)
 type ebinding = [
-  | `Variable  of EcTypes.pvar_kind * EcTypes.ty
+  | `Variable  of EcTypes.ty
   | `Function  of function_
   | `Module    of module_expr
   | `ModType   of module_sig
@@ -482,3 +525,5 @@ module LDecl : sig
   val inv_memenv  : hyps -> hyps
   val inv_memenv1 : hyps -> hyps
 end
+
+val pp_debug_form : (env -> Format.formatter -> form -> unit) ref

--- a/src/ecFol.ml
+++ b/src/ecFol.ml
@@ -10,7 +10,6 @@
 open EcIdent
 open EcUtils
 open EcTypes
-open EcModules
 open EcMemory
 open EcBigInt.Notations
 
@@ -21,9 +20,9 @@ module CI = EcCoreLib
 include EcCoreFol
 
 (* -------------------------------------------------------------------- *)
-let f_eqparams f1 ty1 vs1 m1 f2 ty2 vs2 m2 =
-  let f_pvlocs f ty vs m =
-    let arg = f_pvarg f ty m in
+let f_eqparams ty1 vs1 m1 ty2 vs2 m2 =
+  let f_pvlocs ty vs m =
+    let arg = f_pvarg ty m in
     if List.length vs = 1 then [arg]
     else
       let t = Array.of_list vs in
@@ -34,21 +33,21 @@ let f_eqparams f1 ty1 vs1 m1 f2 ty2 vs2 m2 =
   match vs1, vs2 with
   | Some vs1, Some vs2 ->
       if   List.length vs1 = List.length vs2
-      then f_eqs (f_pvlocs f1 ty1 vs1 m1) (f_pvlocs f2 ty2 vs2 m2)
-      else f_eq  (f_tuple (f_pvlocs f1 ty1 vs1 m1))
-                 (f_tuple (f_pvlocs f2 ty2 vs2 m2))
+      then f_eqs (f_pvlocs ty1 vs1 m1) (f_pvlocs ty2 vs2 m2)
+      else f_eq  (f_tuple (f_pvlocs ty1 vs1 m1))
+                 (f_tuple (f_pvlocs ty2 vs2 m2))
 
   | Some vs1, None ->
-      f_eq (f_tuple (f_pvlocs f1 ty1 vs1 m1)) (f_pvarg f2 ty2 m2)
+      f_eq (f_tuple (f_pvlocs ty1 vs1 m1)) (f_pvarg ty2 m2)
 
   | None, Some vs2 ->
-      f_eq (f_pvarg f1 ty1 m1) (f_tuple (f_pvlocs f2 ty2 vs2 m2))
+      f_eq (f_pvarg ty1 m1) (f_tuple (f_pvlocs ty2 vs2 m2))
 
   | None, None ->
-      f_eq (f_pvarg f1 ty1 m1) (f_pvarg f2 ty2 m2)
+      f_eq (f_pvarg ty1 m1) (f_pvarg ty2 m2)
 
-let f_eqres f1 ty1 m1 f2 ty2 m2 =
-  f_eq (f_pvar (pv_res f1) ty1 m1) (f_pvar (pv_res f2) ty2 m2)
+let f_eqres ty1 m1 ty2 m2 =
+  f_eq (f_pvar pv_res ty1 m1) (f_pvar pv_res ty2 m2)
 
 let f_eqglob mp1 m1 mp2 m2 =
   f_eq (f_glob mp1 m1) (f_glob mp2 m2)
@@ -73,6 +72,7 @@ let destr_rint f =
   | Fop (p, _) when EcPath.p_equal p CI.CI_Real.p_real1 -> BI.one
 
   | _ -> destr_error "destr_rint"
+
 
 (* -------------------------------------------------------------------- *)
 let fop_int_le     = f_op CI.CI_Int .p_int_le    [] (toarrow [tint ; tint ] tbool)
@@ -799,8 +799,10 @@ type sform =
   | SFeq    of form * form
   | SFop    of (EcPath.path * ty list) * (form list)
 
-  | SFhoareF   of hoareF
-  | SFhoareS   of hoareS
+  | SFhoareF  of sHoareF
+  | SFhoareS  of sHoareS
+  | SFcHoareF  of cHoareF
+  | SFcHoareS  of cHoareS
   | SFbdHoareF of bdHoareF
   | SFbdHoareS of bdHoareS
   | SFequivF   of equivF
@@ -839,8 +841,10 @@ let rec sform_of_form fp =
   | Fquant (q, [b]  , f) -> SFquant (q, b, lazy f)
   | Fquant (q, b::bs, f) -> SFquant (q, b, lazy (f_quant q bs f))
 
-  | FhoareF   hf -> SFhoareF   hf
-  | FhoareS   hs -> SFhoareS   hs
+  | FhoareF  hf -> SFhoareF  hf
+  | FhoareS  hs -> SFhoareS  hs
+  | FcHoareF  hf -> SFcHoareF  hf
+  | FcHoareS  hs -> SFcHoareS  hs
   | FbdHoareF hf -> SFbdHoareF hf
   | FbdHoareS hs -> SFbdHoareS hs
   | FequivF   ef -> SFequivF   ef

--- a/src/ecFol.mli
+++ b/src/ecFol.mli
@@ -10,7 +10,6 @@
 open EcBigInt
 open EcPath
 open EcTypes
-open EcModules
 open EcMemory
 
 (* -------------------------------------------------------------------- *)
@@ -20,13 +19,13 @@ include module type of struct include EcCoreFol end
 val f_losslessF: xpath -> form
 
 val f_eqparams:
-     xpath -> EcTypes.ty -> variable list option -> memory
-  -> xpath -> EcTypes.ty -> variable list option -> memory
+     EcTypes.ty -> variable list option -> memory
+  -> EcTypes.ty -> variable list option -> memory
   -> form
 
 val f_eqres:
-     xpath -> EcTypes.ty -> memory
-  -> xpath -> EcTypes.ty -> memory
+     EcTypes.ty -> memory
+  -> EcTypes.ty -> memory
   -> form
 
 val f_eqglob:
@@ -112,6 +111,7 @@ val f_eq_simpl    : form -> form -> form
 
 val f_int_le_simpl  : form -> form -> form
 val f_int_lt_simpl  : form -> form -> form
+
 val f_real_le_simpl : form -> form -> form
 val f_real_lt_simpl : form -> form -> form
 
@@ -194,8 +194,10 @@ type sform =
   | SFeq    of form * form
   | SFop    of (path * ty list) * (form list)
 
-  | SFhoareF   of hoareF
-  | SFhoareS   of hoareS
+  | SFhoareF  of sHoareF
+  | SFhoareS  of sHoareS
+  | SFcHoareF  of cHoareF
+  | SFcHoareS  of cHoareS
   | SFbdHoareF of bdHoareF
   | SFbdHoareS of bdHoareS
   | SFequivF   of equivF
@@ -225,3 +227,15 @@ module DestrReal : sig
   val div : form -> form * form
   val abs : form -> form
 end
+
+(* -------------------------------------------------------------------- *)
+(*val cost_sub_self : cost -> form -> cost
+val cost_add_self : cost -> form -> cost
+val cost_sub_call : EcEnv.env -> cost -> EcPath.xpath -> form -> cost
+val cost_add_call : EcEnv.env -> cost -> EcPath.xpath -> form -> cost
+
+val cost_map      : (form -> form) -> cost -> cost
+val cost_op       : EcEnv.env -> (form -> form -> form ) -> cost -> cost -> cost
+val cost_app      : cost -> form list -> cost
+
+val cost_flatten  : cost -> form *)

--- a/src/ecGState.ml
+++ b/src/ecGState.ml
@@ -67,6 +67,12 @@ let setvalue (name : string) (value : value) (g : gstate) =
   g.gs_values <- Mstr.add name value g.gs_values
 
 (* -------------------------------------------------------------------- *)
+let old_mem_restr = "old_mem_restr"
+
+let get_old_mem_restr (g : gstate) : bool =
+  getflag ~default:false old_mem_restr g
+
+(* -------------------------------------------------------------------- *)
 let add_notifier (notifier : loglevel -> string Lazy.t -> unit) (gs : gstate) =
   let notifier = { nt_id = EcUid.unique (); nt_cb = notifier; } in
   gs.gs_notifiers <- notifier :: gs.gs_notifiers; notifier.nt_id

--- a/src/ecGState.mli
+++ b/src/ecGState.mli
@@ -33,6 +33,10 @@ val getflag : ?default:bool -> string -> gstate -> bool
 val setflag : string -> bool -> gstate -> unit
 
 (* --------------------------------------------------------------------- *)
+val old_mem_restr : string
+val get_old_mem_restr : gstate -> bool
+
+(* --------------------------------------------------------------------- *)
 type nid_t
 type loglevel = [`Debug | `Info | `Warning | `Critical]
 

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -129,6 +129,7 @@ let process_simplify_info ri (tc : tcenv1) =
     EcReduction.logic   = if ri.plogic then Some `Full else None;
     EcReduction.modpath = ri.pmodpath;
     EcReduction.user    = ri.puser;
+    EcReduction.cost    = ri.pcost;
   }
 
 (*-------------------------------------------------------------------- *)
@@ -1848,6 +1849,16 @@ let process_cutdef ttenv (ip, pt) (tc : tcenv1) =
   FApi.t_sub
     [EcLowGoal.t_apply pt; process_intros_1 ttenv ip]
     (t_cut ax tc)
+
+(* -------------------------------------------------------------------- *)
+type cutdef_sc_t = intropattern * pcutdef_schema
+
+let process_cutdef_sc ttenv (ip, inst) (tc : tcenv1) =
+  let pt,sc_i = PT.tc1_process_sc_instantiation tc inst in
+
+  FApi.t_sub
+    [EcLowGoal.t_apply pt; process_intros_1 ttenv ip]
+    (t_cut sc_i tc)
 
 (* -------------------------------------------------------------------- *)
 let process_left (tc : tcenv1) =

--- a/src/ecHiGoal.mli
+++ b/src/ecHiGoal.mli
@@ -27,11 +27,12 @@ type ttenv = {
 type engine  = ptactic_core -> backward
 
 (* -------------------------------------------------------------------- *)
-type cut_t    = intropattern * pformula * (ptactics located) option
-type cutdef_t = intropattern * pcutdef
-type apply_t  = EcParsetree.apply_info
-type focus_t  = EcParsetree.tfocus
-type cutmode  = [`Have | `Suff]
+type cut_t       = intropattern * pformula * (ptactics located) option
+type cutdef_t    = intropattern * pcutdef
+type cutdef_sc_t = intropattern * pcutdef_schema
+type apply_t     = EcParsetree.apply_info
+type focus_t     = EcParsetree.tfocus
+type cutmode     = [`Have | `Suff]
 
 (* -------------------------------------------------------------------- *)
 val process_tfocus : tcenv -> focus_t -> tfocus
@@ -86,6 +87,7 @@ val process_rewrite     : ttenv -> ?target:psymbol -> rwarg list -> backward
 val process_subst       : pformula list -> backward
 val process_cut         : ?mode:cutmode -> engine -> ttenv -> cut_t -> backward
 val process_cutdef      : ttenv -> cutdef_t -> backward
+val process_cutdef_sc   : ttenv -> cutdef_sc_t -> backward
 val process_left        : backward
 val process_right       : backward
 val process_split       : backward

--- a/src/ecHiInductive.ml
+++ b/src/ecHiInductive.ml
@@ -46,9 +46,6 @@ let rcerror loc env e = raise (RcError (loc, env, e))
 let dterror loc env e = raise (DtError (loc, env, e))
 let fxerror loc env e = raise (FxError (loc, env, FXError e))
 
-
-
-
 (* -------------------------------------------------------------------- *)
 let trans_record (env : EcEnv.env) (name : ptydname) (rc : precord) =
   let { pl_loc = loc; pl_desc = (tyvars, name); } = name in

--- a/src/ecHiPredicates.ml
+++ b/src/ecHiPredicates.ml
@@ -39,7 +39,7 @@ let close_pr_body (uni : EcUnify.uidmap) (body : prbody) =
   | PR_Ind pri ->
      let for1 ctor =
        { prc_ctor = ctor.prc_ctor;
-         prc_bds  = List.map (snd_map (Fsubst.gty_subst fsubst)) ctor.prc_bds;
+         prc_bds  = List.map (snd_map (Fsubst.subst_gty fsubst)) ctor.prc_bds;
          prc_spec = List.map (Fsubst.f_subst fsubst) ctor.prc_spec; } in
      PR_Ind
        { pri_args  = List.map (snd_map tsubst) pri.pri_args;

--- a/src/ecInductive.mli
+++ b/src/ecInductive.mli
@@ -61,6 +61,10 @@ val datatype_projectors :
   path * ty_params * ty_dtype -> (symbol * operator) list
 
 (* -------------------------------------------------------------------- *)
+val datatype_projectors :
+  path * ty_params * ty_dtype -> (symbol * operator) list
+
+(* -------------------------------------------------------------------- *)
 type case1 = {
   cs1_ctor : EcPath.path;
   cs1_vars : (EcIdent.t * EcTypes.ty) list;

--- a/src/ecLexer.mll
+++ b/src/ecLexer.mll
@@ -66,6 +66,8 @@
     "res"         , RES        ;        (* KW: prog *)
     "equiv"       , EQUIV      ;        (* KW: prog *)
     "hoare"       , HOARE      ;        (* KW: prog *)
+    "choare"      , CHOARE     ;        (* KW: prog *)
+    "cost"        , COST       ;        (* KW: prog *)
     "phoare"      , PHOARE     ;        (* KW: prog *)
     "islossless"  , LOSSLESS   ;        (* KW: prog *)
     "async"       , ASYNC      ;        (* KW: prog *)
@@ -166,6 +168,7 @@
     "eager"       , EAGER      ;        (* KW: tactic *)
 
     "axiom"       , AXIOM      ;        (* KW: global *)
+    "schema"      , SCHEMA     ;        (* KW: global *)
     "axiomatized" , AXIOMATIZED;        (* KW: global *)
     "lemma"       , LEMMA      ;        (* KW: global *)
     "realize"     , REALIZE    ;        (* KW: global *)
@@ -197,6 +200,7 @@
     "type"        , TYPE       ;        (* KW: global *)
     "class"       , CLASS      ;        (* KW: global *)
     "instance"    , INSTANCE   ;        (* KW: global *)
+    "instantiate" , INSTANTIATE;        (* KW: global *)
     "print"       , PRINT      ;        (* KW: global *)
     "search"      , SEARCH     ;        (* KW: global *)
     "locate"      , LOCATE     ;        (* KW: global *)
@@ -401,6 +405,8 @@ rule main = parse
   | "{|"  { [LPBRACE   ] }
   | "|}"  { [RPBRACE   ] }
   | "`|"  { [TICKPIPE  ] }
+  | "`{"  { [TICKBRACE ] }
+  | "`("  { [TICKPAREN ] }
   | "<$"  { [LESAMPLE  ] }
   | "<@"  { [LEAT      ] }
   | ":~"  { [COLONTILD ] }

--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -401,12 +401,9 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
     in
 
     let default () =
-      if opts.fm_conv then begin
-        let subject = Fsubst.f_subst subst subject in
-        let ptn = Fsubst.f_subst (MEV.assubst ue !ev) ptn in
-          if not (conv ptn subject) then
-            failure ()
-      end else failure ()
+      let subject = Fsubst.f_subst subst subject in
+      let ptn = Fsubst.f_subst (MEV.assubst ue !ev) ptn in
+      if not (conv ptn subject) then failure ()
     in
 
     try
@@ -426,12 +423,14 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
       | Flocal x, _ -> begin
           match EV.get x !ev.evm_form with
           | None ->
+            (* TODO: bug? why not failure ()?*)
               raise MatchFailure
 
           | Some `Unset ->
               let ssbj = Fsubst.f_subst subst subject in
               let ssbj = Fsubst.f_subst (MEV.assubst ue !ev) ssbj in
               if not (Mid.set_disjoint mxs ssbj.f_fv) then
+                (* TODO: bug? why not failure ()?*)
                 raise MatchFailure;
               begin
                 try  EcUnify.unify env ue ptn.f_ty subject.f_ty
@@ -585,6 +584,29 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
             [hf2.bhf_pr; hf2.bhf_po; hf2.bhf_bd]
       end
 
+      | FcHoareF hf1, FcHoareF hf2 -> begin
+          let x2 = EcFol.Fsubst.subst_xpath subst hf2.chf_f in
+
+          if not (EcReduction.EqTest.for_xp env hf1.chf_f x2) then
+            failure ();
+          let mxs = Mid.add EcFol.mhr EcFol.mhr mxs in
+
+          let calls2 = EcPath.Mx.translate (EcFol.Fsubst.subst_xpath subst) hf2.chf_co.c_calls in
+
+          EcPath.Mx.fold2_union (fun _ cb1 cb2 () ->
+              match cb1, cb2 with
+              | None, None -> assert false
+              | None, Some _ | Some _, None -> failure ()
+              | Some cb1, Some cb2 ->
+                List.iter2 (doit env (subst, mxs))
+                  [cb1.cb_cost; cb1.cb_called]
+                  [cb2.cb_cost; cb2.cb_called]
+            ) hf1.chf_co.c_calls calls2 ();
+          List.iter2 (doit env (subst, mxs))
+            [hf1.chf_pr; hf1.chf_po; hf1.chf_co.c_self]
+            [hf2.chf_pr; hf2.chf_po; hf2.chf_co.c_self];
+        end
+
       | FequivF hf1, FequivF hf2 -> begin
           if not (EcReduction.EqTest.for_xp env hf1.ef_fl hf2.ef_fl) then
             failure ();
@@ -679,7 +701,7 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
 
   and doit_bindings env (subst, mxs) q1 q2 =
     let doit_binding (env, subst, mxs) (x1, gty1) (x2, gty2) =
-      let gty2 = Fsubst.gty_subst subst gty2 in
+      let gty2 = Fsubst.subst_gty subst gty2 in
 
       assert (not (Mid.mem x1 mxs) && not (Mid.mem x2 mxs));
 
@@ -700,38 +722,27 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
 
             (env, subst)
 
-        | GTmem None, GTmem None ->
-            (env, subst)
-
-        | GTmem (Some m1), GTmem (Some m2) ->
-            let xp1 = EcMemory.lmt_xpath m1 in
-            let xp2 = EcMemory.lmt_xpath m2 in
-            let m1  = EcMemory.lmt_bindings m1 in
-            let m2  = EcMemory.lmt_bindings m2 in
-
-            if not (EcPath.x_equal xp1 xp2) then
-              raise MatchFailure;
-            if not (
-              try
-                EcSymbols.Msym.equal
-                  (fun (p1,ty1) (p2,ty2) ->
-                    if p1 <> p2 then raise MatchFailure;
-                    EcUnify.unify env ue ty1 ty2; true)
-                  m1 m2
-              with EcUnify.UnificationFailure _ -> raise MatchFailure)
-            then
-              raise MatchFailure;
-
+        | GTmem mt1, GTmem mt2 ->
+            let on_ty ty1 ty2 =
+              try EcUnify.unify env ue ty1 ty2; true
+              with EcUnify.UnificationFailure _ -> false in
+            if not (EcMemory.mt_equal_gen on_ty mt1 mt2) then raise MatchFailure;
             let subst =
               if   id_equal x1 x2
               then subst
               else Fsubst.f_bind_mem subst x2 x1
             in (env, subst)
 
-        | GTmodty (p1, r1), GTmodty (p2, r2) ->
-            if not (ModTy.mod_type_equiv env p1 p2) then
-              raise MatchFailure;
-            if not (NormMp.equal_restr env r1 r2) then
+        | GTmodty p1, GTmodty p2 ->
+          let f_equiv f1 f2 =
+            try doit env (subst, mxs) f1 f2; true with
+            | MatchFailure ->
+                Format.eprintf "match failure:@\n%a@\n%a@."
+                  (!EcEnv.pp_debug_form env) f1
+                  (!EcEnv.pp_debug_form env) f2;
+                false in
+
+            if not (ModTy.mod_type_equiv f_equiv env p1 p2) then
               raise MatchFailure;
 
             let subst =
@@ -739,7 +750,7 @@ let f_match_core opts hyps (ue, ev) ~ptn subject =
               then subst
               else Fsubst.f_bind_mod subst x2 (EcPath.mident x1)
 
-            and env = EcEnv.Mod.bind_local x1 p1 r1 env in
+            and env = EcEnv.Mod.bind_local x1 p1 env in
 
             (env, subst)
 
@@ -869,6 +880,22 @@ module FPosition = struct
           | FhoareF hs ->
               doit pos (`WithCtxt (Sid.add EcFol.mhr ctxt, [hs.hf_pr; hs.hf_po]))
 
+          | FcHoareF chs ->
+            let subctxt = Sid.add EcFol.mhr ctxt in
+            let calls =
+              List.map (fun (_,cb) -> ctxt,cb.cb_called)
+                (EcPath.Mx.bindings chs.chf_co.c_calls) in
+            doit pos (`WithSubCtxt ((subctxt, chs.chf_pr) ::
+                                    (subctxt, chs.chf_po) ::
+                                    (ctxt, chs.chf_co.c_self) ::
+                                    calls))
+
+          | Fcoe coe ->
+            let subctxt = Sid.add (fst coe.coe_mem) ctxt in
+            doit pos (`WithSubCtxt [subctxt, coe.coe_pre])
+
+          (* TODO: A: From what I undertand, there is an error there:
+             it should be  (subctxt, hs.bhf_bd) *)
           | FbdHoareF hs ->
               let subctxt = Sid.add EcFol.mhr ctxt in
               doit pos (`WithSubCtxt ([(subctxt, hs.bhf_pr);
@@ -1016,6 +1043,28 @@ module FPosition = struct
               let (hf_pr, hf_po) = as_seq2 (doit p [hf.hf_pr; hf.hf_po]) in
               f_hoareF_r { hf with hf_pr; hf_po; }
 
+          | FcHoareF chf ->
+            let fkeys, calls = EcPath.Mx.bindings chf.chf_co.c_calls
+                               |> List.map (fun (f,cb) -> ((f,cb.cb_cost),
+                                                           cb.cb_called))
+                               |> List.split in
+            let sub = doit p (chf.chf_pr ::
+                              chf.chf_po ::
+                              chf.chf_co.c_self ::
+                              calls) in
+            begin match sub with
+              | chf_pr :: chf_po :: c_self :: calls ->
+                let c_calls = List.fold_left2 (fun acc (f,cb_cost) cb_called ->
+                    EcPath.Mx.change
+                      (fun old ->
+                         assert (old = None);
+                         Some (call_bound_r cb_cost cb_called)) f acc
+                  ) EcPath.Mx.empty fkeys calls in
+                let cost = cost_r c_self c_calls in
+                f_cHoareF_r { chf with chf_pr; chf_po;
+                                       chf_co = cost; }
+              | _ -> assert false end
+
           | FbdHoareF hf ->
               let sub = doit p [hf.bhf_pr; hf.bhf_po; hf.bhf_bd] in
               let (bhf_pr, bhf_po, bhf_bd) = as_seq3 sub in
@@ -1025,7 +1074,13 @@ module FPosition = struct
               let (ef_pr, ef_po) = as_seq2 (doit p [ef.ef_pr; ef.ef_po]) in
               f_equivF_r { ef with ef_pr; ef_po; }
 
+          | Fcoe coe ->
+              let sub = doit p [coe.coe_pre] in
+              let pre = as_seq1 sub in
+              f_coe_r { coe with coe_pre = pre }
+
           | FhoareS   _ -> raise InvalidPosition
+          | FcHoareS  _ -> raise InvalidPosition
           | FbdHoareS _ -> raise InvalidPosition
           | FequivS   _ -> raise InvalidPosition
           | FeagerF   _ -> raise InvalidPosition

--- a/src/ecMemory.ml
+++ b/src/ecMemory.ml
@@ -19,110 +19,298 @@ type memory = EcIdent.t
 let mem_equal = EcIdent.id_equal
 
 (* -------------------------------------------------------------------- *)
-type local_memtype = {
-  mt_path : EcPath.xpath;
-  mt_vars : ((int*int) option * ty) Msym.t
-}
+type proj_arg =
+  { arg_ty  : ty; (* type of the procedure argument "arg" *)
+    arg_pos : int;       (* projection *)
+  }
 
-type memtype = local_memtype option
+type local_memtype = {
+    mt_name : symbol option;      (* provides access to the full local memory *)
+    mt_decl : variable list;
+    mt_proj : (int * ty) Msym.t;  (* where to find the symbol in mt_decl and its type *)
+    mt_ty   : ty;                 (* ttuple (List.map v_type mt_decl) *)
+    mt_n    : int;                (* List.length mt_decl *)
+  }
+
+let mk_lmt mt_name mt_decl mt_proj =
+  { mt_name;
+    mt_decl;
+    mt_proj;
+    mt_ty = ttuple (List.map v_type mt_decl);
+    mt_n  = List.length mt_decl;
+  }
+
+(* [Lmt_schema] if for an axiom schema, and is instantiated to a concrete
+   memory type when the axiom schema is.  *)
+type memtype =
+  | Lmt_concrete of local_memtype option
+  | Lmt_schema
+
+let lmem_hash lmem =
+  let el_hash (s,(i,ty)) =
+    Why3.Hashcons.combine2
+      (Hashtbl.hash s)
+      i (EcTypes.ty_hash ty) in
+  let mt_proj_hash =
+    Why3.Hashcons.combine_list el_hash 0 (Msym.bindings lmem.mt_proj) in
+  let mt_name_hash = Why3.Hashcons.combine_option Hashtbl.hash lmem.mt_name in
+  let mt_decl_hash = Why3.Hashcons.combine_list EcTypes.v_hash 0 lmem.mt_decl in
+  Why3.Hashcons.combine_list
+    (fun i -> i)
+    (EcTypes.ty_hash lmem.mt_ty)
+    [ lmem.mt_n;
+      mt_name_hash;
+      mt_decl_hash;
+      mt_proj_hash; ]
 
 let mt_fv = function
-  | None -> EcIdent.Mid.empty
-  | Some lmt ->
-    let fv = EcPath.x_fv EcIdent.Mid.empty lmt.mt_path in
-    Msym.fold (fun _ (_,ty) fv -> EcIdent.fv_union fv ty.ty_fv) lmt.mt_vars fv
+  | Lmt_schema              -> EcIdent.Mid.empty
+  | Lmt_concrete None       -> EcIdent.Mid.empty
+  | Lmt_concrete (Some lmt) ->
+    List.fold_left (fun fv v ->
+        EcIdent.fv_union fv v.v_type.ty_fv
+      ) EcIdent.Mid.empty lmt.mt_decl
 
-let lmt_equal mt1 mt2 =
-  EcPath.x_equal mt1.mt_path mt2.mt_path &&
-    Msym.equal (fun (p1,ty1) (p2,ty2) -> p1 = p2 && ty_equal ty1 ty2)
-      mt1.mt_vars mt2.mt_vars
+let lmt_equal ty_equal mt1 mt2 =
+  mt1.mt_name = mt2.mt_name
+  &&
+    if mt1.mt_name = None
+    then
+      Msym.equal (fun (_,ty1) (_,ty2) ->
+          ty_equal ty1 ty2
+        ) mt1.mt_proj mt2.mt_proj
+    else
+      List.all2 (fun v1 v2 ->
+          v1.v_name = v2.v_name
+          && ty_equal v1.v_type v2.v_type)
+        mt1.mt_decl mt2.mt_decl
 
-let lmt_xpath mt = mt.mt_path
-let lmt_bindings mt = mt.mt_vars
-
-let mt_equal mt1 mt2 =
+let mt_equal_gen ty_equal mt1 mt2 =
   match mt1, mt2 with
-  | Some mt1, Some mt2 -> lmt_equal mt1 mt2
-  | None, None         -> true
-  | _   , _            -> false
+  | Lmt_schema,     Lmt_schema -> true
 
-let mt_xpath = function
-  | None -> assert false
-  | Some mt -> lmt_xpath mt
+  | Lmt_schema,     Lmt_concrete _
+  | Lmt_concrete _, Lmt_schema -> false
 
-let mt_bindings = function
-  | None -> assert false
-  | Some mt -> lmt_bindings mt
+  | Lmt_concrete mt1, Lmt_concrete mt2 ->
+    oeq (lmt_equal ty_equal) mt1 mt2
+
+let mt_equal = mt_equal_gen ty_equal
+
+let mt_iter_ty f mt = match mt with
+  | Lmt_schema -> ()
+  | Lmt_concrete mt ->
+    oiter (fun lmt -> List.iter (fun v -> f v.v_type) lmt.mt_decl) mt
 
 (* -------------------------------------------------------------------- *)
 type memenv = memory * memtype
 
-let me_equal (m1,mt1) (m2,mt2) =
-  mem_equal m1 m2 && mt_equal mt1 mt2
+let mem_hash (mem,mt) = match mt with
+  | Lmt_schema -> 0
+  | Lmt_concrete mt ->
+    Why3.Hashcons.combine
+      (EcIdent.id_hash mem)
+      (Why3.Hashcons.combine_option lmem_hash mt)
+
+let me_equal_gen ty_equal (m1,mt1) (m2,mt2) =
+  mem_equal m1 m2 && mt_equal_gen ty_equal mt1 mt2
+
+let me_equal = me_equal_gen ty_equal
 
 (* -------------------------------------------------------------------- *)
 let memory   (m,_) = m
 let memtype  (_,mt) = mt
-let xpath    (_,mt) = mt_xpath mt
-let bindings (_,mt) = mt_bindings mt
 
 (* -------------------------------------------------------------------- *)
 exception DuplicatedMemoryBinding of symbol
 
 (* -------------------------------------------------------------------- *)
-let empty_local (me : memory) mp =
-  (me, Some {mt_path   = mp; mt_vars   = Msym.empty; } )
+let empty_local_mt ~witharg =
+  let lmt = mk_lmt (if witharg then Some arg_symbol else None) [] Msym.empty in
+  Lmt_concrete (Some lmt)
 
-let abstract (me:memory) = (me,None)
+let empty_local ~witharg (me : memory) =
+  me, empty_local_mt ~witharg
 
-(* -------------------------------------------------------------------- *)
-let bindp (x : symbol) pr (ty : EcTypes.ty) ((m,mt) : memenv) =
-  let mt = match mt with
-    | None -> assert false
-    | Some mt -> mt in
-  let merger = function
-    | Some _ -> raise (DuplicatedMemoryBinding x)
-    | None   -> Some (pr,ty)
-  in
-    (m, Some { mt with mt_vars = Msym.change merger x mt.mt_vars })
+let schema_mt = Lmt_schema
+let schema (me:memory) = me, schema_mt
 
-let bind_proj i n x ty me = bindp x (Some (i,n)) ty me
-let bind x ty me = bindp x None ty me
+let abstract_mt = Lmt_concrete None
+let abstract (me:memory) = me, abstract_mt
+
+let is_schema = function Lmt_schema -> true | _ -> false
 
 (* -------------------------------------------------------------------- *)
-let lookup (x : symbol) ((_,mt) : memenv) =
+
+let is_bound_lmt x lmt =
+  Some x = lmt.mt_name || Msym.mem x lmt.mt_proj
+
+let is_bound x mt =
   match mt with
-  | None -> None
-  | Some mt ->  Msym.find_opt x (lmt_bindings mt)
+  | Lmt_schema -> false
+  | Lmt_concrete None -> false
+  | Lmt_concrete (Some lmt) -> is_bound_lmt x lmt
 
-let is_bound x me = lookup x me <> None
+let lookup (x : symbol) (mt : memtype) : (variable * proj_arg option * int option) option =
+  match mt with
+  | Lmt_schema        -> None
+  | Lmt_concrete None -> None
+  | Lmt_concrete (Some lmt) ->
+    if lmt.mt_name = Some x then
+      Some ({v_name = x; v_type = lmt.mt_ty}, None, None)
+    else
+      match Msym.find_opt x lmt.mt_proj with
+      | Some (i,xty) ->
+        if lmt.mt_n = 1 then
+          Some ({ v_name = odfl x lmt.mt_name; v_type = xty}, None, None)
+        else
+          let v = { v_name = x; v_type = xty } in
+          let pa =
+            if lmt.mt_name = None then None
+            else Some { arg_ty = lmt.mt_ty; arg_pos = i; } in
+          Some(v, pa, Some i)
+      | None -> None
 
-let is_bound_pv pv me =
-  is_loc pv && is_bound (EcPath.xbasename pv.pv_name) me
+let lookup_me x me = lookup x (snd me)
+
+let is_bound_pv pv me = match pv with
+  | PVglob _ -> false
+  | PVloc id -> is_bound id me
+
 (* -------------------------------------------------------------------- *)
-let mt_subst sx st o =
+let bindall_lmt (vs:variable list) lmt =
+  let n = List.length lmt.mt_decl in
+  let add_proj mt_proj i v =
+    let x = v.v_name in
+    if lmt.mt_name = Some x then raise (DuplicatedMemoryBinding x);
+    if x = "_" then mt_proj
+    else
+      let merger = function
+        | Some _ -> raise (DuplicatedMemoryBinding x)
+        | None   -> Some (n + i,v.v_type) in
+    Msym.change merger x mt_proj in
+  let mt_decl = lmt.mt_decl @ vs in
+  let mt_proj = List.fold_lefti add_proj lmt.mt_proj vs in
+  mk_lmt lmt.mt_name mt_decl mt_proj
+
+let bindall_mt (vs:variable list) (mt : memtype) : memtype =
+  match mt with
+  | Lmt_schema | Lmt_concrete None -> assert false
+  | Lmt_concrete (Some lmt) -> Lmt_concrete (Some (bindall_lmt vs lmt))
+
+let bindall (vs:variable list) ((m,mt) : memenv) : memenv =
+  m, bindall_mt vs mt
+
+let bindall_fresh (vs:variable list) ((m,mt) : memenv) =
+  match mt with
+  | Lmt_schema | Lmt_concrete None -> assert false
+  | Lmt_concrete (Some lmt) ->
+    let is_bound x m = Some x = lmt.mt_name || Msym.mem x m in
+    let fresh_pv m v =
+      let name = v.v_name in
+      if name = "_" then m, v
+      else
+        let name =
+          if not(is_bound name m) then name
+          else
+            let rec for_idx idx =
+              let x = Printf.sprintf "%s%d" name idx in
+              if is_bound x m then for_idx (idx+1)
+              else x in
+            for_idx 0 in
+        Msym.add name (-1,v.v_type) m, {v with v_name = name } in
+    let _, vs = List.map_fold fresh_pv lmt.mt_proj vs in
+    let lmt = bindall_lmt vs lmt in
+    (m, Lmt_concrete (Some lmt)), vs
+
+let bind_fresh v me =
+  let me, vs = bindall_fresh [v] me in
+  me, as_seq1 vs
+
+(* -------------------------------------------------------------------- *)
+
+let mt_subst st o =
   match o with
-  | None -> o
-  | Some mt ->
-    let p' = sx mt.mt_path in
-    let vars' =
-      if st == identity then mt.mt_vars else
-        Msym.map (fun (p,ty) -> p, st ty) mt.mt_vars in
-           (* FIXME could be greate to use smart_map *)
-    if p' == mt.mt_path && vars' == mt.mt_vars then o else
-      Some { mt_path   = p'; mt_vars   = vars' }
+  | Lmt_schema -> o
+  | Lmt_concrete None -> o
+  | Lmt_concrete (Some mt) ->
+    let decl = mt.mt_decl in
+    let decl' =
+      if st == identity then decl
+      else
+        List.Smart.map (fun vty ->
+            let ty' = st vty.v_type in
+            if ty_equal vty.v_type ty' then vty else {vty with v_type = ty'}) decl in
+    if decl == decl' then o
+    else
+      let lmt = mk_lmt
+          mt.mt_name decl' (Msym.map (fun (i,ty) -> i, st ty) mt.mt_proj) in
+      Lmt_concrete (Some lmt)
 
-let mt_substm sp smp st o =
-  mt_subst (EcPath.x_substm sp smp) st o
-
-let me_subst sx sm st (m,mt as me) =
+let me_subst sm st (m,mt as me) =
   let m' = EcIdent.Mid.find_def m m sm in
-  let mt' = mt_subst sx st mt in
+  let mt' = mt_subst st mt in
   if m' == m && mt' == mt then me else
     (m', mt')
 
-let me_substm sp smp sm st me =
-  me_subst (EcPath.x_substm sp smp) sm st me
+(* -------------------------------------------------------------------- *)
+let for_printing mt =
+  match mt with
+  | Lmt_schema -> None
+  | Lmt_concrete None -> None
+  | Lmt_concrete (Some mt) -> Some (mt.mt_name, mt.mt_decl)
 
 
+(* -------------------------------------------------------------------- *)
+let rec pp_list sep pp fmt xs =
+  let pp_list = pp_list sep pp in
+    match xs with
+    | []      -> ()
+    | [x]     -> Format.fprintf fmt "%a" pp x
+    | x :: xs -> Format.fprintf fmt "%a%(%)%a" pp x sep pp_list xs
 
+let dump_memtype mt =
+  match mt with
+  | Lmt_schema        -> "schema"
+  | Lmt_concrete None -> "abstract"
+  | Lmt_concrete (Some mt) ->
+    let pp_vd fmt v =
+      Format.fprintf fmt "@[%s: %s@]" v.v_name (EcTypes.dump_ty v.v_type)
+    in
+    Format.asprintf "@[{@[%a@]}@]" (pp_list ",@ " pp_vd) mt.mt_decl
+
+(* -------------------------------------------------------------------- *)
+let get_name s p (_,mt) =
+  match mt with
+  | Lmt_schema        -> None
+  | Lmt_concrete None -> None
+  | Lmt_concrete (Some mt) ->
+    match p with
+    | None ->
+      if Some s = mt.mt_name then
+        match mt.mt_decl with
+        | [v] when v.v_name <> "_" -> Some v.v_name
+        | _ -> Some s
+      else
+        begin match Msym.find_opt s mt.mt_proj with
+        | Some _ -> Some s
+        | None   -> None
+        end
+    | Some i ->
+      if Some s = mt.mt_name then
+        omap fst (List.find_opt (fun (_,(i',_)) -> i = i') (Msym.bindings mt.mt_proj))
+      else
+        None
+
+(* -------------------------------------------------------------------- *)
+
+let local_type mt =
+  match mt with
+  | Lmt_schema -> assert false
+  | Lmt_concrete None -> None
+  | Lmt_concrete (Some mt) -> Some (ttuple (List.map v_type mt.mt_decl))
+
+let has_locals mt = match mt with
+  | Lmt_concrete (Some _) -> true
+  | Lmt_concrete None -> false
+  | Lmt_schema -> assert false

--- a/src/ecModules.ml
+++ b/src/ecModules.ml
@@ -1,745 +1,113 @@
 (* --------------------------------------------------------------------
  * Copyright (c) - 2012--2016 - IMDEA Software Institute
- * Copyright (c) - 2012--2021 - Inria
- * Copyright (c) - 2012--2021 - Ecole Polytechnique
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
  *
  * Distributed under the terms of the CeCILL-C-V1 license
  * -------------------------------------------------------------------- *)
 
 (* -------------------------------------------------------------------- *)
-open EcUtils
 open EcSymbols
-open EcTypes
 open EcPath
+open EcCoreFol
 
 module Sid = EcIdent.Sid
 module Mid = EcIdent.Mid
 
 (* -------------------------------------------------------------------- *)
-type lvalue =
-  | LvVar   of (EcTypes.prog_var * EcTypes.ty)
-  | LvTuple of (EcTypes.prog_var * EcTypes.ty) list
-
-let lv_equal lv1 lv2 =
-  match lv1, lv2 with
-  | LvVar (pv1, ty1), LvVar (pv2, ty2) ->
-         (EcTypes.pv_equal pv1 pv2)
-      && (EcTypes.ty_equal ty1 ty2)
-
-  | LvTuple tu1, LvTuple tu2 ->
-      List.all2
-        (fun (pv1, ty1) (pv2, ty2) ->
-             (EcTypes.pv_equal pv1 pv2)
-          && (EcTypes.ty_equal ty1 ty2))
-        tu1 tu2
-
-  | _, _ -> false
+include EcCoreModules
 
 (* -------------------------------------------------------------------- *)
-let lv_fv = function
-  | LvVar (pv, _) ->
-      EcTypes.pv_fv pv
+(* Instantiation of EcCoreModules.PreOI on EcCoreFol.form. *)
+module OI : sig
+  type t = form PreOI.t
 
-  | LvTuple pvs ->
-      let add s (pv, _) = EcIdent.fv_union s (EcTypes.pv_fv pv) in
-      List.fold_left add Mid.empty pvs
+  val hash : t -> int
+  val equal : t -> t -> bool
 
-let symbol_of_lv = function
-  | LvVar (pv, _) ->
-      EcTypes.symbol_of_pv pv
+  val is_in : t -> bool
 
-  | LvTuple pvs ->
-      String.concat "" (List.map (EcTypes.symbol_of_pv |- fst) pvs)
+  val cost_self : t -> [`Bounded of form | `Unbounded]
+  val cost : t -> xpath -> [`Bounded of form | `Zero | `Unbounded]
+  val cost_calls : t -> [`Bounded of form Mx.t | `Unbounded]
+  val costs : t -> [`Bounded of form * form Mx.t | `Unbounded]
 
-let ty_of_lv = function
-  | LvVar   (_, ty)       -> ty
-  | LvTuple tys           -> EcTypes.ttuple (List.map snd tys)
+  val allowed : t -> xpath list
+  val allowed_s : t -> Sx.t
 
-let lv_of_list = function
-  | [] -> None
-  | [(pv, ty)] -> Some (LvVar (pv, ty))
-  | pvs -> Some (LvTuple pvs)
-
-(* -------------------------------------------------------------------- *)
-type instr = {
-  i_node : instr_node;
-  i_fv : int Mid.t;
-  i_tag  : int;
-}
-
-and instr_node =
-  | Sasgn     of lvalue * EcTypes.expr
-  | Srnd      of lvalue * EcTypes.expr
-  | Scall     of lvalue option * EcPath.xpath * EcTypes.expr list
-  | Sif       of EcTypes.expr * stmt * stmt
-  | Swhile    of EcTypes.expr * stmt
-  | Smatch    of expr * ((EcIdent.t * EcTypes.ty) list * stmt) list
-  | Sassert   of EcTypes.expr
-  | Sabstract of EcIdent.t
-
-and stmt = {
-  s_node : instr list;
-  s_fv   : int Mid.t;
-  s_tag  : int;
-}
-
-(* -------------------------------------------------------------------- *)
-let i_equal   = ((==) : instr -> instr -> bool)
-let i_hash    = fun i -> i.i_tag
-let i_compare = fun i1 i2 -> i_hash i1 - i_hash i2
-let i_fv i    = i.i_fv
-let i_node i  = i.i_node
-
-let s_equal   = ((==) : stmt -> stmt -> bool)
-let s_hash    = fun s -> s.s_tag
-let s_compare = fun s1 s2 -> s_hash s1 - s_hash s2
-let s_fv      = fun s -> s.s_fv
-
-(* -------------------------------------------------------------------- *)
-module Hinstr = Why3.Hashcons.Make (struct
-  type t = instr
-
-  let equal_node i1 i2 =
-    match i1, i2 with
-    | Sasgn (lv1, e1), Sasgn (lv2, e2) ->
-        (lv_equal lv1 lv2) && (EcTypes.e_equal e1 e2)
-
-    | Srnd (lv1, e1), Srnd (lv2, e2) ->
-        (lv_equal lv1 lv2) && (EcTypes.e_equal e1 e2)
-
-    | Scall (lv1, f1, es1), Scall (lv2, f2, es2) ->
-           (EcUtils.opt_equal lv_equal lv1 lv2)
-        && (EcPath.x_equal f1 f2)
-        && (List.all2 EcTypes.e_equal es1 es2)
-
-    | Sif (c1, s1, r1), Sif (c2, s2, r2) ->
-           (EcTypes.e_equal c1 c2)
-        && (s_equal s1 s2)
-        && (s_equal r1 r2)
-
-    | Swhile (c1, s1), Swhile (c2, s2) ->
-           (EcTypes.e_equal c1 c2)
-        && (s_equal s1 s2)
-
-    | Smatch (e1, b1), Smatch (e2, b2) when List.length b1 = List.length b2 ->
-        let forb (bs1, s1) (bs2, s2) =
-          let forbs (x1, ty1) (x2, ty2) =
-               EcIdent.id_equal x1  x2
-            && EcTypes.ty_equal ty1 ty2
-          in List.all2 forbs bs1 bs2 && s_equal s1 s2
-        in EcTypes.e_equal e1 e2 && List.all2 forb b1 b2
-
-    | Sassert e1, Sassert e2 ->
-        (EcTypes.e_equal e1 e2)
-
-    | Sabstract id1, Sabstract id2 -> EcIdent.id_equal id1 id2
-
-    | _, _ -> false
-
-  let equal i1 i2 = equal_node i1.i_node i2.i_node
-
-  let hash p =
-    match p.i_node with
-    | Sasgn (lv, e) ->
-        Why3.Hashcons.combine
-          (Hashtbl.hash lv) (EcTypes.e_hash e)
-
-    | Srnd (lv, e) ->
-        Why3.Hashcons.combine
-          (Hashtbl.hash lv) (EcTypes.e_hash e)
-
-    | Scall (lv, f, tys) ->
-        Why3.Hashcons.combine_list EcTypes.e_hash
-          (Why3.Hashcons.combine
-             (Hashtbl.hash lv) (EcPath.x_hash f))
-          tys
-
-    | Sif (c, s1, s2) ->
-        Why3.Hashcons.combine2
-          (EcTypes.e_hash c) (s_hash s1) (s_hash s2)
-
-    | Swhile (c, s) ->
-        Why3.Hashcons.combine (EcTypes.e_hash c) (s_hash s)
-
-    | Smatch (e, b) ->
-        let forb (bds, s) =
-          let forbs (x, ty) =
-            Why3.Hashcons.combine (EcIdent.id_hash x) (EcTypes.ty_hash ty)
-          in Why3.Hashcons.combine_list forbs (s_hash s) bds
-        in Why3.Hashcons.combine_list forb (EcTypes.e_hash e) b
-
-    | Sassert e -> EcTypes.e_hash e
-
-    | Sabstract id -> EcIdent.id_hash id
-
-  let i_fv = function
-    | Sasgn (lv, e) ->
-        EcIdent.fv_union (lv_fv lv) (EcTypes.e_fv e)
-
-    | Srnd (lv, e) ->
-        EcIdent.fv_union (lv_fv lv) (EcTypes.e_fv e)
-
-    | Scall (olv, f, args) ->
-        let ffv = EcPath.x_fv Mid.empty f in
-        let ofv = olv |> omap lv_fv |> odfl Mid.empty in
-        List.fold_left
-          (fun s a -> EcIdent.fv_union s (EcTypes.e_fv a))
-          (EcIdent.fv_union ffv ofv) args
-
-    | Sif (e, s1, s2) ->
-        List.fold_left EcIdent.fv_union Mid.empty
-          [EcTypes.e_fv e; s_fv s1; s_fv s2]
-
-    | Swhile (e, s) ->
-        EcIdent.fv_union (EcTypes.e_fv e) (s_fv s)
-
-    | Smatch (e, b) ->
-        let forb (bs, s) =
-          let bs = Sid.of_list (List.map fst bs) in
-          EcIdent.fv_diff (s_fv s) bs
-
-        in List.fold_left
-             (fun s b -> EcIdent.fv_union s (forb b))
-             (EcTypes.e_fv e) b
-
-    | Sassert e ->
-        EcTypes.e_fv e
-
-    | Sabstract id ->
-        EcIdent.fv_singleton id
-
-  let tag n p = { p with i_tag = n; i_fv = i_fv p.i_node }
-end)
-
-(* -------------------------------------------------------------------- *)
-module Hstmt = Why3.Hashcons.Make (struct
-  type t = stmt
-
-  let equal_node s1 s2 =
-    List.all2 i_equal s1 s2
-
-  let equal s1 s2 = equal_node s1.s_node s2.s_node
-
-  let hash p =
-    Why3.Hashcons.combine_list i_hash 0 p.s_node
-
-  let tag n p =
-    let fv =
-      List.fold_left
-        (fun s i -> EcIdent.fv_union s (i_fv i))
-        Mid.empty p.s_node
-    in { p with s_tag = n; s_fv = fv; }
-end)
-
-(* -------------------------------------------------------------------- *)
-module MSHi = EcMaps.MakeMSH(struct type t = instr let tag i = i.i_tag end)
-module Si   = MSHi.S
-module Mi   = MSHi.M
-module Hi   = MSHi.H
-
-(* -------------------------------------------------------------------- *)
-let mk_instr i = Hinstr.hashcons
-  { i_node = i; i_tag = -1; i_fv = Mid.empty }
-
-let stmt s = Hstmt.hashcons
-  { s_node = s; s_tag = -1; s_fv = Mid.empty}
-
-let rstmt s = stmt (List.rev s)
-
-(* --------------------------------------------------------------------- *)
-let i_asgn     (lv, e)      = mk_instr (Sasgn (lv, e))
-let i_rnd      (lv, e)      = mk_instr (Srnd (lv, e))
-let i_call     (lv, m, tys) = mk_instr (Scall (lv, m, tys))
-let i_if       (c, s1, s2)  = mk_instr (Sif (c, s1, s2))
-let i_while    (c, s)       = mk_instr (Swhile (c, s))
-let i_match    (e, b)       = mk_instr (Smatch (e, b))
-let i_assert   e            = mk_instr (Sassert e)
-let i_abstract id           = mk_instr (Sabstract id)
-
-let s_seq      s1 s2        = stmt (s1.s_node @ s2.s_node)
-let s_empty                 = stmt []
-
-let s_asgn     arg = stmt [i_asgn arg]
-let s_rnd      arg = stmt [i_rnd arg]
-let s_call     arg = stmt [i_call arg]
-let s_if       arg = stmt [i_if arg]
-let s_while    arg = stmt [i_while arg]
-let s_match    arg = stmt [i_match arg]
-let s_assert   arg = stmt [i_assert arg]
-let s_abstract arg = stmt [i_abstract arg]
-
-(* -------------------------------------------------------------------- *)
-let get_asgn = function
-  | { i_node = Sasgn (lv, e) } -> Some (lv, e)
-  | _ -> None
-
-let get_rnd = function
-  | { i_node = Srnd (lv, e) } -> Some (lv, e)
-  | _ -> None
-
-let get_call = function
-  | { i_node = Scall (lv, f, fs) } -> Some (lv, f, fs)
-  | _ -> None
-
-let get_if = function
-  | { i_node = Sif (e, s1, s2) } -> Some (e, s1, s2)
-  | _ -> None
-
-let get_while = function
-  | { i_node = Swhile (e, s) } -> Some (e, s)
-  | _ -> None
-
-let get_match = function
-  | { i_node = Smatch (e, b) } -> Some (e, b)
-  | _ -> None
-
-let get_assert = function
-  | { i_node = Sassert e } -> Some e
-  | _ -> raise Not_found
-
-(* -------------------------------------------------------------------- *)
-let _destr_of_get (get : instr -> 'a option) (i : instr) =
-  match get i with Some x -> x | None -> raise Not_found
-
-let destr_asgn   = _destr_of_get get_asgn
-let destr_rnd    = _destr_of_get get_rnd
-let destr_call   = _destr_of_get get_call
-let destr_if     = _destr_of_get get_if
-let destr_while  = _destr_of_get get_while
-let destr_match  = _destr_of_get get_match
-let destr_assert = _destr_of_get get_assert
-
-(* -------------------------------------------------------------------- *)
-let _is_of_get (get : instr -> 'a option) (i : instr) =
-  EcUtils.is_some (get i)
-
-let is_asgn   = _is_of_get get_asgn
-let is_rnd    = _is_of_get get_rnd
-let is_call   = _is_of_get get_call
-let is_if     = _is_of_get get_if
-let is_while  = _is_of_get get_while
-let is_match  = _is_of_get get_match
-let is_assert = _is_of_get get_assert
-
-(* -------------------------------------------------------------------- *)
-module ISmart : sig
-  type lv_var   = EcTypes.prog_var * EcTypes.ty
-  type lv_tuple = lv_var list
-
-  val lv_var   : lvalue * lv_var   -> lv_var   -> lvalue
-  val lv_tuple : lvalue * lv_tuple -> lv_tuple -> lvalue
-
-  type i_asgn     = lvalue * EcTypes.expr
-  type i_rnd      = lvalue * EcTypes.expr
-  type i_call     = lvalue option * EcPath.xpath * EcTypes.expr list
-  type i_if       = EcTypes.expr * stmt * stmt
-  type i_while    = EcTypes.expr * stmt
-  type i_match    = EcTypes.expr * ((EcIdent.t * ty) list * stmt) list
-  type i_assert   = EcTypes.expr
-  type i_abstract = EcIdent.t
-
-  val i_asgn     : (instr * i_asgn    ) -> i_asgn     -> instr
-  val i_rnd      : (instr * i_rnd     ) -> i_rnd      -> instr
-  val i_call     : (instr * i_call    ) -> i_call     -> instr
-  val i_if       : (instr * i_if      ) -> i_if       -> instr
-  val i_while    : (instr * i_while   ) -> i_while    -> instr
-  val i_match    : (instr * i_match   ) -> i_match    -> instr
-  val i_assert   : (instr * i_assert  ) -> i_assert   -> instr
-  val i_abstract : (instr * i_abstract) -> i_abstract -> instr
-
-  val s_stmt : stmt -> instr list -> stmt
+  val mk : xpath list -> bool -> [`Bounded of form * form Mx.t | `Unbounded] -> t
+  (* val change_calls : t -> xpath list -> t *)
+  val filter : (xpath -> bool) -> t -> t
 end = struct
-  type lv_var   = EcTypes.prog_var * EcTypes.ty
-  type lv_tuple = lv_var list
+  type t = EcCoreFol.form PreOI.t
 
-  type i_asgn     = lvalue * EcTypes.expr
-  type i_rnd      = lvalue * EcTypes.expr
-  type i_call     = lvalue option * EcPath.xpath * EcTypes.expr list
-  type i_if       = EcTypes.expr * stmt * stmt
-  type i_while    = EcTypes.expr * stmt
-  type i_match    = EcTypes.expr * ((EcIdent.t * ty) list * stmt) list
-  type i_assert   = EcTypes.expr
-  type i_abstract = EcIdent.t
-
-  let lv_var (lv, pvt) pvt' =
-    if pvt == pvt' then lv else LvVar pvt'
-
-  let lv_tuple (lv, pvs) pvs' =
-    if pvs == pvs' then lv else LvTuple pvs'
-
-  let i_asgn (i, (lv, e)) (lv', e') =
-    if lv == lv' && e == e' then i else i_asgn (lv', e')
-
-  let i_rnd (i, (lv, e)) (lv', e') =
-    if lv == lv' && e == e' then i else i_rnd (lv', e')
-
-  let i_call (i, (olv, mp, args)) (olv', mp', args') =
-    if   olv == olv' && mp == mp' && args == args'
-    then i else  i_call (olv', mp', args')
-
-  let i_if (i, (e, s1, s2)) (e', s1', s2') =
-    if   e == e' && s1 == s1' && s2 == s2'
-    then i else i_if (e', s1', s2')
-
-  let i_while (i, (e, s)) (e', s') =
-    if e == e' && s == s' then i else i_while (e', s')
-
-  let i_match (i, (e, b)) (e', b') =
-    if e == e' && b == b' then i else i_match (e', b')
-
-  let i_assert (i, e) e' =
-    if e == e' then i else i_assert e'
-
-  let i_abstract (i, x) x' =
-    if x == x' then i else i_abstract x
-
-  let s_stmt s is' =
-    if s.s_node == is' then s else stmt is'
+  let is_in        = PreOI.is_in
+  let allowed      = PreOI.allowed
+  let allowed_s    = PreOI.allowed_s
+  let cost_self    = PreOI.cost_self
+  let cost         = PreOI.cost
+  let cost_calls   = PreOI.cost_calls
+  let costs        = PreOI.costs
+  let mk           = PreOI.mk
+  let filter       = PreOI.filter
+  let equal        = PreOI.equal EcCoreFol.f_equal
+  let hash         = PreOI.hash EcCoreFol.f_hash
 end
 
 (* -------------------------------------------------------------------- *)
-let rec s_subst_top (s : EcTypes.e_subst) =
-  let e_subst = EcTypes.e_subst s in
+type module_type       = EcCoreFol.module_type
+type mod_restr         = EcCoreFol.mod_restr
+type module_sig        = form p_module_sig
+type module_smpl_sig   = form p_module_smpl_sig
+type function_body     = form p_function_body
+type function_         = form p_function_
+type module_expr       = form p_module_expr
+type module_body       = form p_module_body
+type module_structure  = form p_module_structure
+type module_item       = form p_module_item
+type module_comps      = form p_module_comps
+type module_comps_item = form p_module_comps_item
+type top_module_sig    = form p_top_module_sig
+type top_module_expr   = form p_top_module_expr
 
-  if e_subst == identity then identity else
+let mr_empty = {
+  mr_xpaths = ur_empty EcPath.Sx.empty;
+  mr_mpaths = ur_empty EcPath.Sm.empty;
+  mr_oinfos = Msym.empty;
+}
 
-  let pvt_subst (pv, ty as p) =
-    let pv' = EcTypes.pv_subst s.EcTypes.es_xp pv in
-    let ty' = s.EcTypes.es_ty ty in
+let mr_full = {
+  mr_xpaths = ur_full EcPath.Sx.empty;
+  mr_mpaths = ur_full EcPath.Sm.empty;
+  mr_oinfos = Msym.empty;
+}
 
-    if pv == pv' && ty == ty' then p else (pv', ty') in
+let mr_add_restr mr (rx : Sx.t use_restr) (rm : Sm.t use_restr) =
+  { mr_xpaths = ur_union Sx.union Sx.inter mr.mr_xpaths rx;
+    mr_mpaths = ur_union Sm.union Sm.inter mr.mr_mpaths rm;
+    mr_oinfos = mr.mr_oinfos; }
 
-  let lv_subst lv =
-    match lv with
-    | LvVar pvt ->
-        ISmart.lv_var (lv, pvt) (pvt_subst pvt)
+let change_oinfo restr f oi =
+  { restr with mr_oinfos = Msym.add f oi restr.mr_oinfos }
 
-    | LvTuple pvs ->
-        let pvs' = List.Smart.map pvt_subst pvs in
-        ISmart.lv_tuple (lv, pvs) pvs'
+let add_oinfo restr f oi = change_oinfo restr f oi
 
-  in
+let oicalls_filter restr f filter =
+  match Msym.find f restr.mr_oinfos with
+  | oi -> change_oinfo restr f (OI.filter filter oi)
+  | exception Not_found -> restr
 
-  let rec i_subst i =
-    match i.i_node with
-    | Sasgn (lv, e) ->
-        ISmart.i_asgn (i, (lv, e)) (lv_subst lv, e_subst e)
-
-    | Srnd (lv, e) ->
-        ISmart.i_rnd (i, (lv, e)) (lv_subst lv, e_subst e)
-
-    | Scall (olv, mp, args) ->
-        let olv'  = olv |> OSmart.omap lv_subst in
-        let mp'   = s.EcTypes.es_xp mp in
-        let args' = List.Smart.map e_subst args in
-
-        ISmart.i_call (i, (olv, mp, args)) (olv', mp', args')
-
-    | Sif (e, s1, s2) ->
-        ISmart.i_if (i, (e, s1, s2))
-          (e_subst e, s_subst s1, s_subst s2)
-
-    | Swhile (e, b) ->
-        ISmart.i_while (i, (e, b)) (e_subst e, s_subst b)
-
-    | Smatch (e, b) ->
-        let forb ((xs, subs) as b1) =
-          let s, xs' = EcTypes.add_locals s xs in
-          let subs'  = s_subst_top s subs in
-          if xs == xs' && subs == subs' then b1 else (xs', subs')
-        in
-
-        ISmart.i_match (i, (e, b)) (e_subst e, List.Smart.map forb b)
-
-    | Sassert e ->
-        ISmart.i_assert (i, e) (e_subst e)
-
-    | Sabstract _ ->
-        i
-
-  and s_subst s =
-    ISmart.s_stmt s (List.Smart.map i_subst s.s_node)
-
-  in s_subst
+let change_oicalls restr f ocalls =
+  let oi = match Msym.find f restr.mr_oinfos with
+    | oi ->
+      let filter x = List.mem x ocalls in
+      OI.filter filter oi
+    | exception Not_found -> OI.mk ocalls true `Unbounded in
+  add_oinfo restr f oi
 
 (* -------------------------------------------------------------------- *)
-let s_subst = s_subst_top
+let mty_hash  = EcCoreFol.mty_hash
+let mty_equal = EcCoreFol.mty_equal
 
-(* -------------------------------------------------------------------- *)
-module Uninit = struct    (* FIXME: generalize this for use in ecPV *)
-  let e_pv =
-    let rec e_pv tx sx e =
-      match e.e_node with
-      | Evar pv ->
-          if tx pv then Sx.add (xastrip pv.pv_name) sx else sx
-      | _ ->
-          e_fold (e_pv tx) sx e
-    in fun tx e -> e_pv tx Sx.empty e
-end
-
-let rec lv_get_uninit_read (w : Sx.t) (lv : lvalue) =
-  let sx_of_pv pv =
-    if is_loc pv then Sx.singleton (xastrip pv.pv_name) else Sx.empty
-  in
-
-  match lv with
-  | LvVar (x, _) ->
-      Sx.union (sx_of_pv x) w
-
-  | LvTuple xs ->
-      let w' = List.map (sx_of_pv |- fst) xs in
-      Sx.big_union (w :: w')
-
-and s_get_uninit_read (w : Sx.t) (s : stmt) =
-  let do1 (w, r) i =
-    let w, r' = i_get_uninit_read w i in
-    (w, Sx.union r r')
-
-  in List.fold_left do1 (w, Sx.empty) s.s_node
-
-and i_get_uninit_read (w : Sx.t) (i : instr) =
-  match i.i_node with
-  | Sasgn (lv, e) | Srnd (lv, e) ->
-      let r1 = Sx.diff (Uninit.e_pv is_loc e) w in
-      let w2 = lv_get_uninit_read w lv in
-      (Sx.union w w2, r1)
-
-  | Scall (olv, _, args) ->
-      let r1    = Sx.diff (Sx.big_union (List.map (Uninit.e_pv is_loc) args)) w in
-      let w = olv |> omap (lv_get_uninit_read w) |> odfl w in
-      (w, r1)
-
-  | Sif (e, s1, s2) ->
-      let r = Sx.diff (Uninit.e_pv is_loc e) w in
-      let w1, r1 = s_get_uninit_read w s1 in
-      let w2, r2 = s_get_uninit_read w s2 in
-      (Sx.union w (Sx.inter w1 w2), Sx.big_union [r; r1; r2])
-
-  | Swhile (e, s) ->
-      let r  = Sx.diff (Uninit.e_pv is_loc e) w in
-      let rs = snd (s_get_uninit_read w s) in
-      (w, Sx.union r rs)
-
-  | Smatch (e, bs) ->
-      let r   = Sx.diff (Uninit.e_pv is_loc e) w in
-      let wrs = List.map (fun (_, b) -> s_get_uninit_read w b) bs in
-      let ws, rs = List.split wrs in
-      (Sx.union w (Sx.big_inter ws), Sx.big_union (r :: rs))
-
-  | Sassert e ->
-      (w, Sx.diff (Uninit.e_pv is_loc e) w)
-
-  | Sabstract (_ : EcIdent.t) ->
-      (w, Sx.empty)
-
-let get_uninit_read (s : stmt) =
-  snd (s_get_uninit_read Sx.empty s)
-
-(* -------------------------------------------------------------------- *)
-type variable = {
-  v_name : symbol;
-  v_type : EcTypes.ty;
-}
-
-let v_name { v_name = x } = x
-let v_type { v_type = x } = x
-
-(* -------------------------------------------------------------------- *)
-type funsig = {
-  fs_name   : symbol;
-  fs_arg    : EcTypes.ty;
-  fs_anames : variable list option;
-  fs_ret    : EcTypes.ty;
-}
-
-(* -------------------------------------------------------------------- *)
-type oracle_info = {
-  oi_calls : xpath list;
-  oi_in    : bool;
-}
-
-type module_type = {
-  mt_params : (EcIdent.t * module_type) list;
-  mt_name   : EcPath.path;
-  mt_args   : EcPath.mpath list;
-}
-
-type module_sig_body_item =
-| Tys_function of funsig * oracle_info
-
-type module_sig_body = module_sig_body_item list
-
-type module_sig = {
-  mis_params : (EcIdent.t * module_type) list;
-  mis_body   : module_sig_body;
-}
-
-type top_module_sig = {
-  tms_sig : module_sig;
-  tms_loca : is_local;
-}
-(* -------------------------------------------------------------------- *)
-type uses = {
-  us_calls  : xpath list;
-  us_reads  : Sx.t;
-  us_writes : Sx.t;
-}
-
-let mk_uses c r w =
-  let map s = Sx.fold (fun x s -> Sx.add (EcTypes.xp_glob x) s) s Sx.empty in
-  {us_calls = c; us_reads = map r; us_writes = map w }
-
-
-type function_def = {
-  f_locals : variable list;
-  f_body   : stmt;
-  f_ret    : EcTypes.expr option;
-  f_uses   : uses;
-}
-
-type function_body =
-| FBdef   of function_def
-| FBalias of xpath
-| FBabs   of oracle_info
-
-type function_ = {
-  f_name   : symbol;
-  f_sig    : funsig;
-  f_def    : function_body;
-}
-
-(* -------------------------------------------------------------------- *)
-type abs_uses = {
-  aus_calls  : EcPath.xpath list;
-  aus_reads  : (EcTypes.prog_var * EcTypes.ty) list;
-  aus_writes : (EcTypes.prog_var * EcTypes.ty) list;
-}
-
-(* -------------------------------------------------------------------- *)
-type mod_restr = EcPath.Sx.t * EcPath.Sm.t
-
-let mr_equal (rx1,r1) (rx2,r2) =
-  EcPath.Sx.equal rx1 rx2 && EcPath.Sm.equal r1 r2
-
-type module_expr = {
-  me_name      : symbol;
-  me_body      : module_body;
-  me_comps     : module_comps;
-  me_sig       : module_sig;
-}
-
-and module_body =
-  | ME_Alias       of int * EcPath.mpath
-  | ME_Structure   of module_structure
-  | ME_Decl        of module_type * mod_restr
-
-and module_structure = {
-  ms_body : module_item list;
-}
-
-and module_item =
-  | MI_Module   of module_expr
-  | MI_Variable of variable
-  | MI_Function of function_
-
-and module_comps = module_comps_item list
-
-and module_comps_item = module_item
-
-type top_module_expr = {
-  tme_expr : module_expr;
-  tme_loca : locality;
-}
-
-(* -------------------------------------------------------------------- *)
-let vd_equal vd1 vd2 =
-  vd1.v_name = vd2.v_name &&
-  EcTypes.ty_equal vd1.v_type vd2.v_type
-
-let vd_hash vd =
-  Why3.Hashcons.combine (Hashtbl.hash vd.v_name) (EcTypes.ty_hash vd.v_type)
-
-let fd_equal f1 f2 =
-     (s_equal f1.f_body f2.f_body)
-  && (EcUtils.opt_equal EcTypes.e_equal f1.f_ret f2.f_ret)
-  && (List.all2 vd_equal f1.f_locals f2.f_locals)
-
-let fd_hash f =
-  Why3.Hashcons.combine2
-    (s_hash f.f_body)
-    (Why3.Hashcons.combine_option EcTypes.e_hash f.f_ret)
-    (Why3.Hashcons.combine_list vd_hash 0 f.f_locals)
-
-(* -------------------------------------------------------------------- *)
-let rec mty_subst sp sm mty =
-  let mt_params = List.map (snd_map (mty_subst sp sm)) mty.mt_params in
-  let mt_name   = sp mty.mt_name in
-  let mt_args   = List.map sm mty.mt_args in
-  { mt_params; mt_name; mt_args; }
-
-let mty_hash mty =
-  Why3.Hashcons.combine2
-    (EcPath.p_hash mty.mt_name)
-    (Why3.Hashcons.combine_list
-       (fun (x, _) -> EcIdent.id_hash x)
-       0 mty.mt_params)
-    (Why3.Hashcons.combine_list EcPath.m_hash 0 mty.mt_args)
-
-let rec mty_equal mty1 mty2 =
-     (EcPath.p_equal mty1.mt_name mty2.mt_name)
-  && (List.all2 EcPath.m_equal mty1.mt_args mty2.mt_args)
-  && (List.all2 (pair_equal EcIdent.id_equal mty_equal) mty1.mt_params mty2.mt_params)
-
-(* -------------------------------------------------------------------- *)
-let get_uninit_read_of_fun (fp : xpath) (f : function_) =
-  match f.f_def with
-  | FBalias _ | FBabs _ -> Sx.empty
-
-  | FBdef fd ->
-      let w =
-        let toloc { v_name = x } = (EcTypes.pv_loc fp x).pv_name in
-        let w = List.map toloc (f.f_sig.fs_anames |> odfl []) in
-        Sx.of_list (List.map xastrip w)
-      in
-
-      let w, r  = s_get_uninit_read w fd.f_body in
-      let raout = fd.f_ret |> omap (Uninit.e_pv is_loc) in
-      let raout = Sx.diff (raout |> odfl Sx.empty) w in
-      Sx.union r raout
-
-(* -------------------------------------------------------------------- *)
-let get_uninit_read_of_module (p : path) (me : module_expr) =
-  let rec doit_me acc (mp, me) =
-    match me.me_body with
-    | ME_Alias     _  -> acc
-    | ME_Decl      _  -> acc
-    | ME_Structure mb -> doit_mb acc (mp, mb)
-
-  and doit_mb acc (mp, mb) =
-    List.fold_left
-      (fun acc item -> doit_mb1 acc (mp, item))
-      acc mb.ms_body
-
-  and doit_mb1 acc (mp, item) =
-    match item with
-    | MI_Module subme ->
-        doit_me acc (EcPath.mqname mp subme.me_name, subme)
-
-    | MI_Variable _ ->
-        acc
-
-    | MI_Function f ->
-        let xp = xpath_fun mp f.f_name in
-        let r  = get_uninit_read_of_fun xp f in
-        if Sx.is_empty r then acc else (xp, r) :: acc
-
-  in
-
-  let mp =
-    let margs =
-      List.map
-        (fun (x, _) -> EcPath.mpath_abs x [])
-        me.me_sig.mis_params
-    in EcPath.mpath_crt (EcPath.pqname p me.me_name) margs None
-
-  in List.rev (doit_me [] (mp, me))
+let mr_equal  = EcCoreFol.mr_equal
+let mr_hash   = EcCoreFol.mr_hash

--- a/src/ecModules.mli
+++ b/src/ecModules.mli
@@ -1,243 +1,75 @@
 (* --------------------------------------------------------------------
  * Copyright (c) - 2012--2016 - IMDEA Software Institute
- * Copyright (c) - 2012--2021 - Inria
- * Copyright (c) - 2012--2021 - Ecole Polytechnique
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
  *
  * Distributed under the terms of the CeCILL-C-V1 license
  * -------------------------------------------------------------------- *)
 
 (* -------------------------------------------------------------------- *)
-open EcSymbols
 open EcPath
-open EcTypes
+open EcCoreFol
 
 (* -------------------------------------------------------------------- *)
-type lvalue =
-  | LvVar   of (prog_var * ty)
-  | LvTuple of (prog_var * ty) list
-
-val lv_equal     : lvalue -> lvalue -> bool
-val symbol_of_lv : lvalue -> symbol
-val ty_of_lv     : lvalue -> EcTypes.ty
-val lv_of_list   : (prog_var * ty) list -> lvalue option
-
-(* --------------------------------------------------------------------- *)
-type instr = private {
-  i_node : instr_node;
-  i_fv   : int EcIdent.Mid.t;
-  i_tag  : int;
-}
-
-and instr_node =
-  | Sasgn     of lvalue * expr
-  | Srnd      of lvalue * expr
-  | Scall     of lvalue option * xpath * expr list
-  | Sif       of expr * stmt * stmt
-  | Swhile    of expr * stmt
-  | Smatch    of expr * ((EcIdent.t * EcTypes.ty) list * stmt) list
-  | Sassert   of expr
-  | Sabstract of EcIdent.t
-
-and stmt = private {
-  s_node : instr list;
-  s_fv   : int EcIdent.Mid.t;
-  s_tag  : int;
-}
+include module type of struct include EcCoreModules end
 
 (* -------------------------------------------------------------------- *)
-val i_equal   : instr -> instr -> bool
-val i_compare : instr -> instr -> int
-val i_hash    : instr -> int
-val i_fv      : instr -> int EcIdent.Mid.t
-val i_node    : instr -> instr_node
+(* Instantiation of EcCoreModules.PreOI on EcCoreFol.form. *)
+module OI : sig
+  type t = form PreOI.t
 
-val s_equal   : stmt -> stmt -> bool
-val s_compare : stmt -> stmt -> int
-val s_hash    : stmt -> int
-val s_fv      : stmt -> int EcIdent.Mid.t
-val s_subst   : e_subst -> stmt -> stmt
+  val hash : t -> int
+  val equal : t -> t -> bool
 
-(* -------------------------------------------------------------------- *)
-val i_asgn     : lvalue * expr -> instr
-val i_rnd      : lvalue * expr -> instr
-val i_call     : lvalue option * xpath * expr list -> instr
-val i_if       : expr * stmt * stmt -> instr
-val i_while    : expr * stmt -> instr
-val i_match    : expr * ((EcIdent.t * ty) list * stmt) list -> instr
-val i_assert   : expr -> instr
-val i_abstract : EcIdent.t -> instr
+  val is_in : t -> bool
 
-val s_asgn     : lvalue * expr -> stmt
-val s_rnd      : lvalue * expr -> stmt
-val s_call     : lvalue option * xpath * expr list -> stmt
-val s_if       : expr * stmt * stmt -> stmt
-val s_while    : expr * stmt -> stmt
-val s_match    : expr * ((EcIdent.t * ty) list * stmt) list -> stmt
-val s_assert   : expr -> stmt
-val s_abstract : EcIdent.t -> stmt
-val s_seq      : stmt -> stmt -> stmt
-val s_empty    : stmt
+  val cost_self : t -> [`Bounded of form | `Unbounded]
+  val cost : t -> xpath -> [`Bounded of form | `Zero | `Unbounded]
+  val cost_calls : t -> [`Bounded of form Mx.t | `Unbounded]
+  val costs : t -> [`Bounded of form * form Mx.t | `Unbounded]
 
-val stmt  : instr list -> stmt
-val rstmt : instr list -> stmt
+  val allowed : t -> xpath list
+  val allowed_s : t -> Sx.t
 
-(* the following functions raise Not_found if the argument does not match *)
-val destr_asgn   : instr -> lvalue * expr
-val destr_rnd    : instr -> lvalue * expr
-val destr_call   : instr -> lvalue option * xpath * expr list
-val destr_if     : instr -> expr * stmt * stmt
-val destr_while  : instr -> expr * stmt
-val destr_match  : instr -> expr * ((EcIdent.t * ty) list * stmt) list
-val destr_assert : instr -> expr
-
-val is_asgn   : instr -> bool
-val is_rnd    : instr -> bool
-val is_call   : instr -> bool
-val is_if     : instr -> bool
-val is_while  : instr -> bool
-val is_match  : instr -> bool
-val is_assert : instr -> bool
+  val mk : xpath list -> bool -> [`Bounded of form * form Mx.t | `Unbounded] -> t
+  (* val change_calls : t -> xpath list -> t *)
+  val filter : (xpath -> bool) -> t -> t
+end
 
 (* -------------------------------------------------------------------- *)
-val get_uninit_read : stmt -> Sx.t
+type mod_restr         = form p_mod_restr
+type module_type       = form p_module_type
+type module_sig        = form p_module_sig
+type module_smpl_sig   = form p_module_smpl_sig
+type function_body     = form p_function_body
+type function_         = form p_function_
+type module_expr       = form p_module_expr
+type module_body       = form p_module_body
+type module_structure  = form p_module_structure
+type module_item       = form p_module_item
+type module_comps      = form p_module_comps
+type module_comps_item = form p_module_comps_item
+type top_module_sig    = form p_top_module_sig
+type top_module_expr   = form p_top_module_expr
 
-(* -------------------------------------------------------------------- *)
-type variable = {
-  v_name : symbol;
-  v_type : EcTypes.ty;
-}
+(* Careful, the available oracles are empty in both [mr_empty] and [mr_full]. *)
+val mr_empty : mod_restr
+val mr_full  : mod_restr
 
-val v_name : variable -> symbol
-val v_type : variable -> EcTypes.ty
-
-(* -------------------------------------------------------------------- *)
-type funsig = {
-  fs_name   : symbol;
-  fs_arg    : EcTypes.ty;
-  fs_anames : variable list option;
-  fs_ret    : EcTypes.ty;
-}
-
-(* -------------------------------------------------------------------- *)
-(* An oracle in a function provided by a module parameter of a functor *)
-
-type module_type = {                   (* Always in eta-normal form *)
-  mt_params : (EcIdent.t * module_type) list;
-  mt_name   : EcPath.path;
-  mt_args   : EcPath.mpath list;
-}
-
-(* [oi_calls]: The list of oracle that can be called
- * [oi_in]: true if equality of globals is required to ensure
- * equality of result and globals
-*)
-type oracle_info = {
-  oi_calls : xpath list;
-  oi_in    : bool;
-}
-
-type module_sig_body_item =
-(* oracle_info contain only function provided by the module parameters *)
-| Tys_function of funsig * oracle_info
-
-type module_sig_body = module_sig_body_item list
-
-type module_sig = {
-  mis_params : (EcIdent.t * module_type) list;
-  mis_body   : module_sig_body;
-}
-
-type top_module_sig = {
-  tms_sig : module_sig;
-  tms_loca : is_local;
-}
-(* -------------------------------------------------------------------- *)
-type uses = private {
-  us_calls  : xpath list;
-  us_reads  : Sx.t;
-  us_writes : Sx.t;
-}
-
-val mk_uses : xpath list -> Sx.t -> Sx.t -> uses
-
-type function_def = {
-  f_locals : variable list;
-  f_body   : stmt;
-  f_ret    : EcTypes.expr option;
-  f_uses   : uses;
-}
-
-type function_body =
-  | FBdef   of function_def
-  | FBalias of xpath
-  | FBabs   of oracle_info
-
-type function_ = {
-  f_name   : symbol;
-  f_sig    : funsig;
-  f_def    : function_body;
-}
-
-(* -------------------------------------------------------------------- *)
-type abs_uses = {
-  aus_calls  : EcPath.xpath list;
-  aus_reads  : (prog_var * ty) list;
-  aus_writes : (prog_var * ty) list;
-}
-
-(* -------------------------------------------------------------------- *)
-type mod_restr = EcPath.Sx.t * EcPath.Sm.t
-
+val mr_hash  : mod_restr -> int
 val mr_equal : mod_restr -> mod_restr -> bool
 
-(* -------------------------------------------------------------------- *)
-type module_expr = {
-  me_name  : symbol;
-  me_body  : module_body;
-  me_comps : module_comps;
-  me_sig   : module_sig;
-}
+val mr_add_restr :
+  mod_restr -> EcPath.Sx.t use_restr -> EcPath.Sm.t use_restr -> mod_restr
 
-and module_body =
-  | ME_Alias       of int * EcPath.mpath
-                      (* The int represent the number of argument *)
-  | ME_Structure   of module_structure
-  | ME_Decl        of module_type * mod_restr
-
-(* [ms_vars]: the set of global variables declared by the module and
- * all it submodules.
- *
- * [ms_uses]: the set of external top-level modules used by the module
- * We ensure that these paths lead to defined modules (i.e having
- * ME_structure as body)
- *)
-and module_structure = {
-  ms_body : module_item list;
-}
-
-and module_item =
-| MI_Module   of module_expr
-| MI_Variable of variable
-| MI_Function of function_
-
-and module_comps = module_comps_item list
-
-and module_comps_item = module_item
-
-type top_module_expr = {
-  tme_expr : module_expr;
-  tme_loca : locality;
-}
+val add_oinfo : mod_restr -> string -> OI.t -> mod_restr
+val change_oicalls : mod_restr -> string -> xpath list -> mod_restr
+val oicalls_filter :
+  mod_restr ->
+  EcSymbols.Msym.key ->
+  (EcPath.xpath -> bool) ->
+  mod_restr
 
 (* -------------------------------------------------------------------- *)
-val fd_equal : function_def -> function_def -> bool
-val fd_hash  : function_def -> int
-
-val mty_subst : (path -> path) -> (mpath -> mpath) -> module_type -> module_type
-
 val mty_equal : module_type -> module_type -> bool
 val mty_hash  : module_type -> int
-
-(* -------------------------------------------------------------------- *)
-val get_uninit_read_of_fun : xpath -> function_ -> Sx.t
-val get_uninit_read_of_module : path -> module_expr -> (xpath * Sx.t) list

--- a/src/ecPV.mli
+++ b/src/ecPV.mli
@@ -17,7 +17,7 @@ open EcFol
 
 (* -------------------------------------------------------------------- *)
 type alias_clash =
- | AC_concrete_abstract of mpath * prog_var
+ | AC_concrete_abstract of mpath * xpath
  | AC_abstract_abstract of mpath * mpath
 
 exception AliasClash of env * alias_clash
@@ -42,9 +42,11 @@ module Mpv : sig
 
   val empty : ('a,'b) t
 
-  val check_npv_mp : env -> prog_var -> mpath -> EcEnv.use -> unit
+  val check_npv_mp :
+    env -> xpath -> mpath -> use use_restr -> unit
 
-  val check_mp_mp : env -> mpath -> EcEnv.use -> mpath -> EcEnv.use -> unit
+  val check_mp_mp :
+    env -> mpath -> use use_restr -> mpath -> use use_restr -> unit
 
   val check_npv : env -> prog_var -> ('a,'b) t -> unit
 
@@ -77,9 +79,11 @@ module PVM : sig
 
   val find : env -> prog_var -> memory -> subst -> form
 
-  val subst   : env -> subst -> form  -> form
+  val subst      : env -> subst -> form  -> form
 
-  val subst1  : env -> prog_var -> EcIdent.t -> form -> form -> form
+  val subst_cost : env -> subst -> cost  -> cost
+
+  val subst1     : env -> prog_var -> EcIdent.t -> form -> form -> form
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecPath.mli
+++ b/src/ecPath.mli
@@ -92,13 +92,11 @@ val pp_m : Format.formatter -> mpath -> unit
 (* -------------------------------------------------------------------- *)
 type xpath = private {
   x_top : mpath;
-  x_sub : path;
+  x_sub : symbol;
   x_tag : int;
 }
 
-val xpath     : mpath -> path -> xpath
-val xpath_fun : mpath -> symbol -> xpath
-val xqname    : xpath -> symbol -> xpath
+val xpath     : mpath -> symbol -> xpath
 val xastrip   : xpath -> xpath
 
 val x_equal       : xpath -> xpath -> bool

--- a/src/ecPrinting.mli
+++ b/src/ecPrinting.mli
@@ -37,6 +37,7 @@ type 'a pp = Format.formatter -> 'a -> unit
 val pp_id    : 'a pp -> 'a pp
 val pp_if    : bool -> 'a pp -> 'a pp -> 'a pp
 val pp_maybe : bool -> ('a pp -> 'a pp) -> 'a pp -> 'a pp
+val pp_opt   : 'a pp -> 'a option pp
 
 val pp_enclose:
        pre:('a, 'b, 'c, 'd, 'd, 'a) format6
@@ -58,30 +59,38 @@ val pp_form    : PPEnv.t -> form pp
 val pp_type    : PPEnv.t -> ty pp
 val pp_tyname  : PPEnv.t -> path pp
 val pp_axname  : PPEnv.t -> path pp
+val pp_scname  : PPEnv.t -> path pp
 val pp_tcname  : PPEnv.t -> path pp
 val pp_thname  : PPEnv.t -> path pp
 
 val pp_mem      : PPEnv.t -> EcIdent.t pp
+val pp_memtype  : PPEnv.t -> EcMemory.memtype pp
 val pp_tyvar    : PPEnv.t -> ident pp
 val pp_tyunivar : PPEnv.t -> EcUid.uid pp
 val pp_path     : path pp
 
 (* -------------------------------------------------------------------- *)
-val pp_typedecl : PPEnv.t -> (path * tydecl                ) pp
-val pp_opdecl   : ?long:bool -> PPEnv.t -> (path * operator) pp
-val pp_added_op : PPEnv.t -> operator pp
-val pp_axiom    : ?long:bool -> PPEnv.t -> (path * axiom   ) pp
-val pp_theory   : PPEnv.t -> (path * ctheory               ) pp
-val pp_modtype1 : PPEnv.t -> module_type                     pp
-val pp_modtype  : PPEnv.t -> (module_type * mod_restr      ) pp
-val pp_modexp   : PPEnv.t -> (mpath * module_expr          ) pp
-val pp_modsig   : PPEnv.t -> (path * module_sig            ) pp
+val pp_typedecl    : PPEnv.t -> (path * tydecl                  ) pp
+val pp_opdecl      : ?long:bool -> PPEnv.t -> (path * operator  ) pp
+val pp_added_op    : PPEnv.t -> operator pp
+val pp_axiom       : ?long:bool -> PPEnv.t -> (path * axiom     ) pp
+val pp_schema      : ?long:bool -> PPEnv.t -> (path * ax_schema ) pp
+val pp_theory      : PPEnv.t -> (path * ctheory                 ) pp
+val pp_restr_s     :            (bool                           ) pp
+val pp_restr       : PPEnv.t -> (mod_restr                      ) pp
+val pp_modtype1    : PPEnv.t -> (module_type                    ) pp
+val pp_modtype     : PPEnv.t -> (module_type                    ) pp
+val pp_modexp      : PPEnv.t -> (mpath * module_expr            ) pp
+val pp_modsig      : ?long:bool -> PPEnv.t -> (path * module_sig) pp
+val pp_modsig_smpl : PPEnv.t -> (path * module_smpl_sig         ) pp
 
 (* -------------------------------------------------------------------- *)
-val pp_hoareS   : PPEnv.t -> ?prpo:prpo_display -> hoareS  pp
+val pp_hoareS   : PPEnv.t -> ?prpo:prpo_display -> sHoareS  pp
+val pp_choareS  : PPEnv.t -> ?prpo:prpo_display -> cHoareS  pp
 val pp_bdhoareS : PPEnv.t -> ?prpo:prpo_display -> bdHoareS pp
 val pp_equivS   : PPEnv.t -> ?prpo:prpo_display -> equivS  pp
 
+val pp_cost  : PPEnv.t -> cost pp
 val pp_stmt  : ?lineno:bool -> PPEnv.t -> stmt pp
 val pp_instr : PPEnv.t -> instr pp
 
@@ -102,6 +111,7 @@ module ObjectInfo : sig
   val pr_op  : Format.formatter -> EcEnv.env -> qsymbol -> unit
   val pr_th  : Format.formatter -> EcEnv.env -> qsymbol -> unit
   val pr_ax  : Format.formatter -> EcEnv.env -> qsymbol -> unit
+  val pr_sc  : Format.formatter -> EcEnv.env -> qsymbol -> unit
   val pr_mod : Format.formatter -> EcEnv.env -> qsymbol -> unit
   val pr_mty : Format.formatter -> EcEnv.env -> qsymbol -> unit
   val pr_rw  : Format.formatter -> EcEnv.env -> qsymbol -> unit
@@ -109,3 +119,9 @@ module ObjectInfo : sig
   val pr_db  : Format.formatter -> EcEnv.env -> db -> unit
   val pr_any : Format.formatter -> EcEnv.env -> qsymbol -> unit
 end
+
+(* -------------------------------------------------------------------- *)
+val pp_use : PPEnv.t -> Format.formatter -> EcEnv.use -> unit
+val pp_use_restr :
+  EcEnv.env -> print_abstract:bool ->
+  Format.formatter -> EcEnv.use EcModules.use_restr -> unit

--- a/src/ecProofTerm.ml
+++ b/src/ecProofTerm.ml
@@ -52,7 +52,7 @@ type apperror =
   | AE_CannotInferMod
   | AE_NotFunctional
   | AE_InvalidArgForm     of invalid_arg_form
-  | AE_InvalidArgMod
+  | AE_InvalidArgMod      of EcTyping.tymod_cnv_failure
   | AE_InvalidArgProof    of (form * form)
   | AE_InvalidArgModRestr of EcTyping.restriction_error
 
@@ -138,6 +138,7 @@ and concretize_e_head (CPTEnv subst) head =
   | PTHandle h        -> PTHandle h
   | PTLocal  x        -> PTLocal  x
   | PTGlobal (p, tys) -> PTGlobal (p, List.map subst.fs_ty tys)
+  | PTSchema _ -> assert false
 
 and concretize_e_pt cptenv { pt_head; pt_args } =
   { pt_head = concretize_e_head cptenv pt_head;
@@ -494,6 +495,130 @@ let process_named_pterm pe (tvi, fp) =
 
   (p, (typ, ax))
 
+(* -------------------------------------------------------------------- *)
+let process_named_schema pe (tvi, sn) =
+  let env = LDecl.toenv pe.pte_hy in
+
+  let p, sc =
+    match EcEnv.Schema.lookup_opt (unloc sn) (LDecl.toenv pe.pte_hy) with
+    | Some (p,sc) -> p, sc
+    | None -> tc_lookup_error pe.pte_pe `Schema (unloc sn) in
+
+  let typ = sc.EcDecl.axs_tparams in
+
+  let tvi =
+    Exn.recast_pe pe.pte_pe pe.pte_hy
+      (fun () -> omap (EcTyping.transtvi env pe.pte_ue) tvi) in
+
+  PT.pf_check_tvi pe.pte_pe typ tvi;
+
+  (* FIXME: TC HOOK *)
+  let fs  = EcUnify.UniEnv.opentvi pe.pte_ue typ tvi in
+  let sty = { ty_subst_id with ts_v = Mid.find_opt^~ fs } in
+
+  let typ = List.map (fun (a, _) -> EcIdent.Mid.find a fs) typ in
+
+  let e_params =
+    List.map (fun (id, ty) ->
+        id, EcTypes.ty_subst sty ty) sc.EcDecl.axs_params in
+
+  (* When substituting in a schema's formula, we have to rebind the schema's
+     expression variables. *)
+  let rebind =
+    List.map (fun (id,ty) ->
+        id, EcTypes.e_local id ty
+      ) e_params
+    |> Mid.of_list in
+  let sc_i =
+    Fsubst.subst_tvar
+      ~es_loc:rebind
+      fs sc.EcDecl.axs_spec in
+
+  (p, typ, sc.EcDecl.axs_pparams, e_params, sc_i)
+
+(* -------------------------------------------------------------------- *)
+let process_sc_instantiation pe inst =
+  let env = LDecl.toenv pe.pte_hy in
+
+  let ue = EcUnify.UniEnv.create None in
+  let pe = { pe with pte_ue = ue } in
+
+  let p, typ, p_params, e_params, sc_i =
+    process_named_schema pe (inst.ptcds_tys, inst.ptcds_name) in
+  let ppargs = inst.ptcds_mps in
+  let pexprs = inst.ptcds_exprs in
+
+  let check_length s params args =
+    if List.length params <> List.length (unloc args) then
+      tc_error pe.pte_pe ~loc:(loc args)
+        "wrong number of %s arguments: expected %d, got %d" s
+        (List.length params)
+        (List.length (unloc args)) in
+
+  check_length "predicate" p_params ppargs;
+  check_length "expression" e_params pexprs;
+
+  (* We type, in order, the memtype, memory predicates and expressions *)
+  let memtype = EcTyping.trans_memtype env pe.pte_ue inst.ptcds_mt in
+  let memenv = EcCoreFol.mhr, memtype in
+
+  (* The environment for expression arguments typing. *)
+  let e_env = EcEnv.Memory.push_active memenv env in
+
+  let mpreds = List.map2 (fun (mem, pform) id ->
+      (* default to mhr if no memory is given *)
+      let mem = omap_dfl (fun m -> EcIdent.create (unloc m)) mhr (unloc mem) in
+      let memenv = mem, memtype in
+      let env = EcEnv.Memory.push_active memenv env in
+      let f = EcTyping.trans_form env pe.pte_ue pform tbool in
+      id, (mem, f)
+    ) (unloc ppargs) p_params in
+
+  let exprs = List.map2 (fun pexpr (id, ty_expected) ->
+      (* `InProc, because we want to look for variables declared in [memenv] *)
+      id, EcTyping.transexpcast e_env `InProc pe.pte_ue ty_expected pexpr
+    ) (unloc pexprs) e_params in
+
+  (* We close the unification environment, and substitute in all infered args. *)
+  if not (EcUnify.UniEnv.closed pe.pte_ue) then
+    assert false;
+
+  let eus = EcUnify.UniEnv.close pe.pte_ue in
+  let sty = { ty_subst_id with ts_u = eus } in
+  let se = EcTypes.e_uni eus in
+
+  let typ = List.map (EcTypes.ty_subst sty) typ in
+  let memtype = EcMemory.mt_subst (EcTypes.ty_subst sty) memtype in
+  let mpreds = List.map (fun (id, (m,p)) ->
+      let fs = Fsubst.f_subst_init ~sty () in
+      let p = Fsubst.f_subst fs p in
+      id, (m,p)) mpreds in
+  let exprs = List.map (fun (id, e) -> id, se e) exprs in
+
+  (* We instantiate the schema. *)
+  (* FIXME: instantiating and substituting in schema is ugly. *)
+  (* For cost judgement, we also need to substitue the expression variables
+     in the precondition. *)
+  let tx f_old f_new = match f_old.f_node, f_new.f_node with
+    | Fcoe coe_old, Fcoe coe_new when EcMemory.is_schema (snd coe_old.coe_mem) ->
+      let fs =
+        List.fold_left (fun s (id,e) ->
+            let f = EcCoreFol.form_of_expr (fst coe_new.coe_mem) e in
+            Fsubst.f_bind_local s id f)
+          (Fsubst.f_subst_init ()) exprs in
+
+      EcCoreFol.f_coe_r { coe_new with
+                          coe_pre = Fsubst.f_subst fs coe_new.coe_pre }
+    | _ -> f_new in
+
+  let fs =
+    Fsubst.f_subst_init ~sty
+      ~esloc:(Mid.of_list exprs)
+      ~mempred:(Mid.of_list mpreds)
+      ~mt:memtype () in
+
+  (p, typ, memtype, mpreds, exprs, Fsubst.f_subst ~tx fs sc_i)
+
 (* ------------------------------------------------------------------ *)
 let process_pterm_cut ~prcut pe pt =
   let (pt, ax) =
@@ -579,7 +704,13 @@ and trans_pterm_arg_mod pe { pl_desc = arg; pl_loc = loc; } =
   in
 
   let env  = LDecl.toenv pe.pte_hy in
-  let mod_ = (fun () -> EcTyping.trans_msymbol env mp) in
+
+  let comp_sig (mp, _) =
+    let msig = NormMp.sig_of_mp env mp in
+    (mp, msig) in
+
+  let mod_ = (fun () -> EcTyping.trans_msymbol env mp
+                        |> comp_sig) in
   let mod_ = Exn.recast_pe pe.pte_pe pe.pte_hy mod_ in
 
     { ptea_env = pe; ptea_arg = PVAModule mod_; }
@@ -684,18 +815,24 @@ and check_pterm_oarg ?loc pe (x, xty) f arg =
          tc_pterm_apperror ?loc pe (AE_WrongArgKind (ak, `Mem))
   end
 
-  | GTmodty (emt, restr) -> begin
+  | GTmodty emt -> begin
       match dfl_arg_for_mod pe arg with
       | PVAModule (mp, mt) -> begin
-        try
-          EcTyping.check_modtype_with_restrictions env mp mt emt restr;
-          EcPV.check_module_in env mp emt;
-          (Fsubst.f_subst_mod x mp f, PAModule (mp, mt))
+          try
+            let obl = EcTyping.check_modtype env mp mt emt in
+            EcPV.check_module_in env mp emt;
+
+            let f = Fsubst.f_subst_mod x mp f in
+            let f = match obl with
+              | `Ok ->  f
+              | `ProofObligation obl -> f_imps obl f in
+
+          (f, PAModule (mp, mt))
         with
-        | EcTyping.TymodCnvFailure _ ->
-            tc_pterm_apperror ?loc pe AE_InvalidArgMod
         | EcTyping.RestrictionError (_, e) ->
-            tc_pterm_apperror ?loc pe (AE_InvalidArgModRestr e)
+          tc_pterm_apperror ?loc pe (AE_InvalidArgModRestr e)
+        | EcTyping.TymodCnvFailure e ->
+            tc_pterm_apperror ?loc pe (AE_InvalidArgMod e)
       end
       | arg ->
          let ak = argkind_of_ptarg arg in
@@ -762,7 +899,7 @@ and apply_pterm_to_local ?loc pt id =
   | LD_var (ty, _) ->
       apply_pterm_to_arg_r ?loc pt (PVAFormula (f_local id ty))
 
-  | LD_modty (mty, _) ->
+  | LD_modty mty ->
       let env  = LDecl.toenv pt.ptev_env.pte_hy in
       let msig = EcEnv.ModTy.sig_of_mt env mty in
       apply_pterm_to_arg_r ?loc pt (PVAModule (EcPath.mident id, msig))
@@ -859,6 +996,18 @@ let tc1_process_full_pterm ?implicits (tc : tcenv1) (ff : ppterm) =
   let pe   = FApi.tc1_penv tc in
   let hyps = FApi.tc1_hyps tc in
   process_full_pterm ?implicits (ptenv_of_penv hyps pe) ff
+
+(* -------------------------------------------------------------------- *)
+let tc1_process_sc_instantiation (tc : tcenv1) (inst : pcutdef_schema) =
+  let pe   = FApi.tc1_penv tc in
+  let hyps = FApi.tc1_hyps tc in
+  let p, types, memtype, mpreds, exprs, f =
+    process_sc_instantiation (ptenv_of_penv hyps pe) inst in
+  let pt = { pt_head = PTSchema (p, types, memtype,
+                                 List.map snd mpreds,
+                                 List.map snd exprs);
+             pt_args = []; } in
+  pt, f
 
 (* -------------------------------------------------------------------- *)
 let tc1_process_full_closed_pterm_cut ~prcut (tc : tcenv1) (ff : 'a gppterm) =

--- a/src/ecProofTerm.mli
+++ b/src/ecProofTerm.mli
@@ -23,7 +23,7 @@ type apperror =
   | AE_CannotInferMod
   | AE_NotFunctional
   | AE_InvalidArgForm     of invalid_arg_form
-  | AE_InvalidArgMod
+  | AE_InvalidArgMod      of EcTyping.tymod_cnv_failure
   | AE_InvalidArgProof    of (form * form)
   | AE_InvalidArgModRestr of EcTyping.restriction_error
 
@@ -72,8 +72,6 @@ val process_pterm_cut
   : prcut:('a -> form) -> pt_env -> 'a ppt_head -> pt_ev
 val process_pterm
   : pt_env -> (pformula option) ppt_head -> pt_ev
-val process_pterm_arg
-   : ?implicits:bool -> pt_ev  -> ppt_arg located -> pt_ev_arg
 val process_pterm_args_app
   :  ?implicits:bool -> ?ip:(bool list) -> pt_ev  -> ppt_arg located list
   -> pt_ev * bool list
@@ -98,7 +96,9 @@ val tc1_process_full_pterm
 val tc1_process_full_closed_pterm_cut
  : prcut:('a -> form) -> tcenv1 -> 'a gppterm -> proofterm * form
 val tc1_process_full_closed_pterm
- : tcenv1 -> ppterm -> proofterm * form
+  : tcenv1 -> ppterm -> proofterm * form
+val tc1_process_sc_instantiation
+ : tcenv1 -> pcutdef_schema -> proofterm * form
 
 (* Proof-terms manipulation *)
 val check_pterm_arg :

--- a/src/ecProofTyping.ml
+++ b/src/ecProofTyping.ml
@@ -42,6 +42,16 @@ let process_form ?mv hyps pf ty =
 let process_formula ?mv hyps pf =
   process_form hyps ?mv pf tbool
 
+let process_cost ?mv hyps (EcParsetree.PC_costs (self, calls)) tys =
+  let env = LDecl.toenv hyps in
+  let self = process_form_opt ?mv hyps self (Some (toarrow tys txint)) in
+  let calls = List.map (fun (m,f,c) ->
+      let f, self = EcTyping.trans_oracle env (m,f) in
+      let f_c = process_form_opt ?mv hyps c (Some (toarrow tys tint)) in
+      f, call_bound_r self f_c
+    ) calls in
+  cost_r self (EcPath.Mx.of_list calls)
+
 let process_exp hyps mode oty e =
   let env = LDecl.toenv hyps in
   let ue  = unienv_of_hyps hyps in
@@ -61,6 +71,9 @@ let pf_process_form_opt pe ?mv hyps oty pf =
 let pf_process_form pe ?mv hyps ty pf =
   Exn.recast_pe pe hyps (fun () -> process_form ?mv hyps pf ty)
 
+let pf_process_cost pe ?mv hyps tys pcost =
+  Exn.recast_pe pe hyps (fun () -> process_cost ?mv hyps pcost tys)
+
 let pf_process_formula pe ?mv hyps pf =
   Exn.recast_pe pe hyps (fun () -> process_formula ?mv hyps pf)
 
@@ -76,6 +89,9 @@ let tc1_process_form_opt ?mv tc oty pf =
 
 let tc1_process_form ?mv tc ty pf =
   Exn.recast_tc1 tc (fun hyps -> process_form ?mv hyps pf ty)
+
+let tc1_process_cost ?mv tc tys pcost =
+  Exn.recast_tc1 tc (fun hyps -> process_cost ?mv hyps pcost tys)
 
 let tc1_process_formula ?mv tc pf =
   Exn.recast_tc1 tc (fun hyps -> process_formula ?mv hyps pf)
@@ -137,7 +153,8 @@ let tc1_process_Xhl_form ?side tc ty pf =
 
   let memory, mv =
     match concl.f_node, side with
-    | FhoareS   hs, None        -> (hs.hs_m , Some (hs.hs_pr , hs.hs_po ))
+    | FhoareS  hs, None        -> (hs.hs_m, Some (hs.hs_pr, hs.hs_po ))
+    | FcHoareS  hs, None        -> (hs.chs_m, Some (hs.chs_pr, hs.chs_po ))
     | FbdHoareS hs, None        -> (hs.bhs_m, Some (hs.bhs_pr, hs.bhs_po))
     | FequivS   es, Some `Left  -> ((mhr, snd es.es_ml), None)
     | FequivS   es, Some `Right -> ((mhr, snd es.es_mr), None)

--- a/src/ecProofTyping.mli
+++ b/src/ecProofTyping.mli
@@ -30,6 +30,7 @@ val pf_check_tvi   : proofenv -> ty_params -> EcUnify.tvi -> unit
 val process_form_opt : ?mv:metavs -> LDecl.hyps -> pformula -> ty option -> form
 val process_form     : ?mv:metavs -> LDecl.hyps -> pformula -> ty -> form
 val process_formula  : ?mv:metavs -> LDecl.hyps -> pformula -> form
+val process_cost     : ?mv:metavs -> LDecl.hyps -> pcost    -> ty list -> cost
 val process_exp      : LDecl.hyps -> [`InProc|`InOp] -> ty option -> pexpr -> expr
 val process_pattern  : LDecl.hyps -> pformula -> ptnenv * form
 
@@ -37,6 +38,7 @@ val process_pattern  : LDecl.hyps -> pformula -> ptnenv * form
  * Typing exceptions are recasted in the proof env. context *)
 val pf_process_form_opt : proofenv -> ?mv:metavs -> LDecl.hyps -> ty option -> pformula -> form
 val pf_process_form     : proofenv -> ?mv:metavs -> LDecl.hyps -> ty -> pformula -> form
+val pf_process_cost     : proofenv -> ?mv:metavs -> LDecl.hyps -> ty list -> pcost -> cost
 val pf_process_formula  : proofenv -> ?mv:metavs -> LDecl.hyps -> pformula -> form
 val pf_process_exp      : proofenv -> LDecl.hyps -> [`InProc|`InOp] -> ty option -> pexpr -> expr
 val pf_process_pattern  : proofenv -> LDecl.hyps -> pformula -> ptnenv * form
@@ -46,6 +48,7 @@ val pf_process_pattern  : proofenv -> LDecl.hyps -> pformula -> ptnenv * form
 val tc1_process_form_opt : ?mv:metavs -> tcenv1 -> ty option -> pformula -> form
 val tc1_process_form     : ?mv:metavs -> tcenv1 -> ty -> pformula -> form
 val tc1_process_formula  : ?mv:metavs -> tcenv1 -> pformula -> form
+val tc1_process_cost     : ?mv:metavs -> tcenv1 -> ty list -> pcost -> cost
 val tc1_process_exp      : tcenv1 -> [`InProc|`InOp] -> ty option -> pexpr -> expr
 val tc1_process_pattern  : tcenv1 -> pformula -> ptnenv * form
 

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -17,8 +17,10 @@ open EcEnv
 (* -------------------------------------------------------------------- *)
 exception IncompatibleType of env * (ty * ty)
 exception IncompatibleForm of env * (form * form)
+exception IncompatibleExpr of env * (expr * expr)
 
 (* -------------------------------------------------------------------- *)
+
 type 'a eqtest = env -> 'a -> 'a -> bool
 type 'a eqntest = env -> ?norm:bool -> 'a -> 'a -> bool
 
@@ -48,7 +50,9 @@ module User : sig
 
   type error =
     | MissingVarInLhs   of EcIdent.t
+    | MissingEVarInLhs  of EcIdent.t
     | MissingTyVarInLhs of EcIdent.t
+    | MissingPVarInLhs  of EcIdent.t
     | NotAnEq
     | NotFirstOrder
     | RuleDependsOnMemOrModule
@@ -58,7 +62,7 @@ module User : sig
 
   type rule = EcEnv.Reduction.rule
 
-  val compile : opts:options -> prio:int -> EcEnv.env -> EcPath.path -> rule
+  val compile : opts:options -> prio:int -> EcEnv.env -> [`Ax | `Sc] -> EcPath.path -> rule
 end
 
 (* -------------------------------------------------------------------- *)
@@ -74,7 +78,8 @@ type reduction_info = {
   eta     : bool;              (* reduce eta-expansion *)
   logic   : rlogic_info;       (* perform logical simplification *)
   modpath : bool;              (* reduce module path *)
-  user    : bool               (* reduce user defined rules *)
+  user    : bool;              (* reduce user defined rules *)
+  cost    : bool;              (* reduce trivial cost statements *)
 }
 
 and deltap      = [`Yes | `No | `Force]
@@ -88,8 +93,12 @@ val betaiota_red : reduction_info
 val nodelta      : reduction_info
 val delta        : reduction_info
 
+val reduce_logic : reduction_info -> env -> LDecl.hyps -> form -> form
+
 val h_red_opt : reduction_info -> LDecl.hyps -> form -> form option
 val h_red     : reduction_info -> LDecl.hyps -> form -> form
+
+val reduce_cost : reduction_info -> env -> coe -> form
 
 val reduce_user_gen :
   (EcFol.form -> EcFol.form) ->
@@ -102,7 +111,7 @@ val is_conv    : ?ri:reduction_info -> LDecl.hyps -> form -> form -> bool
 val check_conv : ?ri:reduction_info -> LDecl.hyps -> form -> form -> unit
 
 val check_bindings :
-  exn -> EcEnv.env -> EcFol.f_subst ->
+  exn -> EcDecl.ty_params -> EcEnv.env -> EcFol.f_subst ->
   (EcIdent.t * EcFol.gty) list -> (EcIdent.t * EcFol.gty) list ->
   EcEnv.env * EcFol.f_subst
 (* -------------------------------------------------------------------- *)

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -811,6 +811,13 @@ module Ax = struct
   type mode = [`WeakCheck | `Check | `Report]
 
   (* ------------------------------------------------------------------ *)
+  let bind_schema
+    ?(import = EcTheory.import0) (scope : scope) ((x, sc) : _ * ax_schema)
+    =
+    assert (scope.sc_pr_uc = None);
+    let item = EcTheory.mkitem import (EcTheory.Th_schema (x, sc)) in
+    { scope with sc_env = EcSection.add_item item scope.sc_env }
+
   let bind ?(import = EcTheory.import0) (scope : scope) ((x, ax) : _ * axiom) =
     assert (scope.sc_pr_uc = None);
     let item = EcTheory.mkitem import (EcTheory.Th_axiom (x, ax)) in
@@ -846,6 +853,9 @@ module Ax = struct
     let loc = ax.pl_loc and ax = ax.pl_desc in
     let ue  = TT.transtyvars env (loc, ax.pa_tyvars) in
 
+    if ax.pa_kind <> PSchema && ax.pa_scvars <> None then
+      hierror "can only have schema variables in schema";
+
     let (pconcl, tintro) =
       match ax.pa_vars with
       | None ->
@@ -861,7 +871,34 @@ module Ax = struct
     let tintro = mk_loc loc (Plogic (Pmove prevertv0)) in
     let tintro = { pt_core = tintro; pt_intros = [`Ip ip]; } in
 
-    let concl = TT.trans_prop env ue pconcl in
+    let pparams =
+      if ax.pa_kind <> PSchema
+      then begin
+        assert (ax.pa_pvars = None);
+        None end
+      else omap_dfl (fun (PT_MemPred l) ->
+          List.map (fun v -> EcIdent.create (unloc v)) l
+          |> some
+        ) (Some []) ax.pa_pvars in
+
+    let scparams =
+      if ax.pa_kind <> PSchema
+      then begin
+        assert (ax.pa_scvars = None);
+        None end
+      else match ax.pa_scvars with
+        | None -> Some []
+        | Some scv ->
+          List.map (fun (vs,pty) ->
+              let ty = TT.transty tp_tydecl env ue pty in
+              List.map (fun v -> EcIdent.create (unloc v), ty) vs
+            ) scv
+          |> List.flatten
+          |> some in
+
+    let concl =
+      TT.trans_prop env
+        ?schema_mpreds:pparams ?schema_mt:scparams ue pconcl in
 
     if not (EcUnify.UniEnv.closed ue) then
       hierror "the formula contains free type variables";
@@ -869,47 +906,61 @@ module Ax = struct
     let concl   = EcFol.Fsubst.uni (EcUnify.UniEnv.close ue) concl in
     let tparams = EcUnify.UniEnv.tparams ue in
 
-    let axd  =
-      let kind =
-        match ax.pa_kind with
-        | PAxiom tags -> `Axiom (Ssym.of_list (List.map unloc tags), false)
-        | _ -> `Lemma
+    if ax.pa_kind <> PSchema then
+      let axd  =
+        let kind =
+          match ax.pa_kind with
+          | PAxiom tags -> `Axiom (Ssym.of_list (List.map unloc tags), false)
+          | _ -> `Lemma
 
-      in { ax_tparams    = tparams;
-           ax_spec       = concl;
-           ax_kind       = kind;
-           ax_loca       = ax.pa_locality;
-           ax_visibility = if ax.pa_nosmt then `NoSmt else `Visible; }
-    in
+        in { ax_tparams    = tparams;
+             ax_spec       = concl;
+             ax_kind       = kind;
+             ax_loca       = ax.pa_locality;
+             ax_visibility = if ax.pa_nosmt then `NoSmt else `Visible; }
+      in
 
-    match ax.pa_kind with
-    | PLemma tc -> begin
-        let local =
-          match ax.pa_locality with
-          | `Declare -> hierror ~loc "cannot mark with `declare` a lemma"
-          | `Local   -> true
-          | `Global  -> false in
+      match ax.pa_kind with
+      | PLemma tc -> begin
+          let local =
+            match ax.pa_locality with
+            | `Declare -> hierror ~loc "cannot mark with `declare` a lemma"
+            | `Local   -> true
+            | `Global  -> false in
 
-        let check    = Check_mode.check scope.sc_options in
-        let pucflags = { puc_visibility = axd.ax_visibility; puc_local = local; } in
-        let pucflags = (([], None), pucflags) in
+          let check    = Check_mode.check scope.sc_options in
+          let pucflags = { puc_visibility = axd.ax_visibility; puc_local = local; } in
+          let pucflags = (([], None), pucflags) in
 
-        match tc with
-        | None ->
-            let scope =
-              start_lemma scope ~name:(unloc ax.pa_name)
-                pucflags check (axd, None) in
-            let scope = snd (Tactics.process1_r false `Check scope tintro) in
-            None, scope
+          match tc with
+          | None ->
+              let scope =
+                start_lemma scope ~name:(unloc ax.pa_name)
+                  pucflags check (axd, None) in
+              let scope = snd (Tactics.process1_r false `Check scope tintro) in
+              None, scope
 
-        | Some tc ->
-            start_lemma_with_proof scope
-              (Some tintro) pucflags (mode, mk_loc loc tc) check
-              ~name:(unloc ax.pa_name) axd
-      end
+          | Some tc ->
+              start_lemma_with_proof scope
+                (Some tintro) pucflags (mode, mk_loc loc tc) check
+                ~name:(unloc ax.pa_name) axd
+        end
 
-    | PAxiom _ ->
-        (Some (unloc ax.pa_name), bind scope (unloc ax.pa_name, axd))
+      | PAxiom _ ->
+          (Some (unloc ax.pa_name), bind scope (unloc ax.pa_name, axd))
+
+      | PSchema ->
+          assert false
+    else
+      let sc = { axs_tparams = tparams;
+                 axs_pparams = odfl [] pparams;
+                 axs_params  = odfl [] scparams;
+                 axs_spec    = concl;
+                 axs_loca    = ax.pa_locality; }
+      in
+
+      Some (unloc ax.pa_name),
+      bind_schema scope (unloc ax.pa_name, sc)
 
   (* ------------------------------------------------------------------ *)
   and add_defer (scope : scope) proofs =
@@ -1330,6 +1381,27 @@ end
 module Mod = struct
   module TT = EcTyping
 
+  let add_local_restr env path m =
+    let mpath = EcPath.pqname path m.me_name in
+    match m.me_body with
+    | ME_Alias _ | ME_Decl _ -> env
+    | ME_Structure _ ->
+      (* We keep only the internal part, i.e the inner global variables *)
+      (* TODO : using mod_use here to compute the set of inner global
+         variables is inefficient, change this algo *)
+      let mp = EcPath.mpath_crt mpath [] None in
+      let use = EcEnv.NormMp.mod_use env mp in
+      let rx =
+        let add x _ rx =
+          if EcPath.m_equal (EcPath.m_functor x.EcPath.x_top) mp then
+            Sx.add x rx
+          else rx in
+        Mx.fold add use.EcEnv.us_pv EcPath.Sx.empty in
+      EcEnv.Mod.add_restr_to_locals
+        { (ur_empty Sx.empty) with ur_neg = rx }
+        (ur_empty Sm.empty)
+        env
+
   let bind ?(import = EcTheory.import0) (scope : scope) (m : top_module_expr) =
     assert (scope.sc_pr_uc = None);
     let item = EcTheory.mkitem import (EcTheory.Th_module m) in
@@ -1347,7 +1419,7 @@ module Mod = struct
         Format.fprintf fmt "  - %a -> [%a]"
           (EcPrinting.pp_funname ppe) (xastrip xp)
           (EcPrinting.pp_list ", " pp_symbol)
-          (List.map EcPath.xbasename (Sx.ntr_elements names))
+          (Ssym.elements names)
       in
 
       notify scope `Warning
@@ -1359,13 +1431,13 @@ module Mod = struct
 
   let declare (scope : scope) (m : pmodule_decl) =
     let modty = m.ptm_modty in
-    let env = env scope in
-    let tysig = fst (TT.transmodtype env (fst modty)) in
-    let restr = List.map (TT.trans_topmsymbol env) (snd modty) in
     let name  = EcIdent.create (unloc m.ptm_name) in
-    let restr = Sx.empty, Sm.of_list restr in
+    let tysig = fst (TT.transmodtype (env scope) modty.pmty_pq) in
+    (* We modify tysig restrictions according if necessary. *)
+    let tysig = trans_restr_for_modty (env scope) tysig modty.pmty_mem in
+
     { scope with
-      sc_env = EcSection.add_decl_mod name tysig restr scope.sc_env }
+        sc_env = EcSection.add_decl_mod name tysig scope.sc_env }
 
   let add (scope : scope) (m : pmodule_def_or_decl) =
     match m with
@@ -2016,17 +2088,23 @@ module Reduction = struct
   let add_reduction scope (opts, reds) =
     check_state `InTop "hint simplify" scope;
 
-    let opts = EcTheory.{
-      ur_delta  = List.mem `Delta  opts;
-      ur_eqtrue = List.mem `EqTrue opts;
-    } in
-
     let rules =
       let for1 idx name =
         let idx      = odfl 0 idx in
-        let lemma    = fst (EcEnv.Ax.lookup (unloc name) (env scope)) in
-        let red_info = EcReduction.User.compile ~opts ~prio:idx (env scope) lemma in
-        (lemma, opts, Some red_info) in
+        let mode, ax_sc_p =
+          match EcEnv.Ax.lookup_opt (unloc name) (env scope) with
+          | Some (p,_) -> `Ax, p
+          | None -> `Sc, EcEnv.Schema.lookup_path (unloc name) (env scope) in
+
+        let opts = EcTheory.{
+          ur_delta  = List.mem `Delta  opts;
+          ur_eqtrue = List.mem `EqTrue opts;
+          ur_mode   = mode;
+        } in
+
+        let red_info =
+          EcReduction.User.compile ~opts ~prio:idx (env scope) mode ax_sc_p in
+        (ax_sc_p, opts, Some red_info) in
 
       let rules = List.map (fun (xs, idx) -> List.map (for1 idx) xs) reds in
       List.flatten rules
@@ -2189,16 +2267,19 @@ module Search = struct
       let get_path r = function `ByPath s -> Sp.union r s | _ -> r in
       List.fold_left get_path Sp.empty paths in
 
-    let axioms = EcSearch.search env paths in
-    let axioms = EcSearch.sort relevant axioms in
+    let search_res = EcSearch.search env paths in
+    let search_res = EcSearch.sort relevant search_res in
 
     let buffer = Buffer.create 0 in
     let fmt    = Format.formatter_of_buffer buffer in
     let ppe    = EcPrinting.PPEnv.ofenv env in
 
-    List.iter (fun ax ->
-      Format.fprintf fmt "%a@." (EcPrinting.pp_axiom ~long:true ppe) ax)
-      axioms;
+    List.iter (fun r -> match r with
+        | p,`Axiom ax ->
+          Format.fprintf fmt "%a@." (EcPrinting.pp_axiom ~long:true ppe) (p,ax)
+        | p,`Schema sc ->
+          Format.fprintf fmt "%a@." (EcPrinting.pp_schema ~long:true ppe) (p,sc)
+      ) search_res;
     notify scope `Info "%s" (Buffer.contents buffer)
 
   let locate (scope : scope) ({ pl_desc = name } : pqsymbol) =

--- a/src/ecSearch.ml
+++ b/src/ecSearch.ml
@@ -76,22 +76,35 @@ let match_ (env : EcEnv.env) (search : search list) f =
   in List.for_all do1 search
 
 (* -------------------------------------------------------------------- *)
+type search_result =
+  (path * [`Axiom of EcDecl.axiom | `Schema of EcDecl.ax_schema]) list
+
 let search (env : EcEnv.env) (search : search list) =
-  let check _ ax = match_ env search ax.EcDecl.ax_spec
-  in EcEnv.Ax.all ~check env
+  let check_ax _ ax = match_ env search ax.EcDecl.ax_spec in
+  let check_sc _ sc = match_ env search sc.EcDecl.axs_spec in
+  let axs = EcEnv.Ax.all ~check:check_ax env
+            |> List.map (fun (p,x) -> p, `Axiom x)
+  and scs = EcEnv.Schema.all ~check:check_sc env
+            |> List.map (fun (p,x) -> p, `Schema x) in
+  axs @ scs
 
 (* -------------------------------------------------------------------- *)
 open EcSmt
 open EcDecl
 
-let sort (relevant:Sp.t) (res:(path * EcDecl.axiom) list) =
+let sort (relevant:Sp.t) (res : search_result) =
   (* initialisation of the frequency *)
   let unwanted_ops = Sp.empty in
   let fr = Frequency.create unwanted_ops in
-  let do1 (p, ax) =
-    Frequency.add fr ax;
-    let used = Frequency.f_ops unwanted_ops ax.ax_spec in
-    (p,ax), used in
+  let do1 (p, r) = match r with
+    | `Axiom ax ->
+      Frequency.add fr ax.ax_spec;
+      let used = Frequency.f_ops unwanted_ops ax.ax_spec in
+      (p,`Axiom ax), used
+    | `Schema sc ->
+      Frequency.add fr sc.axs_spec;
+      let used = Frequency.f_ops unwanted_ops sc.axs_spec in
+      (p,`Schema sc), used in
   let res = List.map do1 res in
 
   (* compute the weight of each axiom *)

--- a/src/ecSearch.mli
+++ b/src/ecSearch.mli
@@ -21,5 +21,9 @@ type search = [
   | `ByOr      of search list
 ]
 
-val search : EcEnv.env -> search list -> (path * EcDecl.axiom) list
-val sort : Sp.t -> (path * EcDecl.axiom) list -> (path * EcDecl.axiom) list
+type search_result =
+  (path * [`Axiom of EcDecl.axiom | `Schema of EcDecl.ax_schema]) list
+
+val search : EcEnv.env -> search list -> search_result
+
+val sort : Sp.t -> search_result -> search_result

--- a/src/ecSection.mli
+++ b/src/ecSection.mli
@@ -17,7 +17,7 @@ exception SectionError of string
 (* -------------------------------------------------------------------- *)
 type sc_item =
   | SC_th_item  of theory_item
-  | SC_decl_mod of EcIdent.t * module_type * mod_restr
+  | SC_decl_mod of EcIdent.t * module_type
 
 (* -------------------------------------------------------------------- *)
 type scenv
@@ -27,7 +27,7 @@ val env : scenv -> env
 val initial : env -> scenv
 
 val add_item     : theory_item -> scenv -> scenv
-val add_decl_mod : EcIdent.t -> module_type -> mod_restr -> scenv -> scenv
+val add_decl_mod : EcIdent.t -> module_type -> scenv -> scenv
 
 val enter_section : EcSymbols.symbol option -> scenv -> scenv
 val exit_section  : EcSymbols.symbol option -> scenv -> scenv

--- a/src/ecSmt.mli
+++ b/src/ecSmt.mli
@@ -36,9 +36,6 @@ module Frequency : sig
   val frequency : frequency -> all_rel -> int
   val f_ops : Sp.t -> form -> relevant
 
-  val add : frequency -> EcDecl.axiom -> unit
+  val add : frequency -> EcFol.form -> unit
 
 end
-
-
-

--- a/src/ecSubst.mli
+++ b/src/ecSubst.mli
@@ -42,6 +42,7 @@ val freshen_type : (ty_params * ty) -> (ty_params * ty)
 (* -------------------------------------------------------------------- *)
 val subst_theory  : subst -> theory -> theory
 val subst_ax      : subst -> axiom -> axiom
+val subst_schema  : subst -> ax_schema -> ax_schema
 val subst_op      : subst -> operator -> operator
 val subst_tydecl  : subst -> tydecl -> tydecl
 val subst_tc      : subst -> typeclass -> typeclass
@@ -60,7 +61,7 @@ val subst_modtype      : subst -> module_type -> module_type
 val subst_modsig       : ?params:(ident list) -> subst -> module_sig -> module_sig
 val subst_top_modsig   : subst -> top_module_sig -> top_module_sig
 val subst_modsig_body  : subst -> module_sig_body -> module_sig_body
-
+val subst_mod_restr    : subst -> mod_restr -> mod_restr
 (* -------------------------------------------------------------------- *)
 val subst_genty : subst -> (ty_params * ty) -> (ty_params * ty)
 val subst_ty    : subst -> ty   -> ty

--- a/src/ecThCloning.ml
+++ b/src/ecThCloning.ml
@@ -433,6 +433,9 @@ end = struct
         let name = (loced (xdth @ prefix, x)) in
         ax_ovrd oc (proofs, evc) name  (axd, mode)
 
+      | Th_schema _ ->
+          (proofs, evc)
+
       | Th_theory (x, dth) when dth.cth_mode = `Concrete ->
          List.fold_left (doit (prefix @ [x])) (proofs, evc) dth.cth_items
 

--- a/src/ecTheory.ml
+++ b/src/ecTheory.ml
@@ -35,6 +35,7 @@ and theory_item_r =
   | Th_type      of (symbol * tydecl)
   | Th_operator  of (symbol * operator)
   | Th_axiom     of (symbol * axiom)
+  | Th_schema    of (symbol * ax_schema)
   | Th_modtype   of (symbol * top_module_sig)
   | Th_module    of top_module_expr
   | Th_theory    of (symbol * ctheory)
@@ -61,34 +62,39 @@ and tcinstance = [ `Ring of ring | `Field of field | `General of path ]
 and thmode     = [ `Abstract | `Concrete ]
 
 and rule_pattern =
-  | Rule  of top_rule_pattern * rule_pattern list
-  | Int   of EcBigInt.zint
-  | Var   of EcIdent.t
+  | Rule of top_rule_pattern * rule_pattern list
+  | Cost of EcMemory.memenv * rule_pattern * rule_pattern (* memenv, pre, expr *)
+  | Int  of EcBigInt.zint
+  | Var  of EcIdent.t
 
 and top_rule_pattern =
   [`Op of (EcPath.path * EcTypes.ty list) | `Tuple]
 
 and rule = {
-  rl_tyd  : EcDecl.ty_params;
-  rl_vars : (EcIdent.t * EcTypes.ty) list;
-  rl_cond : EcCoreFol.form list;
-  rl_ptn  : rule_pattern;
-  rl_tg   : EcCoreFol.form;
-  rl_prio : int;
+  rl_tyd   : EcDecl.ty_params;
+  rl_vars  : (EcIdent.t * EcTypes.ty) list;
+  rl_evars : (EcIdent.t * EcTypes.ty) list;
+  rl_pvars : EcIdent.t list;
+  rl_cond  : EcCoreFol.form list;
+  rl_ptn   : rule_pattern;
+  rl_tg    : EcCoreFol.form;
+  rl_prio  : int;
 }
 
 and rule_option = {
   ur_delta  : bool;
   ur_eqtrue : bool;
+  ur_mode   : [`Ax | `Sc];
 }
 
 let mkitem (import : import) (item : theory_item_r) =
   { ti_import = import; ti_item = item; }
 
 (* -------------------------------------------------------------------- *)
-let module_comps_of_module_sig_comps (comps : module_sig_body) =
+let module_comps_of_module_sig_comps (comps : module_sig_body) restr =
   let onitem = function
-    | Tys_function(funsig, oi) ->
+    | Tys_function funsig ->
+      let oi = Msym.find funsig.fs_name restr.mr_oinfos in
         MI_Function {
           f_name = funsig.fs_name;
           f_sig  = funsig;
@@ -98,10 +104,13 @@ let module_comps_of_module_sig_comps (comps : module_sig_body) =
     List.map onitem comps
 
 (* -------------------------------------------------------------------- *)
-let module_expr_of_module_sig name mp tymod restr =
-  let tycomps = module_comps_of_module_sig_comps tymod.mis_body in
+let module_expr_of_module_sig name mp tymod =
+  (* Abstract modules must be fully applied. *)
+  assert (List.length mp.mt_params = List.length mp.mt_args);
 
-    { me_name  = EcIdent.name name;
-      me_body  = ME_Decl (mp, restr);
-      me_comps = tycomps;
-      me_sig   = tymod; }
+  let tycomps = module_comps_of_module_sig_comps tymod.mis_body mp.mt_restr in
+    { me_name     = EcIdent.name name;
+      me_body     = ME_Decl mp;
+      me_comps    = tycomps;
+      me_sig_body = tymod.mis_body;
+      me_params   = tymod.mis_params ; }

--- a/src/ecTheory.mli
+++ b/src/ecTheory.mli
@@ -31,6 +31,7 @@ and theory_item_r =
   | Th_type      of (symbol * tydecl)
   | Th_operator  of (symbol * operator)
   | Th_axiom     of (symbol * axiom)
+  | Th_schema    of (symbol * ax_schema)
   | Th_modtype   of (symbol * top_module_sig)
   | Th_module    of top_module_expr
   | Th_theory    of (symbol * ctheory)
@@ -57,33 +58,35 @@ and ctheory = {
 and tcinstance = [ `Ring of ring | `Field of field | `General of EcPath.path ]
 and thmode     = [ `Abstract | `Concrete ]
 
+(* For cost judgement, we have higher-order pattern. *)
 and rule_pattern =
-  | Rule  of top_rule_pattern * rule_pattern list
-  | Int   of EcBigInt.zint
-  | Var   of EcIdent.t
+  | Rule of top_rule_pattern * rule_pattern list
+  | Cost of EcMemory.memenv * rule_pattern * rule_pattern (* memenv, pre, expr *)
+  | Int  of EcBigInt.zint
+  | Var  of EcIdent.t
 
 and top_rule_pattern =
   [`Op of (EcPath.path * EcTypes.ty list) | `Tuple]
 
 and rule = {
-  rl_tyd  : EcDecl.ty_params;
-  rl_vars : (EcIdent.t * EcTypes.ty) list;
-  rl_cond : EcCoreFol.form list;
-  rl_ptn  : rule_pattern;
-  rl_tg   : EcCoreFol.form;
-  rl_prio : int;
+  rl_tyd   : EcDecl.ty_params;
+  rl_vars  : (EcIdent.t * EcTypes.ty) list;
+  rl_evars : (EcIdent.t * EcTypes.ty) list; (* For schemata *)
+  rl_pvars : EcIdent.t list;                (* For schemata *)
+  rl_cond  : EcCoreFol.form list;
+  rl_ptn   : rule_pattern;
+  rl_tg    : EcCoreFol.form;
+  rl_prio  : int;
 }
 
 and rule_option = {
   ur_delta  : bool;
   ur_eqtrue : bool;
+  ur_mode   : [`Ax | `Sc];
 }
 
 val mkitem : import -> theory_item_r -> theory_item
 
 (* -------------------------------------------------------------------- *)
-val module_comps_of_module_sig_comps:
-  module_sig_body -> module_item list
-
 val module_expr_of_module_sig:
-  EcIdent.t -> module_type -> module_sig -> mod_restr -> module_expr
+  EcIdent.t -> module_type -> module_sig -> module_expr

--- a/src/ecTypes.mli
+++ b/src/ecTypes.mli
@@ -61,6 +61,7 @@ val ty_fv_and_tvar : ty -> int Mid.t
 val tunit   : ty
 val tbool   : ty
 val tint    : ty
+val txint   : ty
 val treal   : ty
 val tdistr  : ty -> ty
 val toption : ty -> ty
@@ -140,18 +141,29 @@ val lp_ids   : lpattern -> EcIdent.t list
 val lp_fv    : lpattern -> EcIdent.Sid.t
 
 (* -------------------------------------------------------------------- *)
-type pvar_kind =
-  | PVglob
-  | PVloc
+type variable = {
+    v_name : symbol;   (* can be "_" *)
+    v_type : ty;
+  }
+val v_name  : variable -> symbol
+val v_type  : variable -> ty
+val v_hash  : variable -> int
+val v_equal : variable -> variable -> bool
 
-type prog_var = private {
-  pv_name : EcPath.xpath;
-  pv_kind : pvar_kind;
-}
+(* -------------------------------------------------------------------- *)
+type pvar_kind =
+  | PVKglob
+  | PVKloc
+
+type prog_var = private
+  | PVglob of EcPath.xpath
+  | PVloc of EcSymbols.symbol
 
 val pv_equal       : prog_var -> prog_var -> bool
 val pv_compare     : prog_var -> prog_var -> int
 val pv_ntr_compare : prog_var -> prog_var -> int
+
+val pv_kind : prog_var -> pvar_kind
 
 (* work only if the prog_var has been normalized *)
 val pv_compare_p : prog_var -> prog_var -> int
@@ -160,17 +172,22 @@ val pv_fv      : prog_var -> int EcIdent.Mid.t
 val is_loc     : prog_var -> bool
 val is_glob    : prog_var -> bool
 
+val get_loc     : prog_var -> EcSymbols.symbol
+val get_glob    : prog_var -> EcPath.xpath
+
 val symbol_of_pv   : prog_var -> symbol
 val string_of_pvar : prog_var -> string
 
 val pv_subst : (EcPath.xpath -> EcPath.xpath) -> prog_var -> prog_var
 
-val pv_loc  : EcPath.xpath -> symbol -> prog_var
+val pv_loc  : EcSymbols.symbol -> prog_var
 val pv_glob : EcPath.xpath -> prog_var
 val xp_glob : EcPath.xpath -> EcPath.xpath
-val pv_res  : EcPath.xpath -> prog_var
-val pv_arg  : EcPath.xpath -> prog_var
-val pv      : EcPath.xpath -> pvar_kind -> prog_var
+
+val arg_symbol : symbol
+val res_symbol : symbol
+val pv_res  : prog_var
+val pv_arg  : prog_var
 
 (* -------------------------------------------------------------------- *)
 type expr = private {
@@ -239,6 +256,7 @@ val is_tuple_var : expr -> bool
 
 val destr_local     : expr -> EcIdent.t
 val destr_var       : expr -> prog_var
+val destr_app       : expr -> expr * expr list
 val destr_tuple_var : expr -> prog_var list
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -16,9 +16,10 @@ open EcLocation
 open EcParsetree
 open EcTypes
 open EcModules
+open EcFol
 
 (* -------------------------------------------------------------------- *)
-type wp = EcEnv.env -> EcMemory.memory -> stmt -> EcFol.form -> EcFol.form option
+type wp = EcEnv.env -> EcMemory.memenv -> stmt -> EcFol.form -> EcFol.form option
 val  wp : wp option ref
 
 (* -------------------------------------------------------------------- *)
@@ -26,18 +27,52 @@ type opmatch = [
   | `Op   of EcPath.path * EcTypes.ty list
   | `Lc   of EcIdent.t
   | `Var  of EcTypes.prog_var
-  | `Proj of EcTypes.prog_var * EcTypes.ty * (int * int)
+  | `Proj of EcTypes.prog_var * EcMemory.proj_arg
 ]
 
+type 'a mismatch_sets = [`Eq of 'a * 'a | `Sub of 'a ]
+
+
+type 'a suboreq       = [`Eq of 'a | `Sub of 'a ]
+
 type mismatch_funsig =
-| MF_targs of ty * ty (* expected, got *)
-| MF_tres  of ty * ty (* expected, got *)
-| MF_restr of EcEnv.env * [`Eq of Sx.t * Sx.t | `Sub of Sx.t ]
+| MF_targs  of ty * ty                               (* expected, got *)
+| MF_tres   of ty * ty                               (* expected, got *)
+| MF_restr  of EcEnv.env * Sx.t mismatch_sets
+| MF_compl     of EcEnv.env *
+                  ((form * form) option
+                   * (form * form) Mx.t) suboreq
+| MF_unbounded
+
+type restr_failure = Sx.t * Sm.t
+
+type restr_eq_failure = Sx.t * Sm.t * Sx.t * Sm.t
+
+type mismatch_restr = [
+  | `Sub    of restr_failure          (* Should not be allowed *)
+  | `RevSub of restr_failure option   (* Should be allowed. None is everybody *)
+  | `Eq     of restr_eq_failure       (* Should be equal *)
+  | `FunCanCallUnboundedOracle of symbol * EcPath.xpath
+]
+
+type restriction_who =
+| RW_mod of EcPath.mpath
+| RW_fun of EcPath.xpath
+
+type restriction_error = restriction_who * [
+  | `Sub of restr_failure              (* Should not be allowed *)
+  | `RevSub of restr_failure option    (* Should be allowed *)
+]
+
+exception RestrictionError of EcEnv.env * restriction_error
 
 type tymod_cnv_failure =
 | E_TyModCnv_ParamCountMismatch
 | E_TyModCnv_ParamTypeMismatch of EcIdent.t
 | E_TyModCnv_MissingComp       of symbol
+
+| E_TyModCnv_MismatchRestr of symbol * mismatch_restr
+
 | E_TyModCnv_MismatchFunSig    of symbol * mismatch_funsig
 | E_TyModCnv_SubTypeArg        of
     EcIdent.t * module_type * module_type * tymod_cnv_failure
@@ -124,13 +159,21 @@ type tyerror =
 | InvalidMatch           of fxerror
 | InvalidFilter          of filter_error
 | FunNotInModParam       of qsymbol
+| FunNotInSignature      of symbol
+| InvalidVar
 | NoActiveMemory
 | PatternNotAllowed
 | MemNotAllowed
 | UnknownScope           of qsymbol
 | NoWP
 | FilterMatchFailure
+| MissingMemType
+| SchemaVariableReBinded of EcIdent.t
+| SchemaMemBinderBelowCost
+| ModuleNotAbstract      of symbol
+| ProcedureUnbounded     of symbol * symbol
 | LvMapOnNonAssign
+| NoDefaultMemRestr
 
 exception TymodCnvFailure of tymod_cnv_failure
 exception TyError of EcLocation.t * env * tyerror
@@ -185,44 +228,54 @@ type ptnmap = ty EcIdent.Mid.t ref
 type metavs = EcFol.form Msym.t
 
 val transmem       : env -> EcSymbols.symbol located -> EcIdent.t
-val trans_form_opt : env -> ?mv:metavs -> EcUnify.unienv -> pformula -> ty option -> EcFol.form
-val trans_form     : env -> ?mv:metavs -> EcUnify.unienv -> pformula -> ty -> EcFol.form
-val trans_prop     : env -> ?mv:metavs -> EcUnify.unienv -> pformula -> EcFol.form
+
+val trans_form_opt :
+  env -> ?mv:metavs ->
+  ?schema_mpreds:(EcIdent.t list) ->
+  ?schema_mt:sc_params ->
+  EcUnify.unienv -> pformula -> ty option -> EcFol.form
+
+val trans_form     :
+  env -> ?mv:metavs ->
+  ?schema_mpreds:(EcIdent.t list) ->
+  ?schema_mt:sc_params ->
+  EcUnify.unienv -> pformula -> ty -> EcFol.form
+
+val trans_prop     :
+  env -> ?mv:metavs ->
+  ?schema_mpreds:(EcIdent.t list) ->
+  ?schema_mt:sc_params ->
+  EcUnify.unienv -> pformula -> EcFol.form
+
 val trans_pattern  : env -> ptnmap -> EcUnify.unienv -> pformula -> EcFol.form
 
 (* -------------------------------------------------------------------- *)
+val trans_memtype :
+  env -> EcUnify.unienv -> pmemtype -> EcMemory.memtype
+
+(* -------------------------------------------------------------------- *)
+val trans_restr_for_modty :
+  env -> module_type -> pmod_restr option -> module_type
+
 val transmodsig  : env -> pinterface -> top_module_sig
 val transmodtype : env -> pmodule_type -> module_type * module_sig
 val transmod     : attop:bool -> env -> pmodule_def -> module_expr
 
 val trans_topmsymbol : env -> pmsymbol located -> mpath
-val trans_msymbol    : env -> pmsymbol located -> mpath * module_sig
+val trans_msymbol    : env -> pmsymbol located -> mpath * module_smpl_sig
 val trans_gamepath   : env -> pgamepath -> xpath
+val trans_oracle     : env -> psymbol * psymbol -> xpath * form
+val trans_restr_mem : env -> pmod_restr_mem -> Sx.t use_restr * Sm.t use_restr
 
 (* -------------------------------------------------------------------- *)
-type restriction_who =
-| RW_mod of EcPath.mpath
-| RW_fun of EcPath.xpath
 
-type restriction_err =
-| RE_UseVariable          of EcPath.xpath
-| RE_UseVariableViaModule of EcPath.xpath * EcPath.mpath
-| RE_UseModule            of EcPath.mpath
-| RE_VMissingRestriction  of EcPath.xpath * EcPath.mpath pair
-| RE_MMissingRestriction  of EcPath.mpath * EcPath.mpath pair
+(* This only checks the memory restrictions. *)
+val check_mem_restr_fun :
+  env -> xpath -> mod_restr -> unit
 
-type restriction_error = restriction_who * restriction_err
-
-exception RestrictionError of EcEnv.env * restriction_error
-
-val check_sig_mt_cnv :
-  env -> module_sig -> module_type -> unit
-
-val check_restrictions_fun :
-  env -> xpath -> use -> mod_restr -> unit
-
-val check_modtype_with_restrictions :
-  env -> mpath -> module_sig -> module_type -> mod_restr -> unit
+val check_modtype :
+  env -> mpath -> module_sig -> module_type ->
+  [> `Ok | `ProofObligation of EcFol.form list ]
 
 (* -------------------------------------------------------------------- *)
 val get_ring  : (ty_params * ty) -> env -> EcDecl.ring  option

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -570,7 +570,7 @@ module List = struct
     function [x] -> x | xs  -> f xs
 
   (* ------------------------------------------------------------------ *)
-  let rec find_dup ?(cmp = Stdlib.compare) (xs : 'a list ) =
+  let rec find_dup ?(cmp = Stdlib.compare) (xs : 'a list) =
     match xs with
     | []      -> None
     | x :: xs ->

--- a/src/phl/ecPhlAuto.ml
+++ b/src/phl/ecPhlAuto.ml
@@ -42,6 +42,10 @@ let t_auto_rnd_hoare_r tc =
   EcPhlRnd.t_hoare_rnd tc
 
 (* -------------------------------------------------------------------- *)
+let t_auto_rnd_choare_r tc =
+  EcPhlRnd.t_choare_rnd EcParsetree.PNoRndParams tc
+
+(* -------------------------------------------------------------------- *)
 let t_auto_rnd_bdhoare_r tc =
   let hs = tc1_as_bdhoareS tc in
 
@@ -70,13 +74,15 @@ let t_auto_rnd_equiv_r tc =
 
 (* -------------------------------------------------------------------- *)
 let t_auto_rnd_hoare   = FApi.t_low0 "auto-rnd-hoare"   t_auto_rnd_hoare_r
+let t_auto_rnd_choare  = FApi.t_low0 "auto-rnd-choare"  t_auto_rnd_choare_r
 let t_auto_rnd_bdhoare = FApi.t_low0 "auto-rnd-bdhoare" t_auto_rnd_bdhoare_r
 let t_auto_rnd_equiv   = FApi.t_low0 "auto-rnd-equiv"   t_auto_rnd_equiv_r
 
 (* -------------------------------------------------------------------- *)
 let t_auto_rnd =
-  t_hS_or_bhS_or_eS
+  t_hS_or_chS_or_bhS_or_eS
     ~th:t_auto_rnd_hoare
+    ~tch:t_auto_rnd_choare
     ~tbh:t_auto_rnd_bdhoare
     ~te:t_auto_rnd_equiv
 

--- a/src/phl/ecPhlCase.ml
+++ b/src/phl/ecPhlCase.ml
@@ -20,6 +20,16 @@ let t_hoare_case_r ?(simplify = true) f tc =
   FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
 
 (* --------------------------------------------------------------------- *)
+let t_choare_case_r ?(simplify = true) f tc =
+  let fand = if simplify then f_and_simpl else f_and in
+  let chs = tc1_as_choareS tc in
+  let concl1 = f_cHoareS_r
+    { chs with chs_pr = fand chs.chs_pr f } in
+  let concl2 = f_cHoareS_r
+    { chs with chs_pr = fand chs.chs_pr (f_not f) } in
+  FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
+
+(* --------------------------------------------------------------------- *)
 let t_bdhoare_case_r ?(simplify = true) f tc =
   let fand = if simplify then f_and_simpl else f_and in
   let bhs = tc1_as_bdhoareS tc in
@@ -41,6 +51,9 @@ let t_equiv_case_r ?(simplify = true) f tc =
 let t_hoare_case ?simplify =
   FApi.t_low1 "hoare-case" (t_hoare_case_r ?simplify)
 
+let t_choare_case ?simplify =
+  FApi.t_low1 "choare-case" (t_choare_case_r ?simplify)
+
 let t_bdhoare_case ?simplify =
   FApi.t_low1 "bdhoare-case" (t_bdhoare_case_r ?simplify)
 
@@ -49,8 +62,9 @@ let t_equiv_case ?simplify =
 
 (* --------------------------------------------------------------------- *)
 let t_hl_case_r ?simplify f tc =
-  t_hS_or_bhS_or_eS
+  t_hS_or_chS_or_bhS_or_eS
     ~th:(t_hoare_case ?simplify f)
+    ~tch:(t_choare_case ?simplify f)
     ~tbh:(t_bdhoare_case ?simplify f)
     ~te:(t_equiv_case ?simplify f)
     tc

--- a/src/phl/ecPhlCase.mli
+++ b/src/phl/ecPhlCase.mli
@@ -12,6 +12,7 @@ open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_case   : ?simplify:bool -> form -> backward
+val t_choare_case  : ?simplify:bool -> form -> backward
 val t_bdhoare_case : ?simplify:bool -> form -> backward
 val t_equiv_case   : ?simplify:bool -> form -> backward
 

--- a/src/phl/ecPhlCodeTx.ml
+++ b/src/phl/ecPhlCodeTx.ml
@@ -81,15 +81,17 @@ let t_kill_r side cpos olen tc =
   in
 
   let tr = fun side -> `Kill (side, cpos, olen) in
-  t_code_transform side ~bdhoare:true cpos tr (t_zip kill_stmt) tc
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_zip kill_stmt) tc
 
 (* -------------------------------------------------------------------- *)
 let alias_stmt env id (pf, _) me i =
   let dopv ty =
     let id       = odfl "x" (omap EcLocation.unloc id) in
     let id       = { v_name = id; v_type = ty; } in
-    let (me, id) = fresh_pv me id in
-    let pv       = pv_loc (EcMemory.xpath me) id in
+    let (me, id) = EcMemory.bind_fresh id me in
+    let pv       = pv_loc id.v_name in
     me, pv in
 
   match i.i_node with
@@ -111,15 +113,17 @@ let alias_stmt env id (pf, _) me i =
 let t_alias_r side cpos id g =
   let env = FApi.tc1_env g in
   let tr = fun side -> `Alias (side, cpos) in
-  t_code_transform side ~bdhoare:true cpos tr (t_fold (alias_stmt env id)) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_fold (alias_stmt env id)) g
 
 (* -------------------------------------------------------------------- *)
 let set_stmt (fresh, id) e =
   let get_i me =
     let id       = EcLocation.unloc id in
     let  v       = { v_name = id; v_type = e.e_ty } in
-    let (me, id) = fresh_pv me v in
-    let pv       = pv_loc (EcMemory.xpath me) id in
+    let (me, id) = EcMemory.bind_fresh v me in
+    let pv       = pv_loc id.v_name in
 
     (me, i_asgn (LvVar (pv, e.e_ty), e))
   in
@@ -137,7 +141,9 @@ let set_stmt (fresh, id) e =
 
 let t_set_r side cpos (fresh, id) e tc =
   let tr = fun side -> `Set (side, cpos) in
-  t_code_transform side ~bdhoare:true cpos tr (t_zip (set_stmt (fresh, id) e)) tc
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_zip (set_stmt (fresh, id) e)) tc
 
 (* -------------------------------------------------------------------- *)
 let cfold_stmt (pf, hyps) me olen zpr =
@@ -173,7 +179,7 @@ let cfold_stmt (pf, hyps) me olen zpr =
 
   List.iter
     (fun (x, _, _) ->
-      if x.pv_kind <> PVloc then
+      if is_glob x then
         tc_error pf "left-values must be local variables")
     asgn;
 
@@ -208,7 +214,9 @@ let cfold_stmt (pf, hyps) me olen zpr =
 let t_cfold_r side cpos olen g =
   let tr = fun side -> `Fold (side, cpos, olen) in
   let cb = fun cenv _ me zpr -> cfold_stmt cenv me olen zpr in
-  t_code_transform side ~bdhoare:true cpos tr (t_zip cb) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_zip cb) g
 
 (* -------------------------------------------------------------------- *)
 let t_kill  = FApi.t_low3 "code-tx-kill"  t_kill_r

--- a/src/phl/ecPhlCond.ml
+++ b/src/phl/ecPhlCond.ml
@@ -22,23 +22,39 @@ module Sid = EcIdent.Sid
 
 (* -------------------------------------------------------------------- *)
 module LowInternal = struct
- let t_gen_cond side e tc =
+ let t_gen_cond side e c tc =
    let hyps  = FApi.tc1_hyps tc in
-   let fresh = ["&m"; "&m"; "_"; "_"; "_"] in
+   let fresh = ["&m"; "&m"; "_"; "_"; "_";"_";"_"] in
    let fresh = LDecl.fresh_ids hyps fresh in
 
-   let m1,m2,h,h1,h2 = as_seq5 fresh in
+   let m1,m2,h,h1,h2,h3,h4 = as_seq7 fresh in
+
    let t_introm = if is_none side then t_id else t_intros_i [m1] in
+
+   let t1 =
+     FApi.t_or
+       (FApi.t_seqs [t_elim_hyp h;
+                     t_intros_i [h1;h2];
+                     t_apply_hyp h2])
+       (t_apply_hyp h) in
+
+   let t2 =
+     FApi.t_seqs [t_elim_hyp h;
+                  t_intros_i [h1; h2];
+                  t_elim_hyp h1;
+                  t_intros_i [h3; h4];
+                  FApi.t_seqsub t_split
+                    [t_apply_hyp h4; t_apply_hyp h2]] in
+   let t3 =
+     match c with
+     | None -> t1
+     | Some _ -> FApi.t_or t2 t1 in
 
    let t_sub b tc =
      FApi.t_on1seq 0
-       (EcPhlRCond.t_rcond side b (Zpr.cpos 1))
+       (EcPhlRCond.t_rcond side b (Zpr.cpos 1) c)
        (FApi.t_seqs
-           [t_introm; EcPhlSkip.t_skip; t_intros_i [m2;h];
-            FApi.t_seqs [t_elim_hyp h;
-                         t_intros_i [h1;h2];
-                         t_apply_hyp h2];
-            t_simplify])
+          [t_introm; EcPhlSkip.t_skip; t_intros_i [m2;h]; t3; t_simplify])
        tc
    in
    FApi.t_seqsub
@@ -50,13 +66,27 @@ end
 let t_hoare_cond tc =
   let hs = tc1_as_hoareS tc in
   let (e,_,_) = fst (tc1_first_if tc hs.hs_s) in
-  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory hs.hs_m) e) tc
+  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory hs.hs_m) e) None tc
+
+(* -------------------------------------------------------------------- *)
+let t_choare_cond c tc =
+  let chs = tc1_as_choareS tc in
+  let (e,_,_) = fst (tc1_first_if tc chs.chs_s) in
+  let t =
+    LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory chs.chs_m) e) c
+  in
+  match c with
+  | None -> t tc
+  | Some pr ->
+    FApi.t_seqsub
+      (EcPhlConseq.t_cHoareS_conseq (f_and chs.chs_pr pr) chs.chs_po)
+      [t_id; t_trivial; t] tc
 
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_cond tc =
   let bhs = tc1_as_bdhoareS tc in
   let (e,_,_) = fst (tc1_first_if tc bhs.bhs_s) in
-  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory bhs.bhs_m) e) tc
+  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory bhs.bhs_m) e) None tc
 
 (* -------------------------------------------------------------------- *)
 let rec t_equiv_cond side tc =
@@ -73,7 +103,7 @@ let rec t_equiv_cond side tc =
         | `Right ->
           let (e,_,_) = fst (tc1_first_if tc es.es_sr) in
           form_of_expr (EcMemory.memory es.es_mr) e
-      in LowInternal.t_gen_cond side e tc
+      in LowInternal.t_gen_cond side e None tc
 
   | None ->
       let el,_,_ = fst (tc1_first_if tc es.es_sl) in

--- a/src/phl/ecPhlCond.mli
+++ b/src/phl/ecPhlCond.mli
@@ -12,6 +12,7 @@ open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_cond   : backward
+val t_choare_cond  : EcFol.form option -> backward
 val t_bdhoare_cond : backward
 val t_equiv_cond   : oside -> backward
 

--- a/src/phl/ecPhlConseq.mli
+++ b/src/phl/ecPhlConseq.mli
@@ -16,23 +16,32 @@ open EcCoreGoal
 (* FIXME: add t_low* to all these tactics                               *)
 
 (* -------------------------------------------------------------------- *)
-val t_equivF_conseq      : form -> form -> FApi.backward
-val t_equivS_conseq      : form -> form -> FApi.backward
-val t_eagerF_conseq      : form -> form -> FApi.backward
-val t_hoareF_conseq      : form -> form -> FApi.backward
-val t_hoareS_conseq      : form -> form -> FApi.backward
-val t_bdHoareF_conseq    : form -> form -> FApi.backward
-val t_bdHoareS_conseq    : form -> form -> FApi.backward
-val t_bdHoareS_conseq_bd : hoarecmp -> form -> FApi.backward
-val t_bdHoareF_conseq_bd : hoarecmp -> form -> FApi.backward
+val t_equivF_conseq       : form -> form -> FApi.backward
+val t_equivS_conseq       : form -> form -> FApi.backward
+val t_eagerF_conseq       : form -> form -> FApi.backward
+val t_hoareF_conseq       : form -> form -> FApi.backward
+val t_hoareS_conseq       : form -> form -> FApi.backward
+val t_cHoareF_conseq      : form -> form -> FApi.backward
+val t_cHoareS_conseq      : form -> form -> FApi.backward
+val t_bdHoareF_conseq     : form -> form -> FApi.backward
+val t_bdHoareS_conseq     : form -> form -> FApi.backward
+
+val t_cHoareF_conseq_c    : cost -> FApi.backward
+val t_cHoareS_conseq_c    : cost -> FApi.backward
+val t_cHoareF_conseq_full : form -> form -> cost -> FApi.backward
+val t_cHoareS_conseq_full : form -> form -> cost -> FApi.backward
+val t_bdHoareS_conseq_bd  : hoarecmp -> form -> FApi.backward
+val t_bdHoareF_conseq_bd  : hoarecmp -> form -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_equivF_conseq_nm   : form -> form -> FApi.backward
-val t_equivS_conseq_nm   : form -> form -> FApi.backward
-val t_hoareF_conseq_nm   : form -> form -> FApi.backward
-val t_hoareS_conseq_nm   : form -> form -> FApi.backward
-val t_bdHoareF_conseq_nm : form -> form -> FApi.backward
-val t_bdHoareS_conseq_nm : form -> form -> FApi.backward
+val t_equivF_conseq_nm    : form -> form -> FApi.backward
+val t_equivS_conseq_nm    : form -> form -> FApi.backward
+val t_hoareF_conseq_nm    : form -> form -> FApi.backward
+val t_hoareS_conseq_nm    : form -> form -> FApi.backward
+val t_cHoareF_conseq_nm   : form -> form -> FApi.backward
+val t_cHoareS_conseq_nm   : form -> form -> FApi.backward
+val t_bdHoareF_conseq_nm  : form -> form -> FApi.backward
+val t_bdHoareS_conseq_nm  : form -> form -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
 val t_equivS_conseq_bd : side -> EcFol.form -> EcFol.form ->FApi.backward

--- a/src/phl/ecPhlDeno.ml
+++ b/src/phl/ecPhlDeno.ml
@@ -71,7 +71,7 @@ let t_core_phoare_deno pre post tc =
   let fun_ = EcEnv.Fun.by_xpath pr.pr_fun env in
 
   (* building the substitution for the pre *)
-  let sargs = PVM.add env (pv_arg pr.pr_fun) mhr pr.pr_args PVM.empty in
+  let sargs = PVM.add env pv_arg mhr pr.pr_args PVM.empty in
   let smem = Fsubst.f_bind_mem Fsubst.f_subst_id mhr pr.pr_mem in
   let concl_pr = Fsubst.f_subst smem (PVM.subst env sargs pre) in
 
@@ -79,7 +79,7 @@ let t_core_phoare_deno pre post tc =
   (* FIXME:
    * let smem_ = Fsubst.f_bind_mem Fsubst.f_subst_id mhr mhr in
    * let ev   = Fsubst.f_subst smem_ ev in *)
-  let me = EcEnv.Fun.actmem_post mhr pr.pr_fun fun_ in
+  let me = EcEnv.Fun.actmem_post mhr fun_ in
   let concl_po = f_forall_mems [me] (concl_post pr.pr_event) in
 
   FApi.xmutate1 tc `HlDeno [concl_e; concl_pr; concl_po]
@@ -99,8 +99,8 @@ let t_phoare_deno_r pre post tc =
 let cond_pre env prl prr pre =
   (* building the substitution for the pre *)
   (* we substitute param by args and left by ml and right by mr *)
-  let sargs = PVM.add env (pv_arg prl.pr_fun) mleft  prl.pr_args PVM.empty in
-  let sargs = PVM.add env (pv_arg prr.pr_fun) mright prr.pr_args sargs in
+  let sargs = PVM.add env pv_arg mleft  prl.pr_args PVM.empty in
+  let sargs = PVM.add env pv_arg mright prr.pr_args sargs in
   let smem  = Fsubst.f_subst_id in
   let smem  = Fsubst.f_bind_mem smem mleft  prl.pr_mem in
   let smem  = Fsubst.f_bind_mem smem mright prr.pr_mem in
@@ -145,8 +145,8 @@ let t_equiv_deno_r pre post tc =
     | `Le -> f_imp evl evr
     | `Ge -> f_imp evr evl in
 
-  let mel = EcEnv.Fun.actmem_post mleft  prl.pr_fun funl in
-  let mer = EcEnv.Fun.actmem_post mright prr.pr_fun funr in
+  let mel = EcEnv.Fun.actmem_post mleft  funl in
+  let mer = EcEnv.Fun.actmem_post mright funr in
   let concl_po = f_forall_mems [mel; mer] (f_imp post cmp) in
 
   FApi.xmutate1 tc `HlDeno [concl_e; concl_pr; concl_po]
@@ -359,10 +359,10 @@ let process_pre tc hyps prl prr pre post =
     let doglob m mi g = push (f_eq (f_glob g m) (f_glob g mi)) in
     let dof f a m mi =
       try
-        let fv = PV.remove env (pv_res f) (PV.fv env m post) in
+        let fv = PV.remove env pv_res (PV.fv env m post) in
         PV.iter (dopv m mi) (doglob m mi) (eqobs_inF_refl env f fv);
         if not (EcReduction.EqTest.for_type env a.f_ty tunit) then
-          push (f_eq (f_pvarg f a.f_ty m) a)
+          push (f_eq (f_pvarg a.f_ty m) a)
       with EcCoreGoal.TcError _ | EqObsInError -> () in
 
     dof fl al mleft ml; dof fr ar mright mr;

--- a/src/phl/ecPhlEqobs.ml
+++ b/src/phl/ecPhlEqobs.ml
@@ -21,18 +21,18 @@ open EcLowPhlGoal
 module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
-let extend_body f fsig body =
-  let arg = pv_arg f in
+let extend_body fsig body =
+  let arg = pv_arg in
   let i =
     match fsig.fs_anames with
     | None | Some [] -> []
 
     | Some [v] ->
-        [i_asgn (LvVar (pv_loc f v.v_name, v.v_type),
+        [i_asgn (LvVar (pv_loc v.v_name, v.v_type),
                  e_var arg fsig.fs_arg)]
 
     | Some lv ->
-        let lv = List.map (fun v -> pv_loc f v.v_name, v.v_type) lv in
+        let lv = List.map (fun v -> pv_loc v.v_name, v.v_type) lv in
         [i_asgn (LvTuple lv, e_var arg fsig.fs_arg)]
 
   in
@@ -282,7 +282,7 @@ and f_eqobs_in fl fr sim eqO =
             let sim, eqi =
               List.fold_left2
                 (fun (sim,eqo) o_l o_r -> f_eqobs_in o_l o_r sim eqo)
-                (sim,eqo) oil.oi_calls oir.oi_calls in
+                (sim,eqo) (OI.allowed oil) (OI.allowed oir) in
             if Mpv2.subset eqi eqo then sim, eqo
             else aux (Mpv2.union eqi eqo) in
           aux eqo in
@@ -295,7 +295,7 @@ and f_eqobs_in fl fr sim eqO =
             PV.check_depend env fvr topr
           with TcError _ -> raise EqObsInError
         end;
-        let eqi = if oil.oi_in then Mpv2.add_glob env top top eqi else eqi in
+        let eqi = if OI.is_in oil then Mpv2.add_glob env top top eqi else eqi in
         sim, eqi
 
       | FBdef funl, FBdef funr ->
@@ -312,8 +312,8 @@ and f_eqobs_in fl fr sim eqO =
           | Some el, Some er -> add_eqs sim Mpv2.empty_local outf el er
           | _, _ -> raise EqObsInError in
 
-        let argl, bodyl = extend_body nfl sigl funl.f_body in
-        let argr, bodyr = extend_body nfr sigr funr.f_body in
+        let argl, bodyl = extend_body sigl funl.f_body in
+        let argr, bodyr = extend_body sigr funr.f_body in
         let sim, eqi    = s_eqobs_in_full bodyl bodyr sim local eqo' in
 
         let eqi = Mpv2.remove sim.sim_env argl argr eqi in
@@ -335,9 +335,9 @@ let mk_inv_spec2 env inv (fl, fr, eqi, eqo) =
   if not testty then raise EqObsInError;
   let eq_params =
     f_eqparams
-      fl sigl.fs_arg sigl.fs_anames mleft
-      fr sigr.fs_arg sigr.fs_anames mright in
-  let eq_res = f_eqres fl sigl.fs_ret mleft fr sigr.fs_ret mright in
+      sigl.fs_arg sigl.fs_anames mleft
+      sigr.fs_arg sigr.fs_anames mright in
+  let eq_res = f_eqres sigl.fs_ret mleft sigr.fs_ret mright in
   let pre = f_and eq_params (Mpv2.to_form mleft mright eqi inv) in
   let post = f_and eq_res (Mpv2.to_form mleft mright eqo inv) in
   f_equivF pre fl fr post
@@ -469,7 +469,7 @@ let process_eqobs_inF info tc =
     | None ->
       try Mpv2.needed_eq env mleft mright ef.ef_po
       with _ -> tc_error !!tc "cannot infer the set of equalities" in
-  let eqo = Mpv2.remove env (pv_res fl) (pv_res fr) eqo in
+  let eqo = Mpv2.remove env pv_res pv_res eqo in
   let sim = init_sim env spec inv in
   let _, eqi =
     try f_eqobs_in fl fr sim eqo

--- a/src/phl/ecPhlExists.ml
+++ b/src/phl/ecPhlExists.ml
@@ -108,6 +108,8 @@ let process_exists_intro ~(elim : bool) fs tc =
     match concl.f_node with
     | FhoareF hf -> fst (LDecl.hoareF hf.hf_f hyps)
     | FhoareS hs -> LDecl.push_active hs.hs_m hyps
+    | FcHoareF hf -> fst (LDecl.hoareF hf.chf_f hyps)
+    | FcHoareS hs -> LDecl.push_active hs.chs_m hyps
     | FbdHoareF bhf -> fst (LDecl.hoareF bhf.bhf_f hyps)
     | FbdHoareS bhs -> LDecl.push_active bhs.bhs_m hyps
     | FequivF ef -> fst (LDecl.equivF ef.ef_fl ef.ef_fr hyps)

--- a/src/phl/ecPhlFun.ml
+++ b/src/phl/ecPhlFun.ml
@@ -12,6 +12,7 @@ open EcParsetree
 open EcPath
 open EcTypes
 open EcFol
+open EcMemory
 open EcModules
 open EcEnv
 open EcPV
@@ -31,8 +32,12 @@ module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
 let check_oracle_use (_pf : proofenv) env adv o =
-  let use = NormMp.fun_use env o in
-  EcTyping.check_restrictions_fun env o use (Sx.empty, Sm.singleton adv)
+  let restr = { mr_empty with
+                mr_mpaths = { mr_empty.mr_mpaths with
+                              ur_neg = Sm.singleton adv; }} in
+
+  (* This only checks the memory restrictions. *)
+  EcTyping.check_mem_restr_fun env o restr
 
 let check_concrete pf env f =
   if NormMp.is_abstract_fun f env then
@@ -44,33 +49,34 @@ let check_concrete pf env f =
 
 (* -------------------------------------------------------------------- *)
 let lossless_hyps env top sub =
-  let sig_ = (fst (EcEnv.Mod.by_mpath top env)).me_sig in
+  let clear_to_top restr =
+    let mr_mpaths = { (ur_empty Sm.empty) with ur_neg = Sm.singleton top } in
+    { restr with mr_xpaths = ur_empty Sx.empty;
+                 mr_mpaths = mr_mpaths } in
+
+  let sig_ = EcEnv.NormMp.sig_of_mp env top in
   let bd =
     List.map
-      (fun (id, mt) -> (id, GTmodty (mt, (Sx.empty, Sm.singleton top))))
-      sig_.mis_params
+      (fun (id, mt) ->
+         (id, GTmodty { mt with mt_restr = clear_to_top mt.mt_restr } )
+      ) sig_.mis_params
   in
   (* WARN: this implies that the oracle do not have access to top *)
   let args  = List.map (fun (id,_) -> EcPath.mident id) sig_.mis_params in
   let concl = f_losslessF (EcPath.xpath (EcPath.m_apply top args) sub) in
   let calls =
-    let name = EcPath.basename sub in
-    let Tys_function (_, oi) =
-      oget (List.ofind
-        (fun (Tys_function(fs,_)) -> fs.fs_name = name)
-        sig_.mis_body)
-    in
-    oi.oi_calls
+    let name = sub in
+    (EcSymbols.Msym.find name sig_.mis_restr.mr_oinfos) |> OI.allowed
   in
   let hyps = List.map f_losslessF calls in
     f_forall bd (f_imps hyps concl)
 
 (* -------------------------------------------------------------------- *)
-let subst_pre env f fs m s =
+let subst_pre env fs (m : memory) s =
   match fs.fs_anames with
   | Some lv ->
-      let v = List.map (fun v -> f_pvloc f v m) lv in
-        PVM.add env (pv_arg f) m (f_tuple v) s
+      let v = List.map (fun v -> f_pvloc v m) lv in
+        PVM.add env pv_arg m (f_tuple v) s
   | None -> s
 
 (* ------------------------------------------------------------------ *)
@@ -82,10 +88,34 @@ let t_hoareF_fun_def_r tc =
   let (memenv, (fsig, fdef), env) = Fun.hoareS f env in
   let m = EcMemory.memory memenv in
   let fres = odfl f_tt (omap (form_of_expr m) fdef.f_ret) in
-  let post = PVM.subst1 env (pv_res f) m fres hf.hf_po in
-  let pre  = PVM.subst env (subst_pre env f fsig m PVM.empty) hf.hf_pr in
+  let post = PVM.subst1 env pv_res m fres hf.hf_po in
+  let pre  = PVM.subst env (subst_pre env fsig m PVM.empty) hf.hf_pr in
   let concl' = f_hoareS memenv pre fdef.f_body post in
   FApi.xmutate1 tc `FunDef [concl']
+
+(* ------------------------------------------------------------------ *)
+let t_choareF_fun_def_r tc =
+  let env = FApi.tc1_env tc in
+  let chf = tc1_as_choareF tc in
+  let f = NormMp.norm_xfun env chf.chf_f in
+  check_concrete !!tc env f;
+  let (memenv, (fsig, fdef), env) = Fun.hoareS f env in
+  let m = EcMemory.memory memenv in
+  let fres = odfl f_tt (omap (form_of_expr m) fdef.f_ret) in
+  let post = PVM.subst1 env pv_res m fres chf.chf_po in
+  let spre = subst_pre env fsig m PVM.empty in
+  let pre = PVM.subst env spre chf.chf_pr in
+  let c   = PVM.subst_cost env spre chf.chf_co in
+  let cond, c = match fdef.f_ret with
+    | None -> None, c
+    | Some ret ->
+      let cond, c =
+        EcCHoare.cost_sub_self
+          c (EcCHoare.cost_of_expr_any memenv ret) in
+      Some cond, c in
+  let concl' = f_cHoareS memenv pre fdef.f_body post c in
+  let goals = ofold (fun f fs -> f :: fs) [concl'] cond in
+  FApi.xmutate1 tc `FunDef goals
 
 (* ------------------------------------------------------------------ *)
 let t_bdhoareF_fun_def_r tc =
@@ -96,8 +126,8 @@ let t_bdhoareF_fun_def_r tc =
   let (memenv, (fsig, fdef), env) = Fun.hoareS f env in
   let m = EcMemory.memory memenv in
   let fres = odfl f_tt (omap (form_of_expr m) fdef.f_ret) in
-  let post = PVM.subst1 env (pv_res f) m fres bhf.bhf_po in
-  let spre = subst_pre env f fsig m PVM.empty in
+  let post = PVM.subst1 env pv_res m fres bhf.bhf_po in
+  let spre = subst_pre env fsig m PVM.empty in
   let pre = PVM.subst env spre bhf.bhf_pr in
   let bd  = PVM.subst env spre bhf.bhf_bd in
   let concl' = f_bdHoareS memenv pre fdef.f_body post bhf.bhf_cmp bd in
@@ -117,29 +147,79 @@ let t_equivF_fun_def_r tc =
   let mr = EcMemory.memory menvr in
   let fresl = odfl f_tt (omap (form_of_expr ml) fdefl.f_ret) in
   let fresr = odfl f_tt (omap (form_of_expr mr) fdefr.f_ret) in
-  let s = PVM.add env (pv_res fl) ml fresl PVM.empty in
-  let s = PVM.add env (pv_res fr) mr fresr s in
+  let s = PVM.add env pv_res ml fresl PVM.empty in
+  let s = PVM.add env pv_res mr fresr s in
   let post = PVM.subst env s ef.ef_po in
-  let s = subst_pre env fl fsigl ml PVM.empty in
-  let s = subst_pre env fr fsigr mr s in
+  let s = subst_pre env fsigl ml PVM.empty in
+  let s = subst_pre env fsigr mr s in
   let pre = PVM.subst env s ef.ef_pr in
   let concl' = f_equivS menvl menvr pre fdefl.f_body fdefr.f_body post in
   FApi.xmutate1 tc `FunDef [concl']
 
 (* -------------------------------------------------------------------- *)
 let t_hoareF_fun_def   = FApi.t_low0 "hoare-fun-def"   t_hoareF_fun_def_r
+let t_choareF_fun_def  = FApi.t_low0 "choare-fun-def"  t_choareF_fun_def_r
 let t_bdhoareF_fun_def = FApi.t_low0 "bdhoare-fun-def" t_bdhoareF_fun_def_r
 let t_equivF_fun_def   = FApi.t_low0 "equiv-fun-def"   t_equivF_fun_def_r
 
 (* -------------------------------------------------------------------- *)
 let t_fun_def_r tc =
   let th  = t_hoareF_fun_def
+  and tch = t_choareF_fun_def
   and tbh = t_bdhoareF_fun_def
   and te  = t_equivF_fun_def in
 
-  t_hF_or_bhF_or_eF ~th ~tbh ~te tc
+  t_hF_or_chF_or_bhF_or_eF ~th ~tch ~tbh ~te tc
 
 let t_fun_def = FApi.t_low0 "fun-def" t_fun_def_r
+
+(* -------------------------------------------------------------------- *)
+type abs_inv_inf = (xpath * ptybinding * cost) list
+
+let process_p_abs_inv_inf tc hyps p_abs_inv_inf =
+  let open EcLocation in
+  let open EcParsetree in
+  let l = ref [] in
+  let check_uniq (_,x,_) =
+    match x with
+    | None -> ()
+    | Some y ->
+      let s = EcLocation.unloc y in
+      if List.mem s !l then
+        tc_error !!tc ~catchable:false ~loc:(loc y)
+          "duplicate name %s" s
+      else l := s :: !l in
+  List.iter check_uniq p_abs_inv_inf;
+
+  let env = LDecl.toenv hyps in
+
+  let doit (f, x, (PC_costs(ci,co))) =
+    let lo =
+      match x with
+      | Some y -> loc y
+      | None   -> loc f in
+    let x =
+      match x with
+      | Some _ -> mk_loc lo x
+      | None   -> mk_loc lo (Some (mk_loc lo "k")) in
+
+    let f = EcTyping.trans_gamepath env f in
+    let bd = [x], mk_loc lo PTunivar in
+    let doc c =
+      let loc = loc c in
+      mk_loc loc (PFlambda([bd], c)) in
+    let ci = doc ci in
+    let doco (m,f,c) = (m,f,doc c) in
+    let co = List.map doco co in
+    let c = TTC.pf_process_cost !!tc hyps [tint] (PC_costs(ci,co)) in
+    f, bd, c in
+
+  List.map doit p_abs_inv_inf
+
+type inv_inf =  [
+  | `Std     of cost
+  | `CostAbs of abs_inv_inf
+]
 
 (* -------------------------------------------------------------------- *)
 module FunAbsLow = struct
@@ -149,8 +229,113 @@ module FunAbsLow = struct
     let fv = PV.fv env mhr inv in
     PV.check_depend env fv top;
     let ospec o = f_hoareF inv o inv in
-    let sg = List.map ospec oi.oi_calls in
+    let sg = List.map ospec (OI.allowed oi) in
     (inv, inv, sg)
+
+  (* ------------------------------------------------------------------ *)
+  let choareF_abs_spec pf_ env f inv (xc : abs_inv_inf) =
+    let (top, _, oi, _) = EcLowPhlGoal.abstract_info env f in
+    let ppe = EcPrinting.PPEnv.ofenv env in
+
+    (* We check that the invariant cannot be modified by the adversary. *)
+    let fv_inv   = PV.fv env mhr inv in
+    PV.check_depend env fv_inv top;
+    (* TODO: (Adrien) why are we checking this for bdhoareF_abs_spec, and is
+       it needed here?*)
+    (* check_oracle_use pf env top o; *)
+
+    let cost_orcl oi o = match OI.cost oi o with
+      | `Bounded cbd -> cbd
+      | `Zero -> f_i0
+      | `Unbounded ->
+        tc_error pf_ "the number of calls to %a is unbounded"
+          (EcPrinting.pp_funname ppe) o in
+
+    (* We create the oracles invariants *)
+    let oi_self, oi_costs = match OI.costs oi with
+      | `Unbounded ->
+        tc_error pf_ "%a is unbounded" (EcPrinting.pp_funname ppe) f
+      | `Bounded (self,costs) -> self, costs in
+    let bds, _ = decompose_lambda inv in
+    assert (List.length bds = List.length xc);
+    let mks =
+      List.fold_left2 (fun mks (k,_) (f, _, _) ->
+          Mx.add f k mks) Mx.empty bds xc in
+
+    (* If [f] can call [o] at most zero times, we remove it. *)
+    let ois = OI.allowed oi
+              |> List.filter (fun o ->
+                  not @@ opt_equal f_equal
+                    (Mx.find_opt o oi_costs)
+                    (Some f_x0)) in
+    let kargs_pr = List.map (fun (x,_) -> f_local x tint) bds in
+    let pr = f_app_simpl inv kargs_pr tbool in
+
+    let ospec o_called =
+      let k_called = Mx.find o_called mks in
+      let kargs_po =
+        List.map (fun (x,_) ->
+            let f = f_local x tint in
+            if EcIdent.id_equal x k_called then f_int_add f f_i1
+            else f) bds in
+      let po = f_app_simpl inv kargs_po tbool in
+      let call_bounds =
+        List.map2 (fun (o,_,_) (x,_) ->
+            let f = f_local x tint in
+            let ge0 = f_int_le f_i0 f in
+            let cbd = cost_orcl oi o in
+            let max =
+              if EcIdent.id_equal x k_called then f_int_lt f cbd
+              else f_int_le f cbd in
+            f_anda ge0 max) xc bds in
+      let call_bounds = f_ands0_simpl call_bounds in
+      (* We now compute the cost of the call to [o_called]. *)
+      let cost = List.find_opt (fun (x,_,_) -> x_equal x o_called) xc in
+      let cost = match cost with
+        | None ->
+          tc_error pf_ "no cost has been supplied for %a"
+            (EcPrinting.pp_funname ppe) o_called
+        | Some (_,_,cost) -> cost in
+      let k_cost = EcCHoare.cost_app cost [f_local k_called tint] in
+      let form = f_cHoareF pr o_called po k_cost in
+      f_forall_simpl bds (f_imp_simpl call_bounds form) in
+    (* We have the conditions for the oracles. *)
+    let sg = List.map ospec ois in
+
+    (* Finally, we compute the conclusion. *)
+    (* choare [{ inv 0 } f {exists ks, 0 <= ks <= cbd /\ inv ks }]
+              time sum_cost] *)
+    let pre_inv =
+      let ks0 = List.map (fun _ -> f_i0) bds in
+      f_app_simpl inv ks0 tbool in
+    let post_inv =
+      let call_bounds =
+        List.map2 (fun (o,_,_) (x,_) ->
+            let f = f_local x tint in
+            let ge0 = f_int_le f_i0 f in
+            let cbd = cost_orcl oi o in
+            let max = f_int_le f cbd in
+            f_anda ge0 max) xc bds in
+      let call_bounds = f_ands0_simpl call_bounds in
+      f_exists bds (f_and call_bounds pr) in
+    let fn_orcl = EcPath.xpath top f.x_sub in
+    let f_cb = call_bound_r oi_self f_i1 in
+    let f_cost = cost_r f_x0 (Mx.singleton fn_orcl f_cb)  in
+    let orcls_cost = List.map (fun o ->
+        let cbd = cost_orcl oi o in
+        (* Cost of a call to [o]. *)
+        let (_,_,o_cost) = List.find (fun (x,_, _) -> x_equal x o) xc in
+
+        (* Upper-bound on the costs of [o]'s calls. *)
+        EcCHoare.choare_sum o_cost (f_i0, cbd)
+      ) ois in
+    let total_cost =
+      List.fold_left
+        (EcCHoare.cost_add env)
+        f_cost orcls_cost in
+
+    (pre_inv, post_inv, total_cost, sg)
+
 
   (* ------------------------------------------------------------------ *)
   let bdhoareF_abs_spec pf env f inv =
@@ -162,12 +347,12 @@ module FunAbsLow = struct
       check_oracle_use pf env top o;
       f_bdHoareF inv o inv FHeq f_r1 in
 
-    let sg = List.map ospec oi.oi_calls in
+    let sg = List.map ospec (OI.allowed oi) in
     (inv, inv, lossless_hyps env top f.x_sub :: sg)
 
   (* ------------------------------------------------------------------ *)
   let equivF_abs_spec pf env fl fr inv =
-    let (topl, fl, oil, sigl), (topr, fr, oir, sigr) =
+    let (topl, _fl, oil, sigl), (topr, _fr, oir, sigr) =
       EcLowPhlGoal.abstract_info2 env fl fr
     in
 
@@ -185,7 +370,7 @@ module FunAbsLow = struct
           if   EcPath.x_equal o_l o_r
           then check_oracle_use pf env topl o_r;
           false
-        with _ when oil.oi_in -> true
+        with _ when OI.is_in oil -> true
       in
 
       let fo_l = EcEnv.Fun.by_xpath o_l env in
@@ -193,11 +378,11 @@ module FunAbsLow = struct
 
       let eq_params =
         f_eqparams
-          o_l fo_l.f_sig.fs_arg fo_l.f_sig.fs_anames ml
-          o_r fo_r.f_sig.fs_arg fo_r.f_sig.fs_anames mr in
+          fo_l.f_sig.fs_arg fo_l.f_sig.fs_anames ml
+          fo_r.f_sig.fs_arg fo_r.f_sig.fs_anames mr in
 
       let eq_res =
-        f_eqres o_l fo_l.f_sig.fs_ret ml o_r fo_r.f_sig.fs_ret mr in
+        f_eqres fo_l.f_sig.fs_ret ml fo_r.f_sig.fs_ret mr in
 
       let invs = if use then [eqglob; inv] else [inv] in
       let pre  = EcFol.f_ands (eq_params :: invs) in
@@ -205,15 +390,15 @@ module FunAbsLow = struct
       f_equivF pre o_l o_r post
     in
 
-    let sg = List.map2 ospec oil.oi_calls oir.oi_calls in
+    let sg = List.map2 ospec (OI.allowed oil) (OI.allowed oir) in
 
     let eq_params =
       f_eqparams
-        fl sigl.fs_arg sigl.fs_anames ml
-        fr sigr.fs_arg sigr.fs_anames mr in
+        sigl.fs_arg sigl.fs_anames ml
+        sigr.fs_arg sigr.fs_anames mr in
 
-    let eq_res = f_eqres fl sigl.fs_ret ml fr sigr.fs_ret mr in
-    let lpre   = if oil.oi_in then [eqglob;inv] else [inv] in
+    let eq_res = f_eqres sigl.fs_ret ml sigr.fs_ret mr in
+    let lpre   = if OI.is_in oil then [eqglob;inv] else [inv] in
     let pre    = f_ands (eq_params::lpre) in
     let post   = f_ands [eq_res; eqglob; inv] in
 
@@ -228,6 +413,17 @@ let t_hoareF_abs_r inv tc =
 
   let tactic tc = FApi.xmutate1 tc `FunAbs sg in
   FApi.t_last tactic (EcPhlConseq.t_hoareF_conseq pre post tc)
+
+(* ------------------------------------------------------------------ *)
+let t_choareF_abs_r inv inv_inf tc =
+  let env = FApi.tc1_env tc in
+  let hf = tc1_as_choareF tc in
+  let pre, post, cost, sg =
+    FunAbsLow.choareF_abs_spec !!tc env hf.chf_f inv inv_inf in
+
+  let tactic tc = FApi.xmutate1 tc `FunAbs sg in
+  FApi.t_last tactic (EcPhlConseq.t_cHoareF_conseq_full pre post cost tc)
+
 
 (* ------------------------------------------------------------------ *)
 let t_bdhoareF_abs_r inv tc =
@@ -257,6 +453,7 @@ let t_equivF_abs_r inv tc =
 
 (* -------------------------------------------------------------------- *)
 let t_hoareF_abs   = FApi.t_low1 "hoare-fun-abs"   t_hoareF_abs_r
+let t_choareF_abs  = FApi.t_low2 "choare-fun-abs"  t_choareF_abs_r
 let t_bdhoareF_abs = FApi.t_low1 "bdhoare-fun-abs" t_bdhoareF_abs_r
 let t_equivF_abs   = FApi.t_low1 "equiv-fun-abs"   t_equivF_abs_r
 
@@ -264,7 +461,7 @@ let t_equivF_abs   = FApi.t_low1 "equiv-fun-abs"   t_equivF_abs_r
 module UpToLow = struct
   (* ------------------------------------------------------------------ *)
   let equivF_abs_upto pf env fl fr bad invP invQ =
-    let (topl, fl, oil, sigl), (topr, fr, oir, sigr) =
+    let (topl, _fl, oil, sigl), (topr, _fr, oir, sigr) =
       EcLowPhlGoal.abstract_info2 env fl fr
     in
 
@@ -289,41 +486,41 @@ module UpToLow = struct
       let fo_r = EcEnv.Fun.by_xpath o_r env in
       let eq_params =
         f_eqparams
-          o_l fo_l.f_sig.fs_arg fo_l.f_sig.fs_anames
-          ml o_r fo_r.f_sig.fs_arg fo_r.f_sig.fs_anames mr in
+          fo_l.f_sig.fs_arg fo_l.f_sig.fs_anames ml
+          fo_r.f_sig.fs_arg fo_r.f_sig.fs_anames mr in
 
       let eq_res =
-        f_eqres o_l fo_l.f_sig.fs_ret ml o_r fo_r.f_sig.fs_ret mr in
+        f_eqres fo_l.f_sig.fs_ret ml fo_r.f_sig.fs_ret mr in
 
       let pre   = EcFol.f_ands [EcFol.f_not bad2; eq_params; invP] in
       let post  = EcFol.f_if_simpl bad2 invQ (f_and eq_res invP) in
       let cond1 = f_equivF pre o_l o_r post in
       let cond2 =
         let q = Fsubst.f_subst_mem ml EcFol.mhr invQ in
-          f_forall[(mr, GTmem None)]
+          f_forall[(mr, GTmem abstract_mt)]
             (f_imp bad2 (f_bdHoareF q o_l q FHeq f_r1)) in
       let cond3 =
         let q  = Fsubst.f_subst_mem mr EcFol.mhr invQ in
         let bq = f_and bad q in
-          f_forall [(ml, GTmem None)]
+          f_forall [(ml, GTmem abstract_mt)]
             (f_bdHoareF bq o_r bq FHeq f_r1) in
 
       [cond1; cond2; cond3]
     in
 
-    let sg = List.map2 ospec oil.oi_calls oir.oi_calls in
+    let sg = List.map2 ospec (OI.allowed oil) (OI.allowed oir) in
     let sg = List.flatten sg in
     let lossless_a = lossless_hyps env topl fl.x_sub in
     let sg = lossless_a :: sg in
 
     let eq_params =
       f_eqparams
-        fl sigl.fs_arg sigl.fs_anames ml
-        fr sigr.fs_arg sigr.fs_anames mr in
+        sigl.fs_arg sigl.fs_anames ml
+        sigr.fs_arg sigr.fs_anames mr in
 
-    let eq_res = f_eqres fl sigl.fs_ret ml fr sigr.fs_ret mr in
+    let eq_res = f_eqres sigl.fs_ret ml sigr.fs_ret mr in
 
-    let pre  = if oil.oi_in then [eqglob;invP] else [invP] in
+    let pre  = if OI.is_in oil then [eqglob;invP] else [invP] in
     let pre  = f_if_simpl bad2 invQ (f_ands (eq_params::pre)) in
     let post = f_if_simpl bad2 invQ (f_ands [eq_res;eqglob;invP]) in
 
@@ -348,32 +545,60 @@ module ToCodeLow = struct
   (* ------------------------------------------------------------------ *)
   let to_code env f m =
     let fd = Fun.by_xpath f env in
-
+    let me = EcMemory.empty_local ~witharg:false m in
+    let arg_name =
+      match fd.f_sig.fs_anames with
+      | Some [v] -> v.v_name
+      | _        -> arg_symbol in
+    let arg = {v_name = arg_name; v_type = fd.f_sig.fs_arg } in
+    let res = {v_name = "r"; v_type = fd.f_sig.fs_ret } in
+    let me = EcMemory.bindall [arg;res] me in
     let args =
-      let arg = e_var (pv_arg f) fd.f_sig.fs_arg  in
+      let arg = e_var (pv_loc arg.v_name) arg.v_type in
       match fd.f_sig.fs_anames with
       | None -> [arg]
       | Some [_] -> [arg]
       | Some params -> List.mapi (fun i v -> e_proj arg i v.v_type) params
     in
-
-    let m, res = fresh_pv m {v_name = "r"; v_type = fd.f_sig.fs_ret} in
-    let r = pv_loc f res in
-    let i = i_call (Some(LvVar(r,fd.f_sig.fs_ret)), f, args) in
+    let r = pv_loc res.v_name in
+    let i = i_call (Some(LvVar(r, res.v_type)), f, args) in
     let s = stmt [i] in
-    (m, s, r, fd.f_sig.fs_ret)
+    (me, s, arg, res, args)
+  (* (me, s, r, fd.f_sig.fs_ret, args) *)
+
+  let add_var env vfrom mfrom v me s =
+    PVM.add env vfrom mfrom (f_pvar (pv_loc v.v_name) v.v_type (fst me)) s
+
 end
 
 (* -------------------------------------------------------------------- *)
+
 let t_fun_to_code_hoare_r tc =
   let env = FApi.tc1_env tc in
   let hf = tc1_as_hoareF tc in
   let f = hf.hf_f in
-  let m, _ = Fun.hoareF_memenv f env in
-  let m, st, r, ty = ToCodeLow.to_code env f m in
-  let s = PVM.add env (pv_res f) (fst m) (f_pvar r ty (fst m)) PVM.empty in
-  let post = PVM.subst env s hf.hf_po in
-  let concl = f_hoareS m hf.hf_pr st post in
+  let m, st, a, r, _ = ToCodeLow.to_code env f mhr in
+  let spr = ToCodeLow.add_var env pv_arg mhr a m PVM.empty in
+  let spo = ToCodeLow.add_var env pv_res mhr r m PVM.empty in
+  let pre  = PVM.subst env spr hf.hf_pr in
+  let post = PVM.subst env spo hf.hf_po in
+  let concl = f_hoareS m pre st post in
+
+  FApi.xmutate1 tc `FunToCode [concl]
+
+(* -------------------------------------------------------------------- *)
+(* This is for the proc* tactic, which replaces a statement about `G.f` by
+   a statement about `x <$ G.f(args)`. *)
+let t_fun_to_code_choare_r tc =
+  let env = FApi.tc1_env tc in
+  let chf = tc1_as_choareF tc in
+  let f = chf.chf_f in
+  let m, st, a, r, _ = ToCodeLow.to_code env f mhr in
+  let spr = ToCodeLow.add_var env pv_arg mhr a m PVM.empty in
+  let spo = ToCodeLow.add_var env pv_res mhr r m PVM.empty in
+  let pre  = PVM.subst env spr chf.chf_pr in
+  let post = PVM.subst env spo chf.chf_po in
+  let concl = f_cHoareS m pre st post chf.chf_co in
 
   FApi.xmutate1 tc `FunToCode [concl]
 
@@ -382,12 +607,13 @@ let t_fun_to_code_bdhoare_r tc =
   let env = FApi.tc1_env tc in
   let hf = tc1_as_bdhoareF tc in
   let f = hf.bhf_f in
-  let m, _ = Fun.hoareF_memenv f env in
-  let m, st, r, ty = ToCodeLow.to_code env f m in
-  let s = PVM.add env (pv_res f) (fst m) (f_pvar r ty (fst m)) PVM.empty in
-  let post = PVM.subst env s hf.bhf_po in
-  let concl = f_bdHoareS m hf.bhf_pr st post hf.bhf_cmp hf.bhf_bd in
-
+  let m, st, a, r, _ = ToCodeLow.to_code env f mhr in
+  let spr = ToCodeLow.add_var env pv_arg mhr a m PVM.empty in
+  let spo = ToCodeLow.add_var env pv_res mhr r m PVM.empty in
+  let pre  = PVM.subst env spr hf.bhf_pr in
+  let post = PVM.subst env spo hf.bhf_po in
+  let bd   = PVM.subst env spr hf.bhf_bd in
+  let concl = f_bdHoareS m pre st post hf.bhf_cmp bd in
   FApi.xmutate1 tc `FunToCode [concl]
 
 (* -------------------------------------------------------------------- *)
@@ -395,14 +621,17 @@ let t_fun_to_code_equiv_r tc =
   let env = FApi.tc1_env tc in
   let ef = tc1_as_equivF tc in
   let (fl,fr) = ef.ef_fl, ef.ef_fr in
-  let (ml,mr), _ = Fun.equivF_memenv fl fr env in
-  let ml, sl, rl, tyl = ToCodeLow.to_code env fl ml in
-  let mr, sr, rr, tyr = ToCodeLow.to_code env fr mr in
-  let s = PVM.empty in
-  let s = PVM.add env (pv_res fl) (fst ml) (f_pvar rl tyl (fst ml)) s in
-  let s = PVM.add env (pv_res fr) (fst mr) (f_pvar rr tyr (fst mr)) s in
-  let post  = PVM.subst env s ef.ef_po in
-  let concl = f_equivS ml mr ef.ef_pr sl sr post in
+  let ml, sl, al, rl, _ = ToCodeLow.to_code env fl mleft in
+  let mr, sr, ar, rr, _ = ToCodeLow.to_code env fr mright in
+  let spr =
+    let s = ToCodeLow.add_var env pv_arg mleft al ml PVM.empty in
+    ToCodeLow.add_var env pv_arg mright ar mr s in
+  let spo =
+    let s = ToCodeLow.add_var env pv_res mleft rl ml PVM.empty in
+    ToCodeLow.add_var env pv_res mright rr mr s in
+  let pre   = PVM.subst env spr ef.ef_pr in
+  let post  = PVM.subst env spo ef.ef_po in
+  let concl = f_equivS ml mr pre sl sr post in
 
   FApi.xmutate1 tc `FunToCode [concl]
 
@@ -410,19 +639,23 @@ let t_fun_to_code_eager_r tc =
   let env = FApi.tc1_env tc in
   let eg = tc1_as_eagerF tc in
   let (fl,fr) = eg.eg_fl, eg.eg_fr in
-  let (ml,mr), _ = Fun.equivF_memenv fl fr env in
-  let ml, sl, rl, tyl = ToCodeLow.to_code env fl ml in
-  let mr, sr, rr, tyr = ToCodeLow.to_code env fr mr in
-  let s = PVM.empty in
-  let s = PVM.add env (pv_res fl) (fst ml) (f_pvar rl tyl (fst ml)) s in
-  let s = PVM.add env (pv_res fr) (fst mr) (f_pvar rr tyr (fst mr)) s in
-  let post  = PVM.subst env s eg.eg_po in
+  let ml, sl, al, rl, _ = ToCodeLow.to_code env fl mleft in
+  let mr, sr, ar, rr, _ = ToCodeLow.to_code env fr mright in
+  let spr =
+    let s = ToCodeLow.add_var env pv_arg mleft al ml PVM.empty in
+    ToCodeLow.add_var env pv_arg mright ar mr s in
+  let spo =
+    let s = ToCodeLow.add_var env pv_res mleft rl ml PVM.empty in
+    ToCodeLow.add_var env pv_res mright rr mr s in
+  let pre   = PVM.subst env spr eg.eg_pr in
+  let post  = PVM.subst env spo eg.eg_po in
   let concl =
-    f_equivS ml mr eg.eg_pr (s_seq eg.eg_sl sl) (s_seq sr eg.eg_sr) post in
+    f_equivS ml mr pre (s_seq eg.eg_sl sl) (s_seq sr eg.eg_sr) post in
   FApi.xmutate1 tc `FunToCode [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_fun_to_code_hoare   = FApi.t_low0 "hoare-fun-to-code"   t_fun_to_code_hoare_r
+let t_fun_to_code_choare  = FApi.t_low0 "choare-fun-to-code"  t_fun_to_code_choare_r
 let t_fun_to_code_bdhoare = FApi.t_low0 "bdhoare-fun-to-code" t_fun_to_code_bdhoare_r
 let t_fun_to_code_equiv   = FApi.t_low0 "equiv-fun-to-code"   t_fun_to_code_equiv_r
 let t_fun_to_code_eager   = FApi.t_low0 "eager-fun-to-code"   t_fun_to_code_eager_r
@@ -431,44 +664,72 @@ let t_fun_to_code_eager   = FApi.t_low0 "eager-fun-to-code"   t_fun_to_code_eage
 (* -------------------------------------------------------------------- *)
 let t_fun_to_code_r tc =
   let th  = t_fun_to_code_hoare in
+  let tch = t_fun_to_code_choare in
   let tbh = t_fun_to_code_bdhoare in
   let te  = t_fun_to_code_equiv in
   let teg = t_fun_to_code_eager in
-  t_hF_or_bhF_or_eF ~th ~tbh ~te ~teg tc
+  t_hF_or_chF_or_bhF_or_eF ~th ~tch ~tbh ~te ~teg tc
 
 let t_fun_to_code = FApi.t_low0 "fun-to-code" t_fun_to_code_r
 
 (* -------------------------------------------------------------------- *)
-let t_fun_r inv tc =
+let proj_std a = match a with
+  | `Std b -> b
+  | _ -> assert false
+
+let proj_costabs a = match a with
+  | None -> ([])
+  | Some (`CostAbs b) -> b
+  | _ -> assert false
+
+let t_fun_r inv inv_inf tc =
   let th tc =
+    assert (inv_inf = None);
     let env = FApi.tc1_env tc in
     let h   = destr_hoareF (FApi.tc1_goal tc) in
       if   NormMp.is_abstract_fun h.hf_f env
       then t_hoareF_abs inv tc
       else t_hoareF_fun_def tc
+
+  and tch tc =
+    let env = FApi.tc1_env tc in
+    let h   = destr_cHoareF (FApi.tc1_goal tc) in
+    if   NormMp.is_abstract_fun h.chf_f env
+    then t_choareF_abs inv (proj_costabs inv_inf) tc
+    else begin
+      t_choareF_fun_def tc end
+
   and tbh tc =
+    assert (inv_inf = None);
     let env = FApi.tc1_env tc in
     let h   = destr_bdHoareF (FApi.tc1_goal tc) in
       if   NormMp.is_abstract_fun h.bhf_f env
       then t_bdhoareF_abs inv tc
       else t_bdhoareF_fun_def tc
+
   and te tc =
+    assert (inv_inf = None);
     let env = FApi.tc1_env tc in
     let e   = destr_equivF (FApi.tc1_goal tc) in
       if   NormMp.is_abstract_fun e.ef_fl env
       then t_equivF_abs inv tc
       else t_equivF_fun_def tc
-  in
-    t_hF_or_bhF_or_eF ~th ~tbh ~te tc
 
-let t_fun = FApi.t_low1 "fun" t_fun_r
+  in
+    t_hF_or_chF_or_bhF_or_eF ~th ~tch ~tbh ~te tc
+
+let t_fun = FApi.t_low2 "fun" t_fun_r
 
 (* -------------------------------------------------------------------- *)
 type p_upto_info = pformula * pformula * (pformula option)
 
 (* -------------------------------------------------------------------- *)
 let process_fun_def tc =
-  t_fun_def tc
+  let t_cont tcenv =
+    if FApi.tc_count tcenv = 2 then
+      FApi.t_sub [EcLowGoal.t_trivial; EcLowGoal.t_id] tcenv
+    else tcenv in
+  t_cont (t_fun_def tc)
 
 (* -------------------------------------------------------------------- *)
 let process_fun_to_code tc =
@@ -481,7 +742,7 @@ let process_fun_upto_info (bad, p, q) tc =
   let p    = TTC.pf_process_form !!tc env' tbool p in
   let q    = q |> omap (TTC.pf_process_form !!tc env' tbool) |> odfl f_true in
   let bad  =
-    let env' = LDecl.push_active (EcFol.mhr, None) hyps in
+    let env' = LDecl.push_active (EcMemory.abstract EcFol.mhr) hyps in
     TTC.pf_process_form !!tc env' tbool bad
   in
     (bad, p, q)
@@ -492,24 +753,53 @@ let process_fun_upto info g =
     t_equivF_abs_upto bad p q g
 
 (* -------------------------------------------------------------------- *)
-let process_fun_abs inv tc =
+let ensure_none tc = function
+  | None -> ()
+  | Some _ ->
+    tc_error !!tc "this is not a choare judgement"
+
+let process_inv_pabs_inv_finfo tc inv p_abs_inv_inf =
+  let hyps = FApi.tc1_hyps tc in
+  let env' = LDecl.inv_memenv1 hyps in
+  let abs_inv_info = process_p_abs_inv_inf tc env' p_abs_inv_inf in
+  let bds = List.map (fun (_,bd,_) -> bd) abs_inv_info in
+  let inv =
+    EcLocation.mk_loc (EcLocation.loc inv) (EcParsetree.PFlambda(bds, inv)) in
+  let tints = List.map (fun _ -> tint) bds in
+  let tinv  = toarrow tints tbool in
+  let inv  = TTC.pf_process_form !!tc env' tinv inv in
+  inv, abs_inv_info
+
+let process_fun_abs inv p_abs_inv_inf tc =
   let t_hoare tc =
+    ensure_none tc p_abs_inv_inf;
     let hyps = FApi.tc1_hyps tc in
     let env' = LDecl.inv_memenv1 hyps in
     let inv  = TTC.pf_process_form !!tc env' tbool inv in
     t_hoareF_abs inv tc
 
+  and t_choare tc =
+    if p_abs_inv_inf = None then
+      tc_error !!tc "for calls to abstract procedures in choare judgements, \
+                     additional information must be provided";
+    let inv, abs_inv_info =
+      process_inv_pabs_inv_finfo tc inv (oget p_abs_inv_inf) in
+    t_choareF_abs inv abs_inv_info tc
+
   and t_bdhoare tc =
+    ensure_none tc p_abs_inv_inf;
     let hyps = FApi.tc1_hyps tc in
     let env' = LDecl.inv_memenv1 hyps in
     let inv  = TTC.pf_process_form !!tc env' tbool inv in
     t_bdhoareF_abs inv tc
 
   and t_equiv tc =
+    ensure_none tc p_abs_inv_inf;
     let hyps = FApi.tc1_hyps tc in
     let env' = LDecl.inv_memenv hyps in
     let inv  = TTC.pf_process_form !!tc env' tbool inv in
     t_equivF_abs inv tc
 
   in
-    t_hF_or_bhF_or_eF ~th:t_hoare ~tbh:t_bdhoare ~te:t_equiv tc
+  t_hF_or_chF_or_bhF_or_eF
+    ~th:t_hoare ~tch:t_choare ~tbh:t_bdhoare ~te:t_equiv tc

--- a/src/phl/ecPhlFun.mli
+++ b/src/phl/ecPhlFun.mli
@@ -20,15 +20,34 @@ open EcCoreGoal
 val check_concrete : proofenv -> EcEnv.env -> EcPath.xpath -> unit
 
 val subst_pre :
-     EcEnv.env -> xpath -> funsig -> memory
+     EcEnv.env -> funsig -> memory
   -> EcPV.PVM.subst
   -> EcPV.PVM.subst
 
 (* -------------------------------------------------------------------- *)
 type p_upto_info = pformula * pformula * (pformula option)
 
+type abs_inv_inf = (EcPath.xpath * EcParsetree.ptybinding * EcFol.cost) list
+
+val process_p_abs_inv_inf :
+  EcCoreGoal.tcenv1 ->
+  EcEnv.LDecl.hyps ->
+  p_abs_inv_inf ->
+  abs_inv_inf
+
+val process_inv_pabs_inv_finfo:
+  EcCoreGoal.tcenv1 ->
+  pformula ->
+  p_abs_inv_inf ->
+  form * abs_inv_inf
+
+type inv_inf =  [
+  | `Std     of cost
+  | `CostAbs of abs_inv_inf
+]
+
 val process_fun_def       : FApi.backward
-val process_fun_abs       : pformula -> FApi.backward
+val process_fun_abs       : pformula -> p_abs_inv_inf option -> FApi.backward
 val process_fun_upto_info : p_upto_info -> tcenv1 -> form tuple3
 val process_fun_upto      : p_upto_info -> FApi.backward
 val process_fun_to_code   : FApi.backward
@@ -38,6 +57,10 @@ module FunAbsLow : sig
   val hoareF_abs_spec :
        proofenv -> EcEnv.env -> xpath -> form
     -> form * form * form list
+
+  val choareF_abs_spec :
+       proofenv -> EcEnv.env -> xpath -> form -> abs_inv_inf
+    -> form * form * cost * form list
 
   val bdhoareF_abs_spec :
        proofenv -> EcEnv.env -> xpath -> form
@@ -50,11 +73,13 @@ end
 
 (* -------------------------------------------------------------------- *)
 val t_hoareF_abs   : form -> FApi.backward
+val t_choareF_abs  : form -> abs_inv_inf -> FApi.backward
 val t_bdhoareF_abs : form -> FApi.backward
 val t_equivF_abs   : form -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
 val t_hoareF_fun_def   : FApi.backward
+val t_choareF_fun_def  : FApi.backward
 val t_bdhoareF_fun_def : FApi.backward
 val t_equivF_fun_def   : FApi.backward
 
@@ -62,4 +87,4 @@ val t_equivF_fun_def   : FApi.backward
 val t_equivF_abs_upto : form -> form -> form -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_fun : form -> FApi.backward
+val t_fun : form -> inv_inf option -> FApi.backward

--- a/src/phl/ecPhlHiCond.ml
+++ b/src/phl/ecPhlHiCond.ml
@@ -21,17 +21,27 @@ let process_cond info tc =
     ofdfl (fun _ -> Zpr.cpos (tc1_pos_last_if tc s)) i in
 
   match info with
-  | `Head side ->
-    t_hS_or_bhS_or_eS
-      ~th:t_hoare_cond ~tbh:t_bdhoare_cond ~te:(t_equiv_cond side) tc
+  | `Head (side) ->
+    t_hS_or_chS_or_bhS_or_eS
+      ~th:t_hoare_cond
+      ~tch:(t_choare_cond None)
+      ~tbh:t_bdhoare_cond
+      ~te:(t_equiv_cond side) tc
 
   | `Seq (side, (i1, i2), f) ->
-    let es = tc1_as_equivS tc in
-    let f  = EcProofTyping.tc1_process_prhl_formula tc f in
-    let n1 = default_if i1 es.es_sl in
-    let n2 = default_if i2 es.es_sr in
-    FApi.t_seqsub (EcPhlApp.t_equiv_app (n1, n2) f)
-      [ t_id; t_equiv_cond side ] tc
+    if is_cHoareS (FApi.tc1_goal tc) then
+      if side <> None || i1 <> None || i2 <> None then
+        tc_error !!tc "cannot supply side or code position when goal is a choare"
+      else
+        let f = EcProofTyping.tc1_process_Xhl_formula tc f in
+        t_choare_cond (Some f) tc
+    else
+      let es = tc1_as_equivS tc in
+      let f  = EcProofTyping.tc1_process_prhl_formula tc f in
+      let n1 = default_if i1 es.es_sl in
+      let n2 = default_if i2 es.es_sr in
+      FApi.t_seqsub (EcPhlApp.t_equiv_app (n1, n2) f)
+        [ t_id; t_equiv_cond side ] tc
 
   | `SeqOne (s, i, f1, f2) ->
     let es = tc1_as_equivS tc in
@@ -44,4 +54,4 @@ let process_cond info tc =
 
 (* -------------------------------------------------------------------- *)
 let process_match infos tc =
-  t_hS_or_bhS_or_eS ~te:(t_equiv_match infos) tc
+  t_hS_or_chS_or_bhS_or_eS ~te:(t_equiv_match infos) tc

--- a/src/phl/ecPhlLoopTx.ml
+++ b/src/phl/ecPhlLoopTx.ml
@@ -96,7 +96,9 @@ let fission_stmt (il, (d1, d2)) (pf, hyps) me zpr =
 let t_fission_r side cpos infos g =
   let tr = fun side -> `LoopFission (side, cpos, infos) in
   let cb = fun cenv _ me zpr -> fission_stmt infos cenv me zpr in
-    t_code_transform side ~bdhoare:true cpos tr (t_zip cb) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_zip cb) g
 
 let t_fission = FApi.t_low3 "loop-fission" t_fission_r
 
@@ -150,7 +152,9 @@ let fusion_stmt (il, (d1, d2)) (pf, hyps) me zpr =
 let t_fusion_r side cpos infos g =
   let tr = fun side -> `LoopFusion (side, cpos, infos) in
   let cb = fun cenv _ me zpr -> fusion_stmt infos cenv me zpr in
-    t_code_transform side ~bdhoare:true cpos tr (t_zip cb) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_zip cb) g
 
 let t_fusion = FApi.t_low3 "loop-fusion" t_fusion_r
 
@@ -162,7 +166,9 @@ let unroll_stmt (pf, _) me i =
 
 let t_unroll_r side cpos g =
   let tr = fun side -> `LoopUnraoll (side, cpos) in
-  t_code_transform side  ~bdhoare:true cpos tr (t_fold unroll_stmt) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_fold unroll_stmt) g
 
 let t_unroll = FApi.t_low2 "loop-unroll" t_unroll_r
 
@@ -179,7 +185,9 @@ let splitwhile_stmt b (pf, _) me i =
 
 let t_splitwhile_r b side cpos g =
   let tr = fun side -> `SplitWhile (b, side, cpos) in
-  t_code_transform side ~bdhoare:true cpos tr (t_fold (splitwhile_stmt b)) g
+  t_code_transform side
+    ~bdhoare:true ~choare:None
+    cpos tr (t_fold (splitwhile_stmt b)) g
 
 let t_splitwhile = FApi.t_low3 "split-while" t_splitwhile_r
 
@@ -272,7 +280,7 @@ let process_unroll_for side cpos tc =
     match zs with
     | [] -> t_id tc
     | z :: zs ->
-      ((t_rcond side (zs <> []) (Zpr.cpos pos)) @+
+      ((t_rcond side (zs <> []) (Zpr.cpos pos) None) @+
       [FApi.t_try (t_intro_i m) @!
        t_conseq (f_eq x (f_int z)) @!
        t_set i pos z;

--- a/src/phl/ecPhlPr.ml
+++ b/src/phl/ecPhlPr.ml
@@ -11,7 +11,7 @@ open EcUtils
 open EcModules
 open EcFol
 open EcEnv
-
+open EcTypes
 open EcCoreGoal
 open EcLowPhlGoal
 
@@ -32,7 +32,7 @@ let t_bdhoare_ppr_r tc =
   let fun_ = EcEnv.Fun.by_xpath f_xpath env in
   let penv,_qenv = EcEnv.Fun.hoareF_memenv f_xpath env in
   let m = EcIdent.create "&m" in
-  let args = to_args fun_ (f_pvarg f_xpath fun_.f_sig.fs_arg m) in
+  let args = to_args fun_ (f_pvarg fun_.f_sig.fs_arg m) in
   (* Warning: currently no substitution on pre,post since penv is always mhr *)
   let pre,post = bhf.bhf_pr, bhf.bhf_po in
   let fop = match bhf.bhf_cmp with
@@ -59,8 +59,8 @@ let t_equiv_ppr_r ty phi_l phi_r tc =
   let funl = EcEnv.Fun.by_xpath fl env in
   let funr = EcEnv.Fun.by_xpath fr env in
   let (penvl,penvr), (qenvl,qenvr) = EcEnv.Fun.equivF_memenv fl fr env in
-  let argsl = to_args funl (f_pvarg fl funl.f_sig.fs_arg (fst penvl)) in
-  let argsr = to_args funr (f_pvarg fr funr.f_sig.fs_arg (fst penvr)) in
+  let argsl = to_args funl (f_pvarg funl.f_sig.fs_arg (fst penvl)) in
+  let argsr = to_args funr (f_pvarg funr.f_sig.fs_arg (fst penvr)) in
   let a_id = EcIdent.create "a" in
   let a_f = f_local a_id ty in
   let smem1 = Fsubst.f_bind_mem Fsubst.f_subst_id mleft mhr in
@@ -88,7 +88,8 @@ let t_equiv_ppr   = FApi.t_low3 "equiv-ppr"   t_equiv_ppr_r
 let process_ppr info tc =
   match info with
   | None ->
-      t_hF_or_bhF_or_eF ~th:t_hoare_ppr ~tbh:t_bdhoare_ppr tc
+    (* Remark: the tactic bypr cannot be used for cost goals. *)
+    t_hF_or_chF_or_bhF_or_eF ~th:t_hoare_ppr ~tbh:t_bdhoare_ppr tc
 
   | Some (phi1, phi2) ->
       let hyps = FApi.tc1_hyps tc in
@@ -157,7 +158,7 @@ let t_prfalse tc =
   let smem  = Fsubst.f_bind_mem Fsubst.f_subst_id mhr mhr in
   let ev    = Fsubst.f_subst smem ev in
   let fun_  = EcEnv.Fun.by_xpath f env in
-  let me    = EcEnv.Fun.actmem_post mhr f fun_ in
+  let me    = EcEnv.Fun.actmem_post mhr fun_ in
   let concl_po = f_forall_mems [me] (f_imp f_false ev) in
 
   FApi.xmutate1 tc `PrFalse [is_zero; concl_po]

--- a/src/phl/ecPhlRCond.ml
+++ b/src/phl/ecPhlRCond.ml
@@ -32,25 +32,42 @@ module Low = struct
             Format.fprintf fmt
               "the targetted instruction is not a conditionnal")
     in
-    let e = form_of_expr m e in
-    let e = if b then e else f_not e in
+    let f_e = form_of_expr m e in
+    let f_e = if b then f_e else f_not f_e in
 
-    (stmt head, e, stmt (head @ s @ tail))
+    (stmt head, e, f_e, stmt (head @ s @ tail))
 
   (* ------------------------------------------------------------------ *)
   let t_hoare_rcond_r b at_pos tc =
     let hs = tc1_as_hoareS tc in
     let m  = EcMemory.memory hs.hs_m in
-    let hd,e,s = gen_rcond !!tc b m at_pos hs.hs_s in
+    let hd,_,e,s = gen_rcond !!tc b m at_pos hs.hs_s in
     let concl1  = f_hoareS_r { hs with hs_s = hd; hs_po = e } in
     let concl2  = f_hoareS_r { hs with hs_s = s } in
     FApi.xmutate1 tc `RCond [concl1; concl2]
 
   (* ------------------------------------------------------------------ *)
+  let t_choare_rcond_r b at_pos c tc =
+    let c = EcUtils.odfl f_true c in
+
+    let chs = tc1_as_choareS tc in
+    let m  = EcMemory.memory chs.chs_m in
+    let hd,e_expr,e,s = gen_rcond !!tc b m at_pos chs.chs_s in
+    let cond, cost =
+      EcCHoare.cost_sub_self
+        chs.chs_co
+        (EcCHoare.cost_of_expr c chs.chs_m e_expr) in
+    let concl1  =
+      f_hoareS chs.chs_m chs.chs_pr hd (f_and_simpl c e) in
+    let concl2  = f_cHoareS_r { chs with chs_s = s;
+                                         chs_co = cost; } in
+    FApi.xmutate1 tc `RCond [concl1; cond; concl2]
+
+  (* ------------------------------------------------------------------ *)
   let t_bdhoare_rcond_r b at_pos tc =
     let bhs = tc1_as_bdhoareS tc in
     let m  = EcMemory.memory bhs.bhs_m in
-    let hd,e,s = gen_rcond !!tc b m at_pos bhs.bhs_s in
+    let hd,_,e,s = gen_rcond !!tc b m at_pos bhs.bhs_s in
     let concl1  = f_hoareS bhs.bhs_m bhs.bhs_pr hd e in
     let concl2  = f_bdHoareS_r { bhs with bhs_s = s } in
     FApi.xmutate1 tc `RCond [concl1; concl2]
@@ -62,7 +79,7 @@ module Low = struct
       match side with
       | `Left  -> es.es_ml,es.es_mr, es.es_sl
       | `Right -> es.es_mr,es.es_ml, es.es_sr in
-    let hd,e,s = gen_rcond !!tc b EcFol.mhr at_pos s in
+    let hd,_,e,s = gen_rcond !!tc b EcFol.mhr at_pos s in
     let mo' = EcIdent.create "&m" in
     let s1 = Fsubst.f_subst_id in
     let s1 = Fsubst.f_bind_mem s1 (EcMemory.memory m) EcFol.mhr in
@@ -77,18 +94,32 @@ module Low = struct
 
   (* ------------------------------------------------------------------ *)
   let t_hoare_rcond   = FApi.t_low2 "hoare-rcond"   t_hoare_rcond_r
+  let t_choare_rcond  = FApi.t_low3 "choare-rcond"  t_choare_rcond_r
   let t_bdhoare_rcond = FApi.t_low2 "bdhoare-rcond" t_bdhoare_rcond_r
   let t_equiv_rcond   = FApi.t_low3 "equiv-rcond"   t_equiv_rcond_r
 end
 
 (* -------------------------------------------------------------------- *)
-let t_rcond side b at_pos tc =
+let t_rcond side b at_pos c tc =
   let concl = FApi.tc1_goal tc in
 
+  let check_none () = if c <> None then
+      tc_error !!tc "optional cost is only for choare judgements" in
+
   match side with
-  | None when is_bdHoareS concl -> Low.t_bdhoare_rcond b at_pos tc
-  | None -> Low.t_hoare_rcond b at_pos tc
-  | Some side -> Low.t_equiv_rcond side b at_pos tc
+  | None when is_bdHoareS concl ->
+    check_none (); Low.t_bdhoare_rcond b at_pos tc
+  | None when is_cHoareS concl  -> Low.t_choare_rcond b at_pos c tc
+  | None ->
+    check_none (); Low.t_hoare_rcond b at_pos tc
+  | Some side ->
+    check_none (); Low.t_equiv_rcond side b at_pos tc
+
+let process_rcond side b at_pos c tc =
+  let c = EcUtils.omap (fun c ->
+      EcProofTyping.tc1_process_Xhl_formula tc c) c in
+
+  t_rcond side b at_pos c tc
 
 (* -------------------------------------------------------------------- *)
 module LowMatch = struct
@@ -145,16 +176,17 @@ module LowMatch = struct
       let po = f_app po vars f.f_ty in
       f_exists (List.map (snd_map gtty) names) (f_eq f po) in
 
-    let me, pvs = List.fold_left_map (fun m (x, xty) ->
-        let var = { v_name = EcIdent.name x; v_type = xty; } in
-        EcLowPhlGoal.fresh_pv m var
-      ) me0 cvars in
+    let me, pvs =
+      let cvars =
+        List.map
+          (fun (x, xty) -> { v_name = EcIdent.name x; v_type = xty; })
+          cvars in
+      EcMemory.bindall_fresh cvars me0 in
 
     let subst, pvs =
-      let px = EcMemory.xpath me0 in
       let s, pvs =
         List.fold_left_map (fun s ((x, xty), name) ->
-            let pv = pv_loc px name in
+            let pv = pv_loc name.v_name in
             let s  = Mid.add x (e_var pv xty) s in
             (s, (pv, xty)))
           Mid.empty (List.combine cvars pvs) in
@@ -165,14 +197,16 @@ module LowMatch = struct
         (EcPV.e_read env e)
         (EcPV.PV.union (EcPV.s_read env hd) (EcPV.s_write env hd)) in
 
-    let epr, asgn =
-
+    (* If frame is false, we do not know how to create a cost. Use sp first. *)
+    let epr, asgn, cost_opt =
     if frame then begin
       let vars = List.map (fun (pv, ty) -> f_pvar pv ty (fst me)) pvs in
       let epr = f_op cname (List.snd tyinst) f.f_ty in
       let epr = f_app epr vars f.f_ty in
 
-      Some (f_eq f epr), []
+      Some (f_eq f epr),
+      [],
+      Some (fun pre -> f_xadd (EcCHoare.cost_of_expr pre me e) f_x1)
 
     end else begin
       let asgn =
@@ -185,15 +219,15 @@ module LowMatch = struct
           let proj = e_oget proj rty in
           i_asgn (lv, proj)) in
 
-      None, otolist asgn
+      None, otolist asgn, None
     end in
 
-    (epr, hd, po1), (me, stmt (hd.s_node @ asgn @ (s_subst subst s).s_node @ tl))
+    (epr, hd, po1, cost_opt), (me, stmt (hd.s_node @ asgn @ (s_subst subst s).s_node @ tl))
 
   (* ------------------------------------------------------------------ *)
   let t_hoare_rcond_match_r c at_pos tc =
     let hs = tc1_as_hoareS tc in
-    let (epr, hd, po1), (me, full) =
+    let (epr, hd, po1, _), (me, full) =
       gen_rcond_full (!!tc, FApi.tc1_env tc) c hs.hs_m at_pos hs.hs_s in
 
     let pr = ofold f_and hs.hs_pr epr in
@@ -206,7 +240,7 @@ module LowMatch = struct
   (* ------------------------------------------------------------------ *)
   let t_bdhoare_rcond_match_r c at_pos tc =
     let bhs = tc1_as_bdhoareS tc in
-    let (epr, hd, po1), (me, full) =
+    let (epr, hd, po1, _), (me, full) =
       gen_rcond_full (!!tc, FApi.tc1_env tc) c bhs.bhs_m at_pos bhs.bhs_s in
 
     let pr = ofold f_and bhs.bhs_pr epr in
@@ -217,6 +251,31 @@ module LowMatch = struct
     FApi.xmutate1 tc `RCondMatch [concl1; concl2]
 
   (* ------------------------------------------------------------------ *)
+  let t_choare_rcond_match_r c at_pos tc =
+    let chs = tc1_as_choareS tc in
+    let (epr, hd, po1, cost_opt), (me, full) =
+      gen_rcond_full (!!tc, FApi.tc1_env tc) c chs.chs_m at_pos chs.chs_s in
+
+    match cost_opt with
+    | None ->
+      tc_error !!tc "choare match: the matched expression must be \
+                     independent of the head statement (maybe use sp first?)."
+    | Some lam_cost ->
+      let cond, cost =
+        EcCHoare.cost_sub_self chs.chs_co (lam_cost chs.chs_pr) in
+
+      let pr = ofold f_and chs.chs_pr epr in
+
+      let concl1 = f_hoareS chs.chs_m chs.chs_pr hd po1 in
+      (* [full] must not contain any new assignments here! *)
+      let concl2 = f_cHoareS_r { chs with chs_pr = pr;
+                                          chs_m = me;
+                                          chs_s = full;
+                                          chs_co = cost} in
+
+      FApi.xmutate1 tc `RCondMatch [concl1; cond; concl2]
+
+  (* ------------------------------------------------------------------ *)
   let t_equiv_rcond_match_r side c at_pos tc =
     let es = tc1_as_equivS tc in
 
@@ -225,7 +284,7 @@ module LowMatch = struct
       | `Left  -> es.es_ml, es.es_mr, es.es_sl
       | `Right -> es.es_mr, es.es_ml, es.es_sr in
 
-    let (epr, hd, po1), (me, full) =
+    let (epr, hd, po1, _), (me, full) =
       gen_rcond_full (!!tc, FApi.tc1_env tc) c (EcFol.mhr, snd m) at_pos s in
 
     let mo'  = EcIdent.create "&m" in
@@ -266,6 +325,9 @@ module LowMatch = struct
   let t_bdhoare_rcond_match =
     FApi.t_low2 "hoare-rcond-match" t_bdhoare_rcond_match_r
 
+  let t_choare_rcond_match =
+    FApi.t_low2 "hoare-rcond-match" t_choare_rcond_match_r
+
   let t_equiv_rcond_match =
     FApi.t_low3 "hoare-rcond-match" t_equiv_rcond_match_r
 end
@@ -276,5 +338,6 @@ let t_rcond_match side c at_pos tc =
 
   match side with
   | None when is_bdHoareS concl -> LowMatch.t_bdhoare_rcond_match c at_pos tc
+  | None when is_cHoareS concl -> LowMatch.t_choare_rcond_match c at_pos tc
   | None -> LowMatch.t_hoare_rcond_match c at_pos tc
   | Some side -> LowMatch.t_equiv_rcond_match side c at_pos tc

--- a/src/phl/ecPhlRCond.mli
+++ b/src/phl/ecPhlRCond.mli
@@ -14,6 +14,7 @@ open EcCoreGoal.FApi
 (* -------------------------------------------------------------------- *)
 module Low : sig
   val t_hoare_rcond   : bool -> codepos1 -> backward
+  val t_choare_rcond  : bool -> codepos1 -> EcFol.form option -> backward
   val t_bdhoare_rcond : bool -> codepos1 -> backward
   val t_equiv_rcond   : side -> bool -> codepos1 -> backward
 end
@@ -26,5 +27,6 @@ module LowMatch : sig
 end
 
 (* -------------------------------------------------------------------- *)
-val t_rcond : oside -> bool -> codepos1 -> backward
+val t_rcond       : oside -> bool -> codepos1 -> EcFol.form option -> backward
+val process_rcond : oside -> bool -> codepos1 -> pformula option -> backward
 val t_rcond_match : oside -> symbol -> codepos1 -> backward

--- a/src/phl/ecPhlRnd.ml
+++ b/src/phl/ecPhlRnd.ml
@@ -21,6 +21,7 @@ open EcLowPhlGoal
 module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
+type chl_infos_t = (form, form option, form) rnd_tac_info
 type bhl_infos_t = (form, ty -> form option, ty -> form) rnd_tac_info
 type rnd_infos_t = (pformula, pformula option, pformula) rnd_tac_info
 type mkbij_t     = EcTypes.ty -> EcTypes.ty -> EcFol.form
@@ -42,6 +43,33 @@ module Core = struct
     let post = f_forall_simpl [(x_id,GTty ty_distr)] post in
     let concl = f_hoareS_r {hs with hs_s=s; hs_po=post} in
     FApi.xmutate1 tc `Rnd [concl]
+
+  (* -------------------------------------------------------------------- *)
+  let t_choare_rnd_r (tac_info : chl_infos_t) tc =
+    let env = FApi.tc1_env tc in
+    let chs = tc1_as_choareS tc in
+    let (lv, distr_e), s = tc1_last_rnd tc chs.chs_s in
+    let ty_distr = proj_distr_ty env (e_ty distr_e) in
+    let x_id = EcIdent.create (symbol_of_lv lv) in
+    let x = f_local x_id ty_distr in
+    let distr = EcFol.form_of_expr (EcMemory.memory chs.chs_m) distr_e in
+    let post = subst_form_lv env (EcMemory.memory chs.chs_m) lv x chs.chs_po in
+    let post = f_imp (f_in_supp x distr) post in
+    let post = f_forall_simpl [(x_id,GTty ty_distr)] post in
+    let post = f_anda (f_lossless ty_distr distr) post in
+
+    let cost_pre = match tac_info with
+      | PNoRndParams -> f_true
+      | PSingleRndParam p -> p
+      | _ -> assert false in
+    let cond, cost =
+      EcCHoare.cost_sub_self
+        chs.chs_co
+        (EcCHoare.cost_of_expr cost_pre chs.chs_m distr_e) in
+    let concl = f_cHoareS_r { chs with chs_s = s;
+                                       chs_po = f_and_simpl cost_pre post;
+                                       chs_co = cost} in
+    FApi.xmutate1 tc `Rnd [cond; concl]
 
   (* -------------------------------------------------------------------- *)
   let wp_equiv_disj_rnd_r side tc =
@@ -414,6 +442,7 @@ let wp_equiv_rnd      = FApi.t_low1 "wp-equiv-rnd"      wp_equiv_rnd_r
 
 (* -------------------------------------------------------------------- *)
 let t_hoare_rnd   = FApi.t_low0 "hoare-rnd"   Core.t_hoare_rnd_r
+let t_choare_rnd  = FApi.t_low1 "choare-rnd"  Core.t_choare_rnd_r
 let t_bdhoare_rnd = FApi.t_low1 "bdhoare-rnd" Core.t_bdhoare_rnd_r
 let t_equiv_rnd   = FApi.t_low2 "equiv-rnd"   t_equiv_rnd_r
 
@@ -424,6 +453,22 @@ let process_rnd side tac_info tc =
   match side, tac_info with
   | None, PNoRndParams when is_hoareS concl ->
       t_hoare_rnd tc
+
+  | None, _ when is_cHoareS concl ->
+    let tac_info =
+      match tac_info with
+      | PNoRndParams ->
+        PNoRndParams
+
+      | PSingleRndParam fp ->
+        PSingleRndParam
+          (TTC.tc1_process_Xhl_form tc tbool fp)
+
+      | _ -> tc_error !!tc "invalid arguments" in
+
+      FApi.t_seqsub (t_choare_rnd tac_info)
+                    [EcLowGoal.t_trivial; EcLowGoal.t_id]
+        tc
 
   | None, _ when is_bdHoareS concl ->
     let tac_info =

--- a/src/phl/ecPhlRnd.mli
+++ b/src/phl/ecPhlRnd.mli
@@ -14,6 +14,7 @@ open EcFol
 open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
+type chl_infos_t = (form, form option, form) rnd_tac_info
 type bhl_infos_t = (form, ty -> form option, ty -> form) rnd_tac_info
 type rnd_infos_t = (pformula, pformula option, pformula) rnd_tac_info
 type mkbij_t     = EcTypes.ty -> EcTypes.ty -> EcFol.form
@@ -24,6 +25,7 @@ val wp_equiv_rnd      : (mkbij_t pair) option -> backward
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_rnd   : backward
+val t_choare_rnd  : chl_infos_t -> backward
 val t_bdhoare_rnd : bhl_infos_t -> backward
 val t_equiv_rnd   : oside -> (mkbij_t option) pair -> backward
 

--- a/src/phl/ecPhlSkip.ml
+++ b/src/phl/ecPhlSkip.ml
@@ -31,6 +31,22 @@ module LowInternal = struct
 
   let t_hoare_skip = FApi.t_low0 "hoare-skip" t_hoare_skip_r
 
+  let t_choare_skip_r tc =
+    let chs = tc1_as_choareS tc in
+
+    if not (List.is_empty chs.chs_s.s_node) then
+      tc_error !!tc "instruction list is not empty";
+
+    let cost_cond =
+      f_xle f_x0 (EcCHoare.cost_flatten chs.chs_co) in
+    let post = f_and chs.chs_po cost_cond in
+    let concl = f_imp chs.chs_pr post in
+    let concl = f_forall_mems [chs.chs_m] concl in
+
+    FApi.xmutate1 tc `Skip [concl]
+
+  let t_choare_skip = FApi.t_low0 "choare-skip" t_choare_skip_r
+
   (* ------------------------------------------------------------------ *)
   let t_bdhoare_skip_r_low tc =
     let bhs = tc1_as_bdhoareS tc in
@@ -79,7 +95,8 @@ end
 
 (* -------------------------------------------------------------------- *)
 let t_skip =
-  t_hS_or_bhS_or_eS
+  t_hS_or_chS_or_bhS_or_eS
     ~th: LowInternal.t_hoare_skip
+    ~tch:LowInternal.t_choare_skip
     ~tbh:LowInternal.t_bdhoare_skip
     ~te: LowInternal.t_equiv_skip

--- a/src/phl/ecPhlSwap.ml
+++ b/src/phl/ecPhlSwap.ml
@@ -72,6 +72,13 @@ let t_hoare_swap_r p1 p2 p3 tc =
   FApi.xmutate1 tc `Swap [concl]
 
 (* -------------------------------------------------------------------- *)
+let t_choare_swap_r p1 p2 p3 tc =
+  let chs   = tc1_as_choareS tc in
+  let s     = LowInternal.swap_stmt tc p1 p2 p3 chs.chs_s in
+  let concl = f_cHoareS_r { chs with chs_s = s } in
+  FApi.xmutate1 tc `Swap [concl]
+
+(* -------------------------------------------------------------------- *)
 let t_bdhoare_swap_r p1 p2 p3 tc =
   let bhs   = tc1_as_bdhoareS tc in
   let s     = LowInternal.swap_stmt tc p1 p2 p3 bhs.bhs_s in
@@ -91,6 +98,7 @@ let t_equiv_swap_r side p1 p2 p3 tc =
 
 (* -------------------------------------------------------------------- *)
 let t_hoare_swap   = FApi.t_low3 "hoare-swap"   t_hoare_swap_r
+let t_choare_swap  = FApi.t_low3 "choare-swap"  t_choare_swap_r
 let t_bdhoare_swap = FApi.t_low3 "bdhoare-swap" t_bdhoare_swap_r
 let t_equiv_swap   = FApi.t_low4 "equiv-swap"   t_equiv_swap_r
 
@@ -99,6 +107,7 @@ module HiInternal = struct
   let stmt_length side tc =
     match (FApi.tc1_goal tc).f_node, side with
     | FhoareS hs   , None -> List.length hs.hs_s.s_node
+    | FcHoareS  chs, None -> List.length chs.chs_s.s_node
     | FbdHoareS bhs, None -> List.length bhs.bhs_s.s_node
 
     | FequivS es, Some `Left  -> List.length es.es_sl.s_node
@@ -149,6 +158,8 @@ let rec process_swap1 info tc =
         match side with
         | None when is_hoareS concl ->
             t_hoare_swap p1 p2 p3
+        | None when is_cHoareS concl ->
+            t_choare_swap p1 p2 p3
         | None when is_bdHoareS concl ->
             t_bdhoare_swap p1 p2 p3
         | None ->

--- a/src/phl/ecPhlSwap.mli
+++ b/src/phl/ecPhlSwap.mli
@@ -13,6 +13,7 @@ open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_swap   : int -> int -> int -> backward
+val t_choare_swap  : int -> int -> int -> backward
 val t_bdhoare_swap : int -> int -> int -> backward
 val t_equiv_swap   : side -> int -> int -> int -> backward
 

--- a/src/phl/ecPhlWhile.mli
+++ b/src/phl/ecPhlWhile.mli
@@ -13,6 +13,7 @@ open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_while      : form -> backward
+val t_choare_while     : form -> form -> form -> cost -> backward
 val t_bdhoare_while    : form -> form -> backward
 val t_equiv_while_disj : side -> form -> form -> backward
 val t_equiv_while      : form -> backward

--- a/src/phl/ecPhlWp.ml
+++ b/src/phl/ecPhlWp.ml
@@ -19,64 +19,90 @@ open EcLowPhlGoal
 module LowInternal = struct
   exception No_wp
 
-  let wp_asgn_aux m lv e (lets, f) =
-    let let1 = lv_subst m lv (form_of_expr m e) in
+  let cost_of_expr_w_pre menv e c_pre = match c_pre with
+    | None -> EcCHoare.cost_of_expr_any menv e
+    | Some pre -> EcCHoare.cost_of_expr pre menv e
+
+  let wp_asgn_aux c_pre memenv lv e (lets, f) =
+    let m = EcMemory.memory memenv in
+    let let1 = lv_subst ?c_pre m lv (form_of_expr m e) in
       (let1::lets, f)
 
-  let rec wp_stmt onesided env m (stmt: EcModules.instr list) letsf =
+  let rec wp_stmt
+      onesided c_pre env memenv (stmt: EcModules.instr list) letsf cost =
     match stmt with
-    | [] -> stmt, letsf
+    | [] -> (stmt, letsf), cost
     | i :: stmt' ->
         try
-          let letsf = wp_instr onesided env m i letsf in
-          wp_stmt onesided env m stmt' letsf
-        with No_wp -> (stmt, letsf)
+          let letsf, i_cost = wp_instr onesided c_pre env memenv i letsf in
+          wp_stmt
+            onesided c_pre env memenv stmt' letsf (f_xadd cost i_cost)
+        with No_wp -> (stmt, letsf), cost
 
-  and wp_instr onesided env m i letsf =
+  and wp_instr onesided c_pre env memenv i letsf =
     match i.i_node with
     | Sasgn (lv,e) ->
-        wp_asgn_aux m lv e letsf
+      wp_asgn_aux c_pre memenv lv e letsf, cost_of_expr_w_pre memenv e c_pre
 
     | Sif (e,s1,s2) ->
-        let r1,letsf1 = wp_stmt onesided env m (List.rev s1.s_node) letsf in
-        let r2,letsf2 = wp_stmt onesided env m (List.rev s2.s_node) letsf in
+        let (r1,letsf1),cost_1 =
+          wp_stmt onesided c_pre env memenv (List.rev s1.s_node) letsf f_x0 in
+        let (r2,letsf2),cost_2 =
+          wp_stmt onesided c_pre env memenv (List.rev s2.s_node) letsf f_x0 in
         if List.is_empty r1 && List.is_empty r2 then begin
           let post1 = mk_let_of_lv_substs env letsf1 in
           let post2 = mk_let_of_lv_substs env letsf2 in
+          let m = EcMemory.memory memenv in
           let post  = f_if (form_of_expr m e) post1 post2 in
-          ([], post)
+          let post  = f_and_simpl (odfl f_true c_pre) post in
+          ([], post),
+          f_xadd
+            (f_xmax cost_1 cost_2)
+            (cost_of_expr_w_pre memenv e c_pre)
         end else raise No_wp
 
-    | Smatch (c,bs) -> begin
+    | Smatch (e, bs) -> begin
         let wps =
-          let do1 (_, s) = wp_stmt onesided env m (List.rev s.s_node) letsf in
+          let do1 (_, s) =
+            wp_stmt onesided c_pre env memenv (List.rev s.s_node) letsf f_x0 in
           List.map do1 bs in
 
-        if not (List.for_all (fun (r, _) -> List.is_empty r) wps) then
+        if not (List.for_all (fun ((r, _), _) -> List.is_empty r) wps) then
           raise No_wp;
         let pbs =
           List.map2
-            (fun (bds, _) (_, letsf) ->
+            (fun (bds, _) ((_, letsf), _) ->
               let post = mk_let_of_lv_substs env letsf in
               f_lambda (List.map (snd_map gtty) bds) post)
             bs wps
-        in ([], f_match (form_of_expr m c) pbs EcTypes.tbool)
+        in
+        let c =
+          match wps with
+          | [] -> f_x0
+          | (_,c1) :: cs -> List.fold_left (fun c (_, c1) -> f_xmax c c1) c1 cs in
+        let c = f_xadd c (cost_of_expr_w_pre memenv e c_pre) in
+        let m = EcMemory.memory memenv in
+        let post =
+          f_and_simpl (odfl f_true c_pre) (f_match (form_of_expr m e) pbs EcTypes.tbool) in
+        (([],post), c)
       end
 
     | Sassert e when onesided ->
-        let phi = form_of_expr m e in
+        let phi = form_of_expr (EcMemory.memory memenv) e in
         let lets,f = letsf in
-        (lets, EcFol.f_and_simpl phi f)
+        (lets, EcFol.f_and_simpl phi f), cost_of_expr_w_pre memenv e c_pre
 
     | _ -> raise No_wp
 end
 
-let wp ?(uselet=true) ?(onesided=false) env m s post =
-  let r,letsf =
-    LowInternal.wp_stmt onesided env m (List.rev s.s_node) ([],post)
+let wp ?(uselet=true) ?(onesided=false) ?c_pre env m s post =
+  let (r,letsf), cost =
+    LowInternal.wp_stmt
+      onesided c_pre env m (List.rev s.s_node)
+      ([],post) f_x0
   in
   let pre = mk_let_of_lv_substs ~uselet env letsf in
-  (List.rev r, pre)
+  List.rev r, pre, cost
 
 (* -------------------------------------------------------------------- *)
 module TacInternal = struct
@@ -88,21 +114,38 @@ module TacInternal = struct
     let env = FApi.tc1_env tc in
     let hs = tc1_as_hoareS tc in
     let (s_hd, s_wp) = o_split i hs.hs_s in
-    let m = EcMemory.memory hs.hs_m in
     let s_wp = EcModules.stmt s_wp in
-    let (s_wp, post) = wp ~uselet ~onesided:true env m s_wp hs.hs_po in
+    let s_wp, post, _ =
+      wp ~uselet ~onesided:true env hs.hs_m s_wp hs.hs_po in
     check_wp_progress tc i hs.hs_s s_wp;
     let s = EcModules.stmt (s_hd @ s_wp) in
     let concl = f_hoareS_r { hs with hs_s = s; hs_po = post} in
     FApi.xmutate1 tc `Wp [concl]
+
+  let t_choare_wp ?(uselet=true) i c_pre tc =
+    let env = FApi.tc1_env tc in
+    EcCHoare.check_loaded env;
+    let chs = tc1_as_choareS tc in
+
+    let (s_hd, s_wp) = o_split i chs.chs_s in
+    let s_wp = EcModules.stmt s_wp in
+
+    let s_wp, post, cost_wp =
+      wp ~uselet ~onesided:true ?c_pre env chs.chs_m s_wp chs.chs_po in
+    check_wp_progress tc i chs.chs_s s_wp;
+    let s = EcModules.stmt (s_hd @ s_wp) in
+    let cond, cost = EcCHoare.cost_sub_self chs.chs_co cost_wp in
+    let concl = f_cHoareS_r { chs with chs_s = s;
+                                       chs_po = post;
+                                       chs_co = cost } in
+    FApi.xmutate1 tc `Wp [cond; concl]
 
   let t_bdhoare_wp ?(uselet=true) i tc =
     let env = FApi.tc1_env tc in
     let bhs = tc1_as_bdhoareS tc in
     let (s_hd, s_wp) = o_split i bhs.bhs_s in
     let s_wp = EcModules.stmt s_wp in
-    let m = EcMemory.memory bhs.bhs_m in
-    let s_wp,post = wp ~uselet env m s_wp bhs.bhs_po in
+    let s_wp,post,_ = wp ~uselet env bhs.bhs_m s_wp bhs.bhs_po in
     check_wp_progress tc i bhs.bhs_s s_wp;
     let s = EcModules.stmt (s_hd @ s_wp) in
     let concl = f_bdHoareS_r { bhs with bhs_s = s; bhs_po = post} in
@@ -114,11 +157,11 @@ module TacInternal = struct
     let i = omap fst ij and j = omap snd ij in
     let s_hdl,s_wpl = o_split i es.es_sl in
     let s_hdr,s_wpr = o_split j es.es_sr in
-    let meml, s_wpl = EcMemory.memory es.es_ml, EcModules.stmt s_wpl in
-    let memr, s_wpr = EcMemory.memory es.es_mr, EcModules.stmt s_wpr in
+    let meml, s_wpl = es.es_ml, EcModules.stmt s_wpl in
+    let memr, s_wpr = es.es_mr, EcModules.stmt s_wpr in
     let post = es.es_po in
-    let s_wpl, post = wp ~uselet env meml s_wpl post in
-    let s_wpr, post = wp ~uselet env memr s_wpr post in
+    let s_wpl, post, _ = wp ~uselet env meml s_wpl post in
+    let s_wpr, post, _ = wp ~uselet env memr s_wpr post in
     check_wp_progress tc i es.es_sl s_wpl;
     check_wp_progress tc j es.es_sr s_wpr;
     let sl = EcModules.stmt (s_hdl @ s_wpl) in
@@ -128,30 +171,51 @@ module TacInternal = struct
 end
 
 (* -------------------------------------------------------------------- *)
-let t_wp_r ?(uselet=true) k g =
+let t_wp_r ?(uselet=true) ?cost_pre k g =
   let module T = TacInternal in
 
-  let (th, tbh, te) =
+  let (th, tch, tbh, te) =
     match k with
-    | None -> (Some (T.t_hoare_wp   ~uselet None),
+    | None -> (Some (T.t_hoare_wp ~uselet None),
+               Some (T.t_choare_wp  ~uselet None cost_pre),
                Some (T.t_bdhoare_wp ~uselet None),
                Some (T.t_equiv_wp   ~uselet None))
 
     | Some (Single i) -> (Some (T.t_hoare_wp   ~uselet (Some i)),
+                          Some (T.t_choare_wp  ~uselet (Some i) cost_pre),
                           Some (T.t_bdhoare_wp ~uselet (Some i)),
                           None (* ------------------- *))
 
     | Some (Double (i, j)) ->
-        (None, None, Some (T.t_equiv_wp ~uselet (Some (i, j))))
+        (None, None, None, Some (T.t_equiv_wp ~uselet (Some (i, j)))) in
 
-  in
-    t_hS_or_bhS_or_eS ?th ?tbh ?te g
+  let (th, tch, tbh, te) =
+    match cost_pre with
+    | None -> th, tch, tbh, te
+    | Some _ ->
+      let err tc =
+        tc_error !!tc "cost precondition are only for choare judgement" in
 
-let t_wp ?(uselet=true) = FApi.t_low1 "wp" (t_wp_r ~uselet)
+      Some err, tch, Some err, Some err in
+
+  t_hS_or_chS_or_bhS_or_eS ?th ?tch ?tbh ?te g
+
+let t_wp ?(uselet=true) ?cost_pre = FApi.t_low1 "wp" (t_wp_r ~uselet ?cost_pre)
 
 (* -------------------------------------------------------------------- *)
 let typing_wp env m s f =
-  match wp ~onesided:true env m  s f with
-  | [], f -> Some f | _, _ -> None
+  match wp ~onesided:true env m s f with
+  | [], f, _ -> Some f | _, _, _ -> None
 
 let () = EcTyping.wp := Some typing_wp
+
+(* -------------------------------------------------------------------- *)
+let process_wp k cost_pre tc =
+  let cost_pre  = match cost_pre with
+    | Some pre -> Some (EcProofTyping.tc1_process_Xhl_formula tc pre)
+    | None -> None in
+  let t_after =
+    match (FApi.tc1_goal tc).f_node with
+    | FcHoareS _ -> [(fun x -> EcLowGoal.t_trivial x); EcLowGoal.t_id]
+    | _          -> [ EcLowGoal.t_id] in
+  FApi.t_seqsub (t_wp ?cost_pre k) t_after tc

--- a/src/phl/ecPhlWp.mli
+++ b/src/phl/ecPhlWp.mli
@@ -8,10 +8,6 @@
 
 (* -------------------------------------------------------------------- *)
 open EcParsetree
-open EcEnv
-open EcMemory
-open EcModules
-open EcFol
 
 open EcCoreGoal.FApi
 
@@ -22,8 +18,8 @@ open EcCoreGoal.FApi
  * soundness of the bounded hoare logic.
  *)
 
-val wp :
-      ?uselet:bool -> ?onesided:bool
-   -> env -> memory -> stmt -> form -> instr list * form
+val t_wp :
+  ?uselet:bool -> ?cost_pre:EcFol.form ->
+  (codepos1 doption) option -> backward
 
-val t_wp : ?uselet:bool -> (codepos1 doption) option -> backward
+val process_wp : (codepos1 doption) option -> pformula option -> backward

--- a/theories/core/AllCore.ec
+++ b/theories/core/AllCore.ec
@@ -8,6 +8,35 @@
 
 (* -------------------------------------------------------------------- *)
 require (*--*) Ring.
-require export Core Int Real.
+require export Core Int Real Xint.
 (*---*) export Ring.IntID.
 
+(* -------------------------------------------------------------------- *)
+schema cost_oget ['a] `{P} {o: 'a option} : 
+  cost [P : oget o] = cost [P:o] + N 1.
+hint simplify cost_oget.
+
+(* Cost on integer operations *)
+op cincr : int -> int.
+op ceqint : int -> int.
+op cltint : int -> int.
+op cleint : int -> int.
+
+axiom ge0_cincr m  : 0 <= cincr m.
+axiom ge0_ceqint m : 0 <= ceqint m.
+axiom ge0_cltint m : 0 <= cltint m.
+axiom ge0_cleint m : 0 <= cleint m.
+
+schema cost_incr {n:int} (m:int) : cost[`|n| <= m : n + 1] = cost[true:n] + N (cincr m).
+
+schema cost_eqint {n1 n2:int} (m:int) : 
+  cost[`|n1| <= m /\ `|n2| <= m : n1 = n2] = cost[true:n1] + cost[true:n2] + N (ceqint m).
+
+schema cost_ltint {n1 n2:int} (m:int) : 
+  cost[`|n1| <= m /\ `|n2| <= m : n1 < n2] = cost[true:n1] + cost[true:n2] + N (cltint m).
+
+schema cost_leint {n1 n2:int} (m:int) : 
+  cost[`|n1| <= m /\ `|n2| <= m : n1 < n2] = cost[true:n1] + cost[true:n2] + N (cleint m).
+
+
+hint simplify cost_incr, cost_eqint, cost_ltint, cost_leint.

--- a/theories/core/Bool.ec
+++ b/theories/core/Bool.ec
@@ -7,6 +7,7 @@
  * -------------------------------------------------------------------- *)
 
 (* -------------------------------------------------------------------- *)
+require import Int Xint.
 require import FinType.
 
 op (^^) (b1 b2:bool) = b1 = !b2.
@@ -28,6 +29,17 @@ by [].
 
 clone FinType as BoolFin with
   type t    <- bool,
-    op enum <- List.(::) true (List.(::) false List."[]"),
-    op card <- 2
+  op enum <- List.(::) true (List.(::) false List."[]"),
+  op card <- 2
 proof enum_spec by case.
+
+schema cost_eqbool `{P} {b1 b2:bool} : cost [P: b1 = b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_and  `{P} {b1 b2:bool} : cost [P: b1 /\ b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_anda `{P} {b1 b2:bool} : cost [P: b1 && b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_or   `{P} {b1 b2:bool} : cost [P: b1 \/ b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_ora  `{P} {b1 b2:bool} : cost [P: b1 || b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_xor  `{P} {b1 b2:bool} : cost [P: b1 ^^ b2] = cost[P:b1] + cost[P:b2] + '1.
+schema cost_not  `{P} {b: bool}    : cost [P: !b] = cost[P:b] + '1.
+
+hint simplify cost_eqbool, cost_and, cost_anda, cost_or, cost_ora, cost_xor, cost_not.
+

--- a/theories/crypto/Birthday.ec
+++ b/theories/crypto/Birthday.ec
@@ -67,8 +67,8 @@ module Exp(S:Sampler,A:Adv) = {
     the probability that the same output is sampled twice is bounded
     by q^2/|T|                                                        **)
 section.
-  declare module A <: Adv {Sample}.
-  declare axiom A_ll (S <: ASampler {A}): islossless S.s => islossless A(S).a.
+  declare module A <: Adv {-Sample}.
+  declare axiom A_ll (S <: ASampler {-A}): islossless S.s => islossless A(S).a.
 
   lemma pr_Sample_le &m:
     Pr[Exp(Sample,A).main() @ &m : size Sample.l <= q /\ !uniq Sample.l]
@@ -155,7 +155,7 @@ module Bounded(A:Adv,S:ASampler) = {
   }
 }.
 
-equiv PushBound (S <: Sampler {Bounder}) (A <: Adv {S,Bounder}):
+equiv PushBound (S <: Sampler {-Bounder}) (A <: Adv {-S,-Bounder}):
   Exp(Bounder(S),A).main ~ Exp(S,Bounded(A)).main:
     ={glob A,glob S} ==>
     ={glob A,glob S}.
@@ -165,9 +165,9 @@ proof. by proc; inline*; sim. qed.
     probability that the same output is sampled twice is bounded by
     q^2/|T|                                                         **)
 section.
-  declare module A <: Adv {Sample,Bounder}.
+  declare module A <: Adv {-Sample,-Bounder}.
 
-  declare axiom A_ll (S <: ASampler {A}): islossless S.s => islossless A(S).a.
+  declare axiom A_ll (S <: ASampler {-A}): islossless S.s => islossless A(S).a.
 
   lemma pr_collision_bounded_oracles &m:
     Pr[Exp(Bounder(Sample),A).main() @ &m: !uniq Sample.l]

--- a/theories/crypto/DiffieHellman.ec
+++ b/theories/crypto/DiffieHellman.ec
@@ -6,7 +6,7 @@
  * Distributed under the terms of the CeCILL-B-V1 license
  * -------------------------------------------------------------------- *)
 
-require import AllCore StdRing StdOrder Distr List FSet.
+require import AllCore StdRing StdOrder Distr List FSet CHoareTactic.
 (*---*) import RField RealOrder.
 require (*  *) CyclicGroup.
 
@@ -64,6 +64,7 @@ end CDH.
 theory List_CDH.
 
   const n: int.
+  axiom gt0_n :  0 < n. 
 
   module type Adversary = {
     proc solve(gx:group, gy:group): group list
@@ -116,12 +117,9 @@ theory List_CDH.
     }.
 
     lemma Reduction &m:
-      0 < n =>
       1%r / n%r * Pr[LCDH(A).main() @ &m: res]
       <= Pr[CDH.CDH(CDH_from_LCDH(A)).main() @ &m: res].
     proof.
-      (* Move "0 < n" into the context *)
-      move=> n_pos.
       (* We prove the inequality by transitivity:
            1%r/n%r * Pr[LCDH(A).main() @ &m: res]
            <= Pr[LCDH'.main() @ &m: res]
@@ -136,7 +134,6 @@ theory List_CDH.
       (* We do this one using a combination of phoare (to deal with the final sampling of z)
          and equiv (to show that LCDH'.aux and CDH.CDH are equivalent in context). *)
       byphoare (_: (glob A) = (glob A){m} ==> _)=> //.
-      (* This line is due to a bug in proc *) pose d:= 1%r/n%r * Pr[LCDH(A).main() @ &m: res].
       pose p:= Pr[LCDH(A).main() @ &m: res]. (* notation for ease of writing below *)
       proc.
       (* We split the probability computation into:
@@ -153,12 +150,41 @@ theory List_CDH.
         by proc *; inline *; wp; call (_: true); auto.
       (* The second part is just arithmetic, but smt needs some help. *)
       rnd (pred1 (g^(LCDH'.x * LCDH'.y))).
-      skip=> /> ? Hin Hle.
-      rewrite /pred1 MUniform.duniform1E Hin /= lef_pinv 2:/#.
+      wp; skip=> /> ? Hin Hle /=.
+      rewrite /pred1 MUniform.duniform1E Hin /= lef_pinv; [2:smt (gt0_n)].
       + by move: Hin;rewrite -mem_undup -index_mem;smt (index_ge0).
       smt (size_undup).
     qed.
   end section.
+
+  abstract theory C.
+
+    op cduniform_n : { int | 0 <= cduniform_n } as ge0_cduniform_n.
+
+    schema cost_duniform `{P} {s : group list} : 
+       cost [P /\ size s <= n : duniform s] <= cost [P : s] + N cduniform_n.
+
+    lemma ex_reduction (cs:int) (A<:Adversary) &m :
+      choare[A.solve : true ==> 0 < size res <= n] time [N cs] =>
+      exists (B <:CDH.Adversary [solve : `{N(cduniform_n + cs)} ] {+A}),
+      Pr[LCDH(A).main() @ &m: res] <= n%r * Pr[CDH.CDH(B).main() @ &m: res]. 
+    proof.
+      move=> hcA;exists (CDH_from_LCDH(A));split; last first.
+      + have /= h1 := Reduction A &m.  
+        rewrite -ler_pdivr_mull; smt(lt_fromint gt0_n).
+      proc => //.
+      instantiate /= h := (cost_duniform {gx, gy, x : group, s : group list} 
+                        `(true) s).
+      rnd (size s <= n).
+      + by apply: (is_int_le _ _ h).
+      call hcA; skip => />; split.
+      + move=> *; apply duniform_ll;rewrite -size_eq0 /#.
+      move: h; pose t :=
+        cost(&hr: {gx, gy, x : group, s : group list})[size s <= n : duniform s].
+      by case: t => // ? /#.
+    qed.
+
+  end C.
 
 end List_CDH.
 
@@ -166,6 +192,7 @@ end List_CDH.
 theory Set_CDH.
 
   const n: int.
+  axiom gt0_n :  0 < n.
 
   module type Adversary = {
     proc solve(gx:group, gy:group): group fset
@@ -182,42 +209,42 @@ theory Set_CDH.
     }
   }.
 
+  clone List_CDH as LCDH with 
+    op n <- n
+    proof gt0_n by apply gt0_n.
+  
   module CDH_from_SCDH (A:Adversary): CDH.Adversary = {
-    proc solve(gx:group, gy:group): group = {
-      var s, x;
-
-      s <@ A.solve(gx, gy);
-      x <$ MUniform.duniform (elems s);
-      return x;
+    module AL = {
+      proc solve(gx:group, gy:group): group list = {
+        var s;
+        s <@ A.solve(gx, gy);
+        return elems s;
+      }
     }
+    proc solve = LCDH.CDH_from_LCDH(AL).solve
   }.
 
   (** Naive reduction to CDH **)
   section.
     declare module A <: Adversary.
 
-    local module AL = {
-      proc solve(gx:group, gy:group) = {
-        var s;
-        s <@ A.solve(gx, gy);
-        return elems s;
-      }
-    }.
-
-    local clone List_CDH as LCDH with op n <- n.
+    (* FIXME: schemas cannot be declared in sections *)
+    (* local clone List_CDH as LCDH with op n <- n. *)
 
     lemma Reduction &m:
-      0 < n =>
       1%r / n%r * Pr[SCDH(A).main() @ &m: res]
       <= Pr[CDH.CDH(CDH_from_SCDH(A)).main() @ &m: res].
     proof.
-      move=> Hn.
-      have := LCDH.Reduction AL &m Hn.
-      have -> : Pr[LCDH.LCDH(AL).main() @ &m : res] = Pr[SCDH(A).main() @ &m : res].
-      + by byequiv=> //;proc;inline *;wp;call (_:true);auto => /> ?????;rewrite memE cardE.
-      have -> //: Pr[CDH.CDH(LCDH.CDH_from_LCDH(AL)).main() @ &m : res] =
-                Pr[CDH.CDH(CDH_from_SCDH(A)).main() @ &m : res].
-      by byequiv=> //;proc;inline *;auto=> /=;call (_:true);auto.
+      have h0 := LCDH.Reduction (<:CDH_from_SCDH(A).AL) &m.
+      have h1 : Pr[SCDH(A).main() @ &m : res] <= 
+                Pr[LCDH.LCDH(CDH_from_SCDH(A).AL).main() @ &m : res].
+      + byequiv=> //;proc;inline *;wp;call (_:true);auto => /> ?????. 
+        by rewrite memE cardE.
+      have -> : Pr[CDH.CDH(CDH_from_SCDH(A)).main() @ &m : res] =
+                Pr[CDH.CDH(LCDH.CDH_from_LCDH(CDH_from_SCDH(A).AL)).main() @ &m : res].
+      + by byequiv=> //;proc;inline *;auto=> /=;call (_:true);auto.
+      apply: ler_trans h0 => /=.
+      by apply ler_wpmul2r => //; rewrite invr_ge0 le_fromint; smt(gt0_n).
     qed.
   
   end section.

--- a/theories/crypto/PKE.ec
+++ b/theories/crypto/PKE.ec
@@ -80,7 +80,7 @@ module CPA_R (S:Scheme, A:Adversary) = {
 section.
 
   declare module S <: Scheme.
-  declare module A <: Adversary{S}.
+  declare module A <: Adversary{-S}.
 
   lemma pr_CPA_LR &m: 
     islossless S.kg => islossless S.enc =>

--- a/theories/crypto/PROM.ec
+++ b/theories/crypto/PROM.ec
@@ -204,7 +204,7 @@ proof.
 by proc; inline *; auto=> /> &2 r _; rewrite mem_map /noflags map_set.
 qed.
 
-equiv RO_FRO_D (D <: RO_Distinguisher { RO, FRO }) :
+equiv RO_FRO_D (D <: RO_Distinguisher { -RO, -FRO }) :
   D(RO).distinguish ~ D(FRO).distinguish : 
     ={arg, glob D} /\ RO.m{1} = noflags FRO.m{2}
     ==> ={res, glob D} /\ RO.m{1} = noflags FRO.m{2}.
@@ -631,7 +631,7 @@ qed.
 
 (* -------------------------------------------------------------------- *)
 section.
-declare module D <: FRO_Distinguisher {FRO}.
+declare module D <: FRO_Distinguisher {-FRO}.
 
 lemma eager_D :
   eager [RRO.resample();, D(FRO).distinguish ~ 
@@ -672,7 +672,7 @@ module Eager (D : FRO_Distinguisher) = {
 
 (* -------------------------------------------------------------------- *)
 section.
-declare module D <: FRO_Distinguisher {FRO}.
+declare module D <: FRO_Distinguisher {-FRO}.
 
 equiv Eager_1_2 : Eager(D).main1 ~ Eager(D).main2 :
   ={glob D, arg} ==> ={res, glob FRO, glob D}.
@@ -723,7 +723,7 @@ rewrite restr_set=> //= Hnd.
 by rewrite rem_id // dom_restr /in_dom_with Hnd.
 qed.
 
-equiv LRO_RRO_D (D <: RO_Distinguisher{RO, FRO}) :
+equiv LRO_RRO_D (D <: RO_Distinguisher{-RO, -FRO}) :
   D(LRO).distinguish ~ D(RRO).distinguish : 
     ={glob D, arg} /\ RO.m{1} = restr Known FRO.m{2}
     ==> ={res, glob D} /\ RO.m{1} = restr Known FRO.m{2}.
@@ -739,7 +739,7 @@ end EagerCore.
 
 (* -------------------------------------------------------------------- *)
 section.
-declare module D <: RO_Distinguisher { RO, FRO }.
+declare module D <: RO_Distinguisher { -RO, -FRO }.
 declare axiom dout_ll x: is_lossless (dout x).
 
 local clone import EagerCore as InnerProof
@@ -827,13 +827,13 @@ module FinRO : RO = {
 }.
 
 module type FinRO_Distinguisher(G : RO) = {
-  proc distinguish(_ : d_in_t): d_out_t { G.init G.get G.set G.sample }
+  proc distinguish(_ : d_in_t): d_out_t { G.init, G.get, G.set, G.sample }
 }.
 
 section PROOFS.
 declare axiom dout_ll x: is_lossless (dout x).
 
-declare module D <: FinRO_Distinguisher{RO, FRO}.
+declare module D <: FinRO_Distinguisher{-RO, -FRO}.
 
 local module GenFinRO (RO:RO) = {
   include RO [set, rem, get]

--- a/theories/crypto/PRP.eca
+++ b/theories/crypto/PRP.eca
@@ -409,8 +409,8 @@ qed.
          = Pr[IND(PRPi'(Indirect),D).main() @ &m: res].
  **)
 section Upto.
-  declare module D <: PRFt.Distinguisher {RP, PRFi}.
-  declare axiom D_ll (O <: PRF_Oracles {D}): islossless O.f => islossless D(O).distinguish.
+  declare module D <: PRFt.Distinguisher {-RP, -PRFi}.
+  declare axiom D_ll (O <: PRF_Oracles {-D}): islossless O.f => islossless D(O).distinguish.
 
   local module PRP_indirect_bad = {
     var bad : bool
@@ -523,7 +523,7 @@ section PRPi_PRPi'_Indirect.
   + by proc; if=> //=; wp; call eq_Direct_Indirect.
   qed.
 
-  declare module D <: Distinguisher { RP }.
+  declare module D <: Distinguisher { -RP }.
 
   lemma pr_PRPi_PRPi'_Indirect &m:
     Pr[IND(RP,D).main() @ &m: res] = Pr[IND(PRPi'(Indirect),D).main() @ &m: res].
@@ -537,9 +537,9 @@ section PRPi_PRPi'_Indirect.
 end section PRPi_PRPi'_Indirect.
 
 section CollisionProbability.
-  declare module D <: Distinguisher {RP, PRFi}.
+  declare module D <: Distinguisher {-RP, -PRFi}.
 
-  declare axiom D_ll (O <: PRF_Oracles {D}): islossless O.f => islossless D(O).distinguish.
+  declare axiom D_ll (O <: PRF_Oracles {-D}): islossless O.f => islossless D(O).distinguish.
   declare axiom D_bounded  : hoare [D(PRFi).distinguish : PRFi.m = empty ==> card (fdom PRFi.m) <= q].
 
   local clone import Birthday as BBound with
@@ -581,7 +581,7 @@ section CollisionProbability.
     }
   }.
 
-  local lemma A_ll (S <: ASampler {A}): islossless S.s => islossless A(S).a.
+  local lemma A_ll (S <: ASampler {-A}): islossless S.s => islossless A(S).a.
   proof.
   move=> S_ll; proc; inline*; wp.
   call (_: true).
@@ -658,10 +658,10 @@ module DBounder (D : Distinguisher) (F : PRF_Oracles) = {
 
 section BOUNDER.
 
-declare module D <: Distinguisher {RP, PRFi, DBounder}.
-declare axiom D_ll (O <: PRF_Oracles {D}): islossless O.f => islossless D(O).distinguish.
+declare module D <: Distinguisher {-RP, -PRFi, -DBounder}.
+declare axiom D_ll (O <: PRF_Oracles {-D}): islossless O.f => islossless D(O).distinguish.
 
-lemma DBounder_ll (O <: PRF_Oracles{DBounder(D)}): 
+lemma DBounder_ll (O <: PRF_Oracles{-DBounder(D)}): 
   islossless O.f => islossless DBounder(D, O).distinguish.
 proof.
   move=> hll; islossless.

--- a/theories/crypto/ROM.eca
+++ b/theories/crypto/ROM.eca
@@ -172,7 +172,7 @@ clone include FiniteEager with
 proof * by exact/enum_spec.
 
 section.
-declare module D <: Distinguisher { LRO, ERO }.
+declare module D <: Distinguisher { -LRO, -ERO }.
 
 declare axiom dout_ll x : is_lossless (dout x).
 
@@ -346,7 +346,7 @@ proof. by move=> O_init_ll; proc; wp; call O_init_ll. qed.
 lemma Log_o_ll (O <: Oracle): islossless O.o => islossless Log(O).o.
 proof. by move=> O_oL; proc; call O_oL; wp. qed.
 
-lemma Log_o_stable (O <: Oracle {Log}) q:
+lemma Log_o_stable (O <: Oracle {-Log}) q:
   islossless O.o => phoare[Log(O).o: mem Log.qs q ==> mem Log.qs q] = 1%r.
 proof. by move=> O_o_ll; proc; call O_o_ll; auto=> />. qed.
 
@@ -393,7 +393,7 @@ proof. by move=> O_init_ll; proc; wp; call O_init_ll. qed.
 lemma Log_o_ll (O <: Oracle): islossless O.o => islossless Log(O).o.
 proof. by move=> O_o_ll; proc; wp; call O_o_ll; wp. qed.
 
-hoare Log_o_stable (O <: Oracle {Log}) x: Log(O).o: x \in Log.qs ==> x \in Log.qs.
+hoare Log_o_stable (O <: Oracle {-Log}) x: Log(O).o: x \in Log.qs ==> x \in Log.qs.
 proof. by proc; wp; call (_: true); skip=> &m; rewrite in_fsetU in_fset1=> ->. qed.
 
 module Bound (O : Oracle) = {
@@ -412,13 +412,13 @@ module Bound (O : Oracle) = {
 lemma Bound_init_ll (O <: Oracle): islossless O.init => islossless Bound(O).init.
 proof. by move=> O_init_ll; proc; wp; call O_init_ll. qed.
 
-lemma Bound_o_ll (O <: Oracle {Log}): islossless O.o => islossless Bound(O).o.
+lemma Bound_o_ll (O <: Oracle {-Log}): islossless O.o => islossless Bound(O).o.
 proof. by move=> O_o_ll; proc; sp; if=> //; wp; call (Log_o_ll O _). qed.
 
-hoare Bound_o_stable (O <: Oracle {Log}) x: Bound(O).o: mem Log.qs x ==> mem Log.qs x.
+hoare Bound_o_stable (O <: Oracle {-Log}) x: Bound(O).o: mem Log.qs x ==> mem Log.qs x.
 proof. by proc; sp; if=> //; wp; call (Log_o_stable O x). qed.
 
-equiv Log_Bound (O <: Oracle {Log}) (D <: Distinguisher { O, Log }):
+equiv Log_Bound (O <: Oracle {-Log}) (D <: Distinguisher { -O, -Log }):
   Exp(Bound(O),D).main ~ Exp(Log(Bound(O)),D).main: ={glob O, glob D, x} ==> ={res}.
 proof.
 proc.
@@ -497,9 +497,9 @@ module G_bad (D : Dist) (H : Oracle) = {
 }.
 
 section.
-declare module D <: Dist { Log, LRO }.
-declare axiom D_a1_ll (H <: POracle { D }): islossless H.o => islossless D(H).a1.
-declare axiom D_a2_ll (H <: POracle { D }): islossless H.o => islossless D(H).a2.
+declare module D <: Dist { -Log, -LRO }.
+declare axiom D_a1_ll (H <: POracle { -D }): islossless H.o => islossless D(H).a1.
+declare axiom D_a2_ll (H <: POracle { -D }): islossless H.o => islossless D(H).a2.
 
 declare axiom dout_ll x : is_lossless (dout x).
 
@@ -605,9 +605,9 @@ module G_bad (D : Dist) (H : Oracle) = {
 }.
 
 section.
-declare module D <: Dist { Log, LRO }.
-declare axiom D_a1_ll (H <: POracle { D }): islossless H.o => islossless D(H).a1.
-declare axiom D_a2_ll (H <: POracle { D }): islossless H.o => islossless D(H).a2.
+declare module D <: Dist { -Log, -LRO }.
+declare axiom D_a1_ll (H <: POracle { -D }): islossless H.o => islossless D(H).a1.
+declare axiom D_a2_ll (H <: POracle { -D }): islossless H.o => islossless D(H).a2.
 
 declare axiom dout_ll x : is_lossless (dout x).
 

--- a/theories/crypto/RndExcept.eca
+++ b/theories/crypto/RndExcept.eca
@@ -123,8 +123,7 @@ abstract theory Adversary.
 
 
   section PROOFS.
-
-  declare module A <: AdvRndE { SampleB }.
+  declare module A <: AdvRndE { -SampleB }.
 
   equiv A_sampleE_sampleEB : Main(R(SampleE),A).main ~ Main(R(SampleEB),A).main :
     ={glob A} ==> ={res, glob A}.
@@ -142,7 +141,7 @@ abstract theory Adversary.
     inline*;auto.
   qed.
 
-  declare axiom A_ll : (forall (O <: SAMPLE_ADV{A}), islossless O.sample => islossless A(O).main).
+  declare axiom A_ll : (forall (O <: SAMPLE_ADV{-A}), islossless O.sample => islossless A(O).main).
 
   equiv A_upto :
      Main(R(SampleEB),A).main ~ Main(R(SampleB),A).main :
@@ -273,12 +272,11 @@ abstract theory AdversaryN.
   }.
 
   section PROOFS.
-
-  declare module A <: AdvRndE { Count }.
+  declare module A <: AdvRndE { -Count }.
 
   local clone import Bad as Bad1.
 
-  declare axiom A_ll : (forall (O <: SAMPLE_ADV{A}), islossless O.sample => islossless A(O).main).
+  declare axiom A_ll : (forall (O <: SAMPLE_ADV{-A}), islossless O.sample => islossless A(O).main).
 
   local lemma pr_bad &m :
     Pr[Main(CountI(R(SampleB)),A).main() @ &m : SampleB.bad /\ 0 <= Count.c <= q ] <= q%r * p%r / n%r .
@@ -525,3 +523,5 @@ abstract theory Adversary1_1.
   end section PROOFS.
 
 end  Adversary1_1.
+ 
+ 

--- a/theories/crypto/SplitRO.ec
+++ b/theories/crypto/SplitRO.ec
@@ -55,7 +55,7 @@ clone MkRO as ROT.
 clone MkRO as ROF.
 
 section PROOFS.
-  declare module D <: RO_Distinguisher { RO, ROT.RO, ROF.RO }.
+  declare module D <: RO_Distinguisher { -RO, -ROT.RO, -ROF.RO }.
 
   equiv RO_split: 
     MainD(D,RO).distinguish ~ MainD(D,RO_DOM(ROT.RO,ROF.RO)).distinguish : 
@@ -142,7 +142,7 @@ module RO_Pair (RO1 : I1.RO) (RO2 : I2.RO) : RO = {
 
 section PROOFS.
 
-  declare module D <: RO_Distinguisher { RO, I1.RO, I2.RO }.
+  declare module D <: RO_Distinguisher { -RO, -I1.RO, -I2.RO }.
 
   local clone import ProdSampling with
     type t1 <- to1,
@@ -161,8 +161,10 @@ section PROOFS.
     swap{2} 5 -3; swap{2} 6 -2; sp 0 2.
     seq 1 2 : (#pre /\ r{1} = ofpair (r{2}, r0{2})).
     + conseq />.
-      transitivity*{2} { (r,r0) <@ S.sample2(sampleto1 x0, sampleto2 x1); } => //; 1: smt().
-      + transitivity*{2} { (r,r0) <@ S.sample(sampleto1 x0, sampleto2 x1); } => //; 1: smt().
+      transitivity*{2} { (r,r0) <@ S.sample2(sampleto1 x0, sampleto2 x1); } => //.
+      move => />; smt().
+      + transitivity*{2} { (r,r0) <@ S.sample(sampleto1 x0, sampleto2 x1); } => //.
+        move => />; smt(). 
         + inline *; wp; rnd topair ofpair; auto => /> &2 ?; split.
           + by move=> ??; rewrite ofpairK. 
           move=> _; split.
@@ -172,7 +174,7 @@ section PROOFS.
           by rewrite topairK ofpairK => ->.
         by call sample_sample2; auto.
       by inline *; auto => />.
-    by auto; smt (get_setE map_set set_pair_map mem_map mem_pair_map mem_set mapE mergeE).
+    by auto => />; smt (get_setE map_set set_pair_map mem_map mem_pair_map mem_set mapE mergeE).
   qed.
 
   equiv RO_split: 

--- a/theories/crypto/SymmetricEncryption.ec
+++ b/theories/crypto/SymmetricEncryption.ec
@@ -109,7 +109,7 @@ module INDCCA (S:Scheme, A:Adv_INDCCA) = {
 
 module ToCCA (A:Adv_INDCPA, O:CCA_Oracles) = A(O).
 
-lemma CCA_implies_CPA (S <: Scheme {INDCPA}) (A <: Adv_INDCPA {S, INDCPA}) &m:
+lemma CCA_implies_CPA (S <: Scheme {-INDCPA}) (A <: Adv_INDCPA {-S, -INDCPA}) &m:
   Pr[INDCPA(S,A).main() @ &m: res] = Pr[INDCCA(S,ToCCA(A)).main() @ &m: res].
 proof strict.
 byequiv (_: ={glob A} ==> ={res})=> //; proc.

--- a/theories/crypto/assumptions/AEAD.ec
+++ b/theories/crypto/assumptions/AEAD.ec
@@ -133,7 +133,7 @@ module AEAD_LoRCondProb(A : AEAD_Adv) = {
    }
 }.
 
-declare module A <: AEAD_Adv {AEAD_Oracles}.
+declare module A <: AEAD_Adv {-AEAD_Oracles}.
 
 equiv condprob_equiv : 
   AEAD_LoR(A).main ~ AEAD_LoRCondProb(A).main : 

--- a/theories/crypto/assumptions/CRHash.ec
+++ b/theories/crypto/assumptions/CRHash.ec
@@ -226,10 +226,10 @@ module (MkAdvCR(A:AdvInd):AdvCR) (O:OrclCR) = {
 
 section.
 
-  declare module A <: AdvInd { RealHash, OrclCR}.
+  declare module A <: AdvInd { -RealHash, -OrclCR}.
   
   declare axiom Alossless :
-    forall (O <: OrclInd{A}),
+    forall (O <: OrclInd{-A}),
           islossless O.hash => 
           islossless O.check => islossless A(O).main.
 

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -588,7 +588,7 @@ by rewrite (ctxt1mem_foldenc _ _ _ _ _ _ H).
 qed.
 
 lemma hop1false &m 
-    (A <: MRPKE_Adv {MRPKE_lor, Adv1_Procs, ODH_Orcl}):
+    (A <: MRPKE_Adv {-MRPKE_lor, -Adv1_Procs, -ODH_Orcl}):
        Pr [MRPKE_Sec(A).main() @ &m : res ] = 
        Pr [ODH_Sec(Adv1(A)).game(false) @ &m : !res].
 proof.
@@ -787,7 +787,7 @@ module MRPKErnd_Sec (A:MRPKE_Adv) = {
 }.
 
 lemma hop1true &m 
-    (A <: MRPKE_Adv {MRPKErnd_lor, Adv1_Procs, ODH_Orcl}):
+    (A <: MRPKE_Adv {-MRPKErnd_lor, -Adv1_Procs, -ODH_Orcl}):
        Pr [MRPKErnd_Sec(A).main() @ &m : res ] = 
        Pr [ODH_Sec(Adv1(A)).game(true) @ &m : res].
 proof.
@@ -991,7 +991,7 @@ apply eq_in_map => y /mem_iota [? ?] /#.
 qed.
 
 lemma hop2 &m 
-    (A <: MRPKE_Adv { Adv2_Procs, MRPKErnd_lor, AEADmul_Oracles }):
+    (A <: MRPKE_Adv { -Adv2_Procs, -MRPKErnd_lor, -AEADmul_Oracles }):
        Pr [MRPKErnd_Sec(A).main() @ &m : res ] = 
        Pr [AEADmul_Sec(Adv2(A)).main() @ &m : res].
 proof. 
@@ -1261,7 +1261,7 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
 qed.
 
 lemma reduction &m 
-  (A <: MRPKE_Adv {  Adv2_Procs, Adv1_Procs, ODH_Orcl, MRPKE_lor, AEADmul_Oracles, MRPKErnd_lor }):
+  (A <: MRPKE_Adv {  -Adv2_Procs, -Adv1_Procs, -ODH_Orcl, -MRPKE_lor, -AEADmul_Oracles, -MRPKErnd_lor }):
      Pr [MRPKE_Sec(A).main() @ &m : res ] <= 
      `| Pr[ODH_Sec(Adv1(A)).game(false) @ &m : !res] - 
         Pr[ODH_Sec(Adv1(A)).game(true) @ &m : res] | +

--- a/theories/crypto/assumptions/PKSMK.ec
+++ b/theories/crypto/assumptions/PKSMK.ec
@@ -188,7 +188,7 @@ module (MkAdvUF(A:AdvInd):AdvUF) (O:OrclUF) = {
 
 section.
 
-  declare module A <: AdvInd { RealSigServ, OrclUF }.
+  declare module A <: AdvInd { -RealSigServ, -OrclUF }.
 
   local module Wrap (O:FullSigService) = {
     include OrclUF [+init]
@@ -245,7 +245,7 @@ section.
        exists sk, (pk,sk) \in keygen /\ s \in sign(sk,m)).
 
   lemma ind_uf &m : 
-    (forall (O <: OrclInd{A}),
+    (forall (O <: OrclInd{-A}),
        islossless O.keygen => islossless O.sign =>
        islossless O.pkeys => islossless O.verify => islossless A(O).main) =>
     `| Pr[IndSig(RealSigServ, A).main() @ &m : res] -
@@ -429,7 +429,7 @@ abstract theory UF1_UF.
 
   section.
 
-    declare module A <: AdvUF { RealSigServ, OrclUF, UF1, UF, WAkg, MkAdvUF1 }.
+    declare module A <: AdvUF { -RealSigServ, -OrclUF, -UF1, -UF, -WAkg, -MkAdvUF1 }.
 
     local module Aux (O:OrclUF) = {
       var forged : int option
@@ -676,8 +676,8 @@ abstract theory UF1_UF.
 
   end section.
 
-  lemma ind_uf1 (A <: AdvInd{RealSigServ, OrclUF, UF1, UF, WAkg, MkAdvUF1}) &m : 
-    (forall (O <: OrclInd{A}),
+  lemma ind_uf1 (A <: AdvInd{-RealSigServ, -OrclUF, -UF1, -UF, -WAkg, -MkAdvUF1}) &m : 
+    (forall (O <: OrclInd{-A}),
        islossless O.keygen => islossless O.sign =>
        islossless O.pkeys => islossless O.verify => islossless A(O).main) =>
     `| Pr[IndSig(RealSigServ, A).main() @ &m : res] -

--- a/theories/crypto/prp_prf/Strong_RP_RF.eca
+++ b/theories/crypto/prp_prf/Strong_RP_RF.eca
@@ -189,8 +189,8 @@ qed.
      restricted oracles into a security statement about restricted
      adversaries. **)
 section Upto.
-  declare module D <: Distinguisher {PRPi, ARP}.
-  declare axiom D_ll (O <: SPRP_Oracles {D}): islossless O.f => islossless O.fi => islossless D(O).distinguish.
+  declare module D <: Distinguisher {-PRPi, -ARP}.
+  declare axiom D_ll (O <: SPRP_Oracles {-D}): islossless O.f => islossless O.fi => islossless D(O).distinguish.
 
   local module PRP_indirect_bad = {
     var bad : bool
@@ -350,8 +350,8 @@ section CollisionProbability.
   (*---*) import StdBigop StdRing StdOrder.
   (*---*) import Bigreal.BRA RField RField.AddMonoid IntOrder.
 
-  declare module D <: Distinguisher {ARP, DBounder}.
-  declare axiom D_ll (O <: SPRP_Oracles {D}): islossless O.f => islossless O.fi => islossless D(O).distinguish.
+  declare module D <: Distinguisher {-ARP, -DBounder}.
+  declare axiom D_ll (O <: SPRP_Oracles {-D}): islossless O.f => islossless O.fi => islossless D(O).distinguish.
 
   local module FEL (D : Distinguisher) = {
     var c : int
@@ -494,8 +494,8 @@ section CollisionProbability.
 end section CollisionProbability.
 
 (* We pull together the results of the first two sections *)
-lemma PartialConclusion (D <: Distinguisher {PRPi, ARP, DBounder}) &m:
-  (forall (O <: SPRP_Oracles {D}), islossless O.f => islossless O.fi => islossless D(O).distinguish) =>
+lemma PartialConclusion (D <: Distinguisher {-PRPi, -ARP, -DBounder}) &m:
+  (forall (O <: SPRP_Oracles {-D}), islossless O.f => islossless O.fi => islossless D(O).distinguish) =>
   `|Pr[IND(PRPi'(Indirect),DBounder(D)).main() @ &m: res]
     - Pr[IND(ARP,DBounder(D)).main() @ &m: res]|
   <= (q^2 - q)%r / 2%r * mu uD (pred1 witness).
@@ -556,7 +556,7 @@ section PRPi_PRPi'_Indirect.
   + by proc; if=> //=; wp; call eq_Direct_Indirect.
   qed.
 
-  declare module D <: Distinguisher {PRPi}.
+  declare module D <: Distinguisher {-PRPi}.
 
   lemma pr_PRPi_PRPi'_Indirect &m:
     Pr[IND(PRPi,D).main() @ &m: res] = Pr[IND(PRPi'(Indirect),D).main() @ &m: res].
@@ -570,8 +570,8 @@ section PRPi_PRPi'_Indirect.
   qed.
 end section PRPi_PRPi'_Indirect.
 
-lemma Conclusion (D <: Distinguisher {PRPi, ARP, DBounder}) &m:
-  (forall (O <: SPRP_Oracles {D}), islossless O.f => islossless O.fi => islossless D(O).distinguish) =>
+lemma Conclusion (D <: Distinguisher {-PRPi, -ARP, -DBounder}) &m:
+  (forall (O <: SPRP_Oracles {-D}), islossless O.f => islossless O.fi => islossless D(O).distinguish) =>
   `|Pr[IND(PRPi,DBounder(D)).main() @ &m: res]
     - Pr[IND(ARP,DBounder(D)).main() @ &m: res]|
   <= (q^2 - q)%r / 2%r * mu uD (pred1 witness).

--- a/theories/datatypes/BitWord.eca
+++ b/theories/datatypes/BitWord.eca
@@ -7,7 +7,7 @@
  * -------------------------------------------------------------------- *)
 
 (* -------------------------------------------------------------------- *)
-require import Bool Core Int List.
+require import Bool Core Int Xint List.
 require (*--*) FinType Word Ring.
 
 pragma +implicits.
@@ -33,6 +33,10 @@ op onew : word = offun (fun i => true ).
 
 op (+^) (w1 w2 : word): word =
   offun (fun i => w1.[i] ^^ w2.[i]).
+
+op cxor : {int | 0 <= cxor } as ge0_cxor.
+schema cost_xor `{P} {w1 w2: word} : cost [P: w1 +^ w2] = cost[P:w1] + cost[P:w2] + N cxor.
+hint simplify cost_xor.
 
 op andw (w1 w2:word): word =
   offun (fun i => w1.[i] /\ w2.[i]).

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -3099,7 +3099,6 @@ lemma lex_total (e : 'a -> 'a -> bool):
   => (forall s1 s2, lex e s1 s2 \/ lex e s2 s1).
 proof. by move=> h; elim=> [|x1 s1 IHs1] [|x2 s2] //=; smt. qed.
 
-(* -------------------------------------------------------------------- *)
 op subseqs ['a] (xs : 'a list) : 'a list list =
   with xs = [] => [[]]
   with xs = y :: ys => map ((::) y) (subseqs ys) ++ subseqs ys.
@@ -3201,3 +3200,13 @@ move=> uq_xs; apply: uniq_flatten_map => /=.
   by case/hasP => ys [#] /alltuplesP[+ _] /alltuplesP[+ _] - -> /#.
 - by apply: range_uniq.
 qed.
+
+(* -------------------------------------------------------------------- *)
+(*                          Cost on list                                *)
+(* -------------------------------------------------------------------- *)
+schema cost_eqnil ['a] `{P} {l:'a list} : cost [P: l = []] = cost [P:l] + '1.
+hint simplify cost_eqnil.
+
+schema cost_drop ['a] `{P} {l: 'a list} : cost [P: drop 1 l] = cost [P: l] + '1.
+schema cost_head ['a] `{P} {w:'a, l:'a list} : cost [P:head w l] = cost[P:w] + cost[P:l] + '1.
+hint simplify cost_drop, cost_head.

--- a/theories/datatypes/Xint.ec
+++ b/theories/datatypes/Xint.ec
@@ -1,0 +1,38 @@
+require import Int.
+
+(* -------------------------------------------------------------------- *)
+type xint = [N of int | Inf].
+
+(* -------------------------------------------------------------------- *)
+abbrev ('0) = N 0.
+abbrev ('1) = N 1.
+
+op xopp (x:xint) = 
+  with x = N x => N (-x)
+  with x = Inf => Inf.
+
+op xadd (x y : xint) =
+  with x = N x, y = N y => N (x + y)
+  with x = N _, y = Inf => Inf
+  with x = Inf, y = N _ => Inf
+  with x = Inf, y = Inf => Inf.
+
+op xmul (x : xint) (y : xint) =
+  with x = N x, y = N y => N (x * y)
+  with x = N _, y = Inf => Inf
+  with x = Inf, y = N _ => Inf
+  with x = Inf, y = Inf => Inf.
+
+abbrev ([-])  = xopp.
+abbrev ( +  ) = xadd.
+abbrev ( - ) x y = xadd x (-y).
+abbrev ( *  ) = xmul.
+abbrev ( ** ) = fun (c : int) (x : xint) => N c * x.
+
+op is_int (x:xint) = 
+  with x = N _ => true
+  with x = Inf => false.
+
+op is_inf (x:xint) = 
+  with x = N _ => false
+  with x = Inf => true.

--- a/theories/distributions/DBool.ec
+++ b/theories/distributions/DBool.ec
@@ -19,7 +19,13 @@ clone include Distr.MFinite with
   op Support.card <- 2
   rename "dunifinE" as "dboolE_count"
   rename "dunifin" as "dbool"
+  rename "cunifin" as "cdbool"
 proof Support.enum_spec by case.
+
+op cdbool : { int | 0 <= cdbool } as ge0_cdbool.
+
+schema cost_dbool `{P} : cost [P: dbool] = N cdbool.
+hint simplify cost_dbool.
 
 lemma dboolE (E : bool -> bool):
   mu dbool E =   (if E true  then 1%r/2%r else 0%r)

--- a/theories/distributions/DInterval.ec
+++ b/theories/distributions/DInterval.ec
@@ -83,3 +83,10 @@ rewrite mulzK 1:gtr_eqF // fromintM gt0_r /=.
 rewrite  RField.invrM ?eq_fromint 1,2:gtr_eqF //.
 by rewrite RField.mulrCA RField.divff // eq_fromint gtr_eqF.
 qed.
+
+(* -------------------------------------------------------------------- *)
+op cdinterval : int -> int.
+axiom ge0_cdinterval m : 0 <= cdinterval m.
+
+schema cost_dinterval {i j : int} (k:int) : cost [ i <= j <= k - i : dinter i (j - 1)] = cost [true : i] + cost [true : j] + N (cdinterval k).
+hint simplify cost_dinterval.

--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -1547,7 +1547,7 @@ lemma dmap_dprod ['a1 'a2 'b1 'b2]
   = dmap (d1 `*` d2) (fun xy : _ * _ => (f1 xy.`1, f2 xy.`2)).
 proof.
 apply/eq_distr=> -[b1 b2]; rewrite !dprod1E !dmap1E /(\o) /=.
-by rewrite -dprodE &(mu_eq) /= => -[a1 a2] @/pred1.
+by rewrite -dprodE &(mu_eq) /= => -[a1 a2] @/pred1 /=; rewrite andaE.
 qed.
 
 lemma dprod_partition
@@ -1652,7 +1652,7 @@ elim: ds xs => [|d ds ih] xs /=; 1: rewrite djoin_nil dunitE.
 rewrite djoin_cons /= dmap1E /(\o) /=; case: xs => [|x xs] /=.
 + by rewrite add1z_neq0 1:size_ge0 /= mu0_false.
 rewrite -(@mu_eq _ (pred1 (x, xs))).
-+ by case=> y ys @/pred1 /=.
++ by case=> y ys @/pred1 /=; rewrite andaE.
 rewrite dprod1E ih BRM.big_cons /predT /=; pose B := BRM.big _ _ _.
 by rewrite (@fun_if (( * ) (mu1 d x))) /= /#.
 qed.

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -446,10 +446,10 @@ module Os : Oracle_i = {
 
 section. (* Reduction from single oracle call to sampling game *)
 
-declare module A <: Adversary {B1,Os,Count}.
+declare module A <: Adversary {-B1,-Os,-Count}.
 
 declare axiom A_ll :
-  forall (O <: Oracle{A}), islossless O.get => islossless A(O).main.
+  forall (O <: Oracle{-A}), islossless O.get => islossless A(O).main.
 
 (* global variables for eager/lazy proof *)
 local module Var = { 
@@ -518,7 +518,7 @@ logic. *)
 
 lemma sdist_oracle1 &m (d1 d2 : a distr) : 
    is_lossless d1 => is_lossless d2 =>
-  (forall (O <: Oracle_i{Count,A}), 
+  (forall (O <: Oracle_i{-Count,-A}), 
      hoare[ A(Count(O)).main : Count.n = 0 ==> Count.n <= 1]) =>
   `| Pr[Game(A,Os).main(d1) @ &m : res] - Pr[Game(A,Os).main(d2) @ &m : res] | 
   <= sdist d1 d2.
@@ -576,12 +576,12 @@ op N : { int | 0 <= N } as N_ge0.
 
 section. 
 
-declare module A <: Adversary {B1,Os,Count}.
+declare module A <: Adversary {-B1,-Os,-Count}.
 
 declare axiom A_ll :
-  forall (O <: Oracle{A}), islossless O.get => islossless A(O).main.
+  forall (O <: Oracle{-A}), islossless O.get => islossless A(O).main.
 
-declare axiom A_bound : (forall (O <: Oracle_i{A,Count}), 
+declare axiom A_bound : (forall (O <: Oracle_i{-A,-Count}), 
   hoare[ A(Count(O)).main : Count.n = 0 ==> Count.n <= N]).
 
 local clone Hybrid as Hyb with
@@ -737,7 +737,7 @@ module O2 = R2.RO.
 infrastructure (e.g., for splitting into muliple oracles *) 
 
 module type Distinguisher (O : R1.RO) = {
-  proc distinguish(_ : unit) : bool {O.get O.set O.sample}
+  proc distinguish(_ : unit) : bool {O.get, O.set, O.sample}
 }.
 
 (* TOTHINK: Calls to [sample] and [get] do not actually provide any
@@ -773,9 +773,9 @@ module Wrap (O : R1.RO) : R1.RO = {
 
 section.
 
-declare module D <: Distinguisher {Os, O1,O2, Count, B1, Wrap}.
+declare module D <: Distinguisher {-Os, -O1, -O2, -Count, -B1, -Wrap}.
 
-declare axiom D_ll : forall (O <: R1.RO{D}), 
+declare axiom D_ll : forall (O <: R1.RO{-D}), 
   islossless O.get => islossless D(O).distinguish.
 
 local module Cache (O : Oracle) : R1.RO = {
@@ -827,7 +827,7 @@ local clone N1 as N1 with
   proof*.
 
 lemma sdist_ROM  &m : 
- (forall (O <: R1.RO{Wrap,D}), 
+ (forall (O <: R1.RO{-Wrap,-D}), 
    hoare [ D(Wrap(O)).distinguish : Wrap.dom = fset0 ==> card Wrap.dom <= N]) =>
   `| Pr [R1.MainD(D,O1).distinguish() @ &m : res] - 
      Pr [R1.MainD(D,O2).distinguish() @ &m : res] |

--- a/theories/encryption/DDH_hybrid.ec
+++ b/theories/encryption/DDH_hybrid.ec
@@ -59,9 +59,9 @@ proof. proc;auto;progress;smt. qed.
 
 section.
 
-  declare module A <: H.AdvOrclb{Count,HybOrcl,DDHb}.
+  declare module A <: H.AdvOrclb{-Count,-HybOrcl,-DDHb}.
 
-  declare axiom losslessA : forall (Ob0 <: Orclb{A}) (LR <: Orcl{A}),
+  declare axiom losslessA : forall (Ob0 <: Orclb{-A}) (LR <: Orcl{-A}),
     islossless LR.orcl =>
     islossless Ob0.leaks =>
     islossless Ob0.orclL =>
@@ -81,5 +81,4 @@ section.
    apply islossless_leaks. apply islossless_orcl1. apply islossless_orcl2. apply losslessA.
    smt(n_pos).
   qed.
-
 end section.

--- a/theories/encryption/Hybrid.ec
+++ b/theories/encryption/Hybrid.ec
@@ -156,8 +156,8 @@ clone import Means as M with
     op d <- [0..max 0 (q-1)].
 
 (* In the case of 0 oracle calls, the behavor does not depend on the oracle *)
-lemma orcl_no_call (A <: AdvOrcl{Count}) (O1 <: Orcl{Count,A}) (O2 <: Orcl{Count,A}) &m p : 
-  (forall (O <: Orcl{A}), islossless O.orcl => islossless A(O).main ) => 
+lemma orcl_no_call (A <: AdvOrcl{-Count}) (O1 <: Orcl{-Count,-A}) (O2 <: Orcl{-Count,-A}) &m p : 
+  (forall (O <: Orcl{-A}), islossless O.orcl => islossless A(O).main ) => 
   islossless O1.orcl => islossless O2.orcl =>
   let p' = fun ga l r, p ga l r /\ l <= 0 in
     Pr[ AdvCount(A(OrclCount(O1))).main() @ &m : p' (glob A) Count.c res] = 
@@ -180,13 +180,13 @@ qed.
 (* Prove that it is equivalent to consider n or 1 calls to the oracle *)
 section.
 
-  declare module Ob <: Orclb    {Count,HybOrcl}.
-  declare module A <: AdvOrclb {Count,HybOrcl,Ob}.
+  declare module Ob <: Orclb   {-Count,-HybOrcl}.
+  declare module A <: AdvOrclb {-Count,-HybOrcl,-Ob}.
 
   declare axiom losslessL: islossless Ob.leaks.
   declare axiom losslessOb1: islossless Ob.orclL.
   declare axiom losslessOb2: islossless Ob.orclR.
-  declare axiom losslessA (Ob0 <: Orclb {A}) (LR <: Orcl {A}):
+  declare axiom losslessA (Ob0 <: Orclb {-A}) (LR <: Orcl {-A}):
     islossless LR.orcl =>
     islossless Ob0.leaks => islossless Ob0.orclL => islossless Ob0.orclR =>
     islossless A(Ob0, LR).main.
@@ -482,17 +482,17 @@ end section.
 (* -------------------------------------------------------------------- *)
 (* Simplified variant: Assume that A calls the oracle at most q times. *)
 section.
-  declare module Ob <: Orclb    {Count,HybOrcl}.
-  declare module A <: AdvOrclb {Count,HybOrcl,Ob}.
+  declare module Ob <: Orclb   {-Count,-HybOrcl}.
+  declare module A <: AdvOrclb {-Count,-HybOrcl,-Ob}.
 
   declare axiom A_call :
-    forall (O <: Orcl{Count,A}),
+    forall (O <: Orcl{-Count,-A}),
       hoare [ Orcln(A(Ob), O).main : true ==> Count.c <= q ].
 
   declare axiom losslessL: islossless Ob.leaks.
   declare axiom losslessOb1: islossless Ob.orclL.
   declare axiom losslessOb2: islossless Ob.orclR.
-  declare axiom losslessA (Ob0 <: Orclb{A}) (LR <: Orcl{A}):
+  declare axiom losslessA (Ob0 <: Orclb{-A}) (LR <: Orcl{-A}):
     islossless LR.orcl =>
     islossless Ob0.leaks => islossless Ob0.orclL => islossless Ob0.orclR =>
     islossless A(Ob0, LR).main.

--- a/theories/encryption/Indist.ec
+++ b/theories/encryption/Indist.ec
@@ -49,7 +49,7 @@ module OrclR (O:Orcl) = {
 }.
 
 module type Adv (O : Orcl) (LR : LR) = {
-  proc main(): bool { O.leaks O.orcl LR.orcl }
+  proc main(): bool { O.leaks, O.orcl, LR.orcl }
 }.
 
 module INDL (O : Orcl) (A : Adv) = {
@@ -117,12 +117,12 @@ module HybGame2(A:Adv) (O:Orcl) (LR:LR) = {
 }.
 
 section.
-declare module O <: Orcl {Count, HybOrcl}.
-declare module A <: Adv  {Count, O, HybOrcl}.
+declare module O <: Orcl {-Count, -HybOrcl}.
+declare module A <: Adv  {-Count, -O, -HybOrcl}.
 
 declare axiom losslessL: islossless O.leaks.
 declare axiom losslessO: islossless O.orcl.
-declare axiom losslessA (O <: Orcl{A}) (LR <: LR{A}):
+declare axiom losslessA (O <: Orcl{-A}) (LR <: LR{-A}):
   islossless LR.orcl =>
   islossless O.leaks => islossless O.orcl =>
   islossless A(O, LR).main.
@@ -193,7 +193,8 @@ have ->:   Pr[INDL(O, HybGame2(A)).main() @ &m:
       + inline OrclL(O).orcl Count.incr.
         by wp; call (: true); auto.
       by wp; call (: true); auto.
-    by wp;rnd.
+  by wp;rnd;auto; smt(q_pos).
+
   by inline *; auto.
 have ->:   Pr[INDR(O, HybGame2(A)).main() @ &m:
                 res /\ p (glob A) (glob O) HybOrcl.l /\ HybOrcl.l <= q /\ Count.c <= 1]
@@ -218,7 +219,7 @@ have ->:   Pr[INDR(O, HybGame2(A)).main() @ &m:
       + inline OrclR(O).orcl Count.incr.
         by wp; call (: true); auto.
       by wp; call (: true); auto.
-    by wp;rnd.
+  by wp;rnd;auto; smt(q_pos).
   by inline *; auto.
 have ->:   Pr[INDL(O, A).main() @ &m : res /\ p (glob A) (glob O) Count.c /\ Count.c <= q]
          = Pr[Ln(Orcl2(O), A').main() @ &m : (res /\ p (glob A) (glob O) Count.c) /\ Count.c <= q].
@@ -287,8 +288,8 @@ module INDb(O:Orcl) (A:Adv) = {
 }.
 
 section.
-declare module O <: Orcl {Count, Orclb}.
-declare module A <: Adv  {Count, O, Orclb}.
+declare module O <: Orcl {-Count, -Orclb}.
+declare module A <: Adv  {-Count, -O, -Orclb}.
 
 local module WA = {
   proc work(x : bool) : bool = {

--- a/theories/encryption/PKE_hybrid.ec
+++ b/theories/encryption/PKE_hybrid.ec
@@ -6,8 +6,11 @@
  * Distributed under the terms of the CeCILL-B-V1 license
  * -------------------------------------------------------------------- *)
 
-require import AllCore List FSet Finite Distr.
+require import AllCore List FSet Finite Distr DInterval.
 require import Indist.
+require import CHoareTactic.
+(*---*) import StdBigop.Bigint BIA Xint.
+
 
 type pkey.
 type skey.
@@ -38,10 +41,11 @@ module type LR = {
   proc orcl (m0 m1:plaintext) : ciphertext
 }.
 
-module type AdvCPA(LR:LR) = {
+module type AdvCPA (LR:LR) = {
   proc main(pk:pkey) : bool
 }.
 
+(* ==================================================================== *)
 module K = {
   var c  : int
   var pk : pkey
@@ -52,7 +56,6 @@ module K = {
 module L (S:Scheme) = {
   proc orcl (m0 m1:plaintext) : ciphertext = {
     var r : ciphertext;
-
     r   <@ S.enc(K.pk,m0);
     K.c <- K.c + 1;
     return r;
@@ -62,7 +65,6 @@ module L (S:Scheme) = {
 module R (S:Scheme) = {
   proc orcl (m0 m1:plaintext) : ciphertext = {
     var r : ciphertext;
-
     r   <@ S.enc(K.pk,m1);
     K.c <- K.c + 1;
     return r;
@@ -72,7 +74,6 @@ module R (S:Scheme) = {
 module LRb (S:Scheme) = {
   proc orcl (m0 m1:plaintext) : ciphertext = {
     var r : ciphertext;
-
     r   <@ S.enc(K.pk,K.b?m0:m1);
     K.c <- K.c + 1;
     return r;
@@ -80,23 +81,26 @@ module LRb (S:Scheme) = {
 }.
 
 module CPAL (S:Scheme) (A:AdvCPA) = {
+  module A = A(L(S))
+
   proc main():bool = {
     var b':bool;
 
     K.c         <- 0;
     (K.pk,K.sk) <@ S.kg();
-    b'          <@ A(L(S)).main(K.pk);
+    b'          <@ A.main(K.pk);
     return b';
   }
 }.
 
 module CPAR (S:Scheme) (A:AdvCPA) = {
+  module A = A(R(S))
+
   proc main():bool = {
     var b':bool;
-
     K.c         <- 0;
     (K.pk,K.sk) <@ S.kg();
-    b'          <@ A(R(S)).main(K.pk);
+    b'          <@ A.main(K.pk);
     return b';
   }
 }.
@@ -113,12 +117,6 @@ module CPA (S:Scheme) (A:AdvCPA) = {
   }
 }.
 
-clone import Indist as Ind with
-  type input <- plaintext,
-  type H.output <- ciphertext,
-  type H.inleaks <- unit,
-  type H.outleaks <- pkey. 
-
 module ToOrcl (S:Scheme) = {
   proc leaks (il:unit) : pkey = {
     (K.pk, K.sk) <@ S.kg();
@@ -132,6 +130,12 @@ module ToOrcl (S:Scheme) = {
     return c;
   }
 }.
+
+clone import Indist as Ind with
+  type input <- plaintext,
+  type H.output <- ciphertext,
+  type H.inleaks <- unit,
+  type H.outleaks <- pkey. 
 
 module ToAdv(A:AdvCPA) (O:Orcl) (LR:LR) = {
   proc main() : bool = {
@@ -156,18 +160,18 @@ module B (S:Scheme) (A:AdvCPA) (LR:LR) = {
 }.
 
 section.
-declare module S <: Scheme {K, H.Count, H.HybOrcl}.
+declare module S <: Scheme {-K, -H.Count, -H.HybOrcl}.
   (* Normaly I would like to locally
      clone Indist in the section, in that case
      restrictions at least on H.c are not needed.
      But LRB and B are used so we need to do it
    *)
 
-declare module A <: AdvCPA {K,H.Count,H.HybOrcl,S}.
+declare module A <: AdvCPA {-K,-H.Count,-H.HybOrcl,-S}.
 
 declare axiom Lkg  : islossless S.kg.
 declare axiom Lenc : islossless S.enc.
-declare axiom La   : forall (LR<:LR{A}), islossless LR.orcl => islossless A(LR).main.
+declare axiom La   : forall (LR<:LR{-A}), islossless LR.orcl => islossless A(LR).main.
 
 lemma CPA1_CPAn &m :
     0 < H.q
@@ -180,7 +184,7 @@ move=> Hq.
 have ->:   Pr[CPAL(S, A).main() @ &m : res /\ K.c <= H.q]
          = Pr[INDL(ToOrcl(S),ToAdv(A)).main() @ &m : res /\ H.Count.c <= H.q].
 + byequiv (: ={glob A, glob S}
-             ==> ={res,glob A, glob S, K.pk} /\ K.c{1} = H.Count.c{2})=> //.
+           ==> ={res,glob A, glob S, K.pk} /\ K.c{1} = H.Count.c{2})=> //.
   proc.
   inline ToAdv(A, ToOrcl(S), OrclL(ToOrcl(S))).main H.Count.init  ToOrcl(S).leaks.
   wp; call (: ={glob S, K.pk} /\ K.c{1} = H.Count.c{2}).
@@ -230,5 +234,393 @@ wp; call (: ={glob S,glob H.HybOrcl, K.pk} /\ K.c{1} = H.Count.c{2}).
   by call (: ={glob S, K.pk}); first sim.
 swap {1} [4..5] -2; inline ToOrcl(S).leaks; wp.
 by call (: true); auto; smt().
+qed.
+end section.
+
+(* ==================================================================== *)
+abstract theory WithCost.
+module K = {
+  var pk : pkey
+  var sk : skey
+  var b  : bool
+}.
+
+module L (S:Scheme) = {
+  proc orcl (m0 m1:plaintext) : ciphertext = {
+    var r : ciphertext;
+    r   <@ S.enc(K.pk,m0);
+    return r;
+  }
+}.
+
+module R (S:Scheme) = {
+  proc orcl (m0 m1:plaintext) : ciphertext = {
+    var r : ciphertext;
+    r   <@ S.enc(K.pk,m1);
+    return r;
+  }
+}.
+
+module LRb (S:Scheme) = {
+  proc orcl (m0 m1:plaintext) : ciphertext = {
+    var r : ciphertext;
+    r   <@ S.enc(K.pk,K.b?m0:m1);
+    return r;
+  }
+}.
+
+module CPAL (S:Scheme) (A:AdvCPA) = {
+  module A = A(L(S))
+
+  proc main():bool = {
+    var b':bool;
+
+    (K.pk,K.sk) <@ S.kg();
+    b'          <@ A.main(K.pk);
+    return b';
+  }
+}.
+
+module CPAR (S:Scheme) (A:AdvCPA) = {
+  module A = A(R(S))
+
+  proc main():bool = {
+    var b':bool;
+    (K.pk,K.sk) <@ S.kg();
+    b'          <@ A.main(K.pk);
+    return b';
+  }
+}.
+
+module CPA (S:Scheme) (A:AdvCPA) = {
+  proc main():bool = {
+    var b':bool;
+    K.b         <$ {0,1};
+    (K.pk,K.sk) <@ S.kg();
+    b'          <@ A(LRb(S)).main(K.pk);
+    return b';
+  }
+}.
+
+op q : { int | 0 < q } as q_gt0.
+
+clone import Indist as Ind with
+  type input <- plaintext,
+  type H.output <- ciphertext,
+  type H.inleaks <- unit,
+  type H.outleaks <- pkey,
+  op   H.q <= q
+
+  proof H.q_ge0 by apply/ltzW/q_gt0.
+
+module ToOrcl (S:Scheme) = {
+  proc leaks (il:unit) : pkey = {
+    (K.pk, K.sk) <@ S.kg();
+    return K.pk;
+  }
+
+  proc orcl (m:plaintext) : ciphertext = {
+    var c : ciphertext;
+
+    c <@ S.enc(K.pk, m);
+    return c;
+  }
+}.
+
+module ToAdv(A:AdvCPA) (O:Orcl) (LR:LR) = {
+  proc main() : bool = {
+    var pk:pkey;
+    var b':bool;
+    pk <@ O.leaks();
+    b' <@ A(LR).main(pk);
+    return b';
+  }
+}.
+module B (S:Scheme) (A:AdvCPA) (LR:LR) = {
+  proc main(pk:pkey) : bool = {
+    var b':bool;
+
+    H.HybOrcl.l0 <$ [0..H.q-1];
+    H.HybOrcl.l <- 0;
+    b' <@ A(HybOrcl2(ToOrcl(S),LR)).main(pk);
+    return b';
+  }
+}.
+
+(* Complexity of the adversary *)
+op cA : { int | 0 <= cA } as cA_pos.
+
+type cScheme = {
+  ckg  : int;
+  cenc : int;
+  cdec : int;
+}.
+
+(* Complexity of the scheme *)
+op cs : cScheme.
+axiom cs_pos : 0 <= cs.`ckg /\ 0 <= cs.`cenc /\ 0 <= cs.`cdec.
+
+schema cost_Hq `{P} : cost [P : H.q] = '0.
+hint simplify cost_Hq.
+
+section.
+declare module S<:Scheme [ kg : `{N cs.`ckg}, enc: `{N cs.`cenc}] {-K, -H.Count, -H.HybOrcl}.
+  (* Normaly I would like to locally
+     clone Indist in the section, in that case
+     restrictions at least on H.c are not needed.
+     But LRB and B are used so we need to do it
+   *)
+
+declare module A <: AdvCPA [main : `{N cA, #LR.orcl: H.q}] {-K,-H.Count,-H.HybOrcl,-S}.
+
+declare axiom La : forall (LR<:LR{-A}), islossless LR.orcl => islossless A(LR).main.
+
+local lemma cost_AL : 
+   choare [A(OrclL(ToOrcl(S))).main : H.Count.c = 0 ==> H.Count.c <= H.q] 
+   time [N (H.q * cincr H.q);
+         A.main : 1;
+         S.enc  : H.q].
+proof.
+  proc (H.Count.c = k) :
+       time [ OrclL(ToOrcl(S)).orcl k : [N (cincr H.q); S.enc : 1] ] => //.
+  + by move => />; rewrite !bigi_constz 1..2:#smt:(H.q_ge0).
+  move=> zo hzo; proc; inline *. 
+  wp := (`|H.Count.c| <= H.q); call (: true); auto => &hr />.
+  smt (cs_pos).
+qed.
+
+local lemma AL_bound : hoare [A(OrclL(ToOrcl(S))).main : H.Count.c = 0 ==> H.Count.c <= H.q].
+proof. by conseq cost_AL. qed.
+
+local lemma cost_AR : 
+   choare [A(OrclR(ToOrcl(S))).main : H.Count.c = 0 ==> H.Count.c <= H.q] 
+   time [N (H.q * cincr H.q);
+         A.main : 1;
+         S.enc  : H.q].
+proof.
+  proc (H.Count.c = k) : time
+       [ OrclR(ToOrcl(S)).orcl k : [N (cincr H.q); S.enc : 1] ] => //.
+  + by move => />; rewrite !bigi_constz 1..2:#smt:(H.q_ge0).
+  move=> zo hzo; proc; inline *; wp; call(:true); wp:=(`|H.Count.c| <= H.q); skip => &hr />.
+  smt(cs_pos).
+qed.
+
+local lemma AR_bound : hoare [A(OrclR(ToOrcl(S))).main : H.Count.c = 0 ==> H.Count.c <= H.q].
+proof. by conseq cost_AR. qed.
+
+local lemma cost_AHL : 
+   choare [A(HybOrcl2(ToOrcl(S), OrclL(ToOrcl(S)))).main : 
+       0 <= H.HybOrcl.l0 <= H.q /\ H.HybOrcl.l = 0 /\ H.Count.c = 0 ==> 
+       H.HybOrcl.l <= H.q /\ H.Count.c <= 1 ]
+    time [N (H.q * (cincr H.q + cincr 1 + cltint H.q + ceqint H.q)); S.enc : H.q; A.main : 1].
+proof.
+  proc 
+    (H.HybOrcl.l = k /\ 0 <= H.HybOrcl.l0 <= H.q /\ H.Count.c = if H.HybOrcl.l <= H.HybOrcl.l0 then 0 else 1):
+    time
+    [ HybOrcl2(ToOrcl(S), OrclL(ToOrcl(S))).orcl k : [N(cincr H.q + cincr 1 + cltint H.q + ceqint H.q); S.enc : 1] ] => //=.
+  + by rewrite !bigi_constz 1,2:#smt:(H.q_ge0).
+  + by move=> &hr /> ->.
+  + by move=> /> /#.
+  move=> zo hzo; proc; inline *.
+  wp := (`|H.HybOrcl.l| <= H.q).
+  if := (`| H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q) => //. smt().
+  + wp; call (:true; time []); auto => &hr />.
+  smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+  if := (`| H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q) => //. 
+  + wp := (`|H.Count.c| <= 1); call (:true; time []); auto => &hr />.
+    smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+  by wp; call (:true; time []); auto => &hr />; smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+qed.
+
+local lemma AHL_bound :  
+   hoare [A(HybOrcl2(ToOrcl(S), OrclL(ToOrcl(S)))).main : 
+       0 <= H.HybOrcl.l0 <= H.q /\ H.HybOrcl.l = 0 /\ H.Count.c = 0 ==> 
+       H.HybOrcl.l <= H.q /\ H.Count.c <= 1 ].
+proof. by conseq cost_AHL. qed.
+
+local lemma cost_AHR : 
+   choare [A(HybOrcl2(ToOrcl(S), OrclR(ToOrcl(S)))).main : 
+       0 <= H.HybOrcl.l0 <= H.q /\ H.HybOrcl.l = 0 /\ H.Count.c = 0 ==> 
+       H.HybOrcl.l <= H.q /\ H.Count.c <= 1 ]
+    time [N (H.q * (cincr H.q + cincr 1 + cltint H.q + ceqint H.q)); S.enc : H.q; A.main : 1].
+proof.
+  proc 
+    (H.HybOrcl.l = k /\ 0 <= H.HybOrcl.l0 <= H.q /\ H.Count.c = if H.HybOrcl.l <= H.HybOrcl.l0 then 0 else 1): time
+    [ HybOrcl2(ToOrcl(S), OrclR(ToOrcl(S))).orcl k : [N (cincr H.q + cincr 1 + cltint H.q + ceqint H.q); S.enc : 1] ] => //=.
+  + by rewrite !bigi_constz 1,2:#smt:(H.q_ge0).
+  + by move=> &hr /> ->.
+  + by move=> /> /#.
+  move=> zo hzo; proc; inline *.
+  wp := (`|H.HybOrcl.l| <= H.q).
+  if := (`| H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q)=> //; 1: smt().
+  + wp; call (:true; time []); auto => &hr />; smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+  if := (`| H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q)=> //.
+  + wp; call (:true; time []); wp := (`|H.Count.c| <= 1); skip => &hr />.
+    smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+  by wp; call (:true; time []); auto => &hr />; smt (ge0_cincr ge0_cltint ge0_ceqint cs_pos).
+qed.
+
+local lemma AHR_bound :  
+   hoare [A(HybOrcl2(ToOrcl(S), OrclR(ToOrcl(S)))).main : 
+       0 <= H.HybOrcl.l0 <= H.q /\ H.HybOrcl.l = 0 /\ H.Count.c = 0 ==> 
+       H.HybOrcl.l <= H.q /\ H.Count.c <= 1 ].
+proof. by conseq cost_AHR. qed.
+
+lemma CPA1_CPAn &m :
+  Pr[CPAL(S,B(S,A)).main() @ &m : res] -
+  Pr[CPAR(S,B(S,A)).main() @ &m : res] =
+  1%r/H.q%r * (Pr[CPAL(S,A).main() @ &m : res] - Pr[CPAR(S,A).main() @ &m : res]).
+proof.
+  have -> : Pr[CPAL(S, A).main() @ &m : res] =
+            Pr[INDL(ToOrcl(S),ToAdv(A)).main() @ &m : res].
+    byequiv (_ : ={glob A, glob S} ==>
+                      ={res,glob A, glob S, K.pk}) => //.
+    proc.
+    inline ToAdv(A, ToOrcl(S), OrclL(ToOrcl(S))).main H.Count.init ToOrcl(S).leaks.
+    wp;call (_: ={glob S, K.pk}).
+      by proc;inline ToOrcl(S).orcl H.Count.incr;wp;call (_:true);wp.
+    by wp;call (_:true);wp.
+  have -> : Pr[CPAR(S, A).main() @ &m : res] =
+            Pr[INDR(ToOrcl(S),ToAdv(A)).main() @ &m : res].
+    byequiv (_ : ={glob A, glob S} ==>
+                      ={res,glob A, glob S, K.pk}) => //.
+    proc.
+    inline ToAdv(A, ToOrcl(S), OrclR(ToOrcl(S))).main H.Count.init  ToOrcl(S).leaks.
+    wp;call (_: ={glob S, K.pk}).
+      by proc;inline ToOrcl(S).orcl H.Count.incr;wp;call (_:true);wp.
+    by wp;call (_:true);wp.
+  have := IND1_INDn (ToOrcl(S)) (ToAdv(A)) _ _ _ q_gt0 &m (fun ga go c, true) => //=.
+  + have h : choare [ToOrcl(S).leaks : true ==> true] time ['0; S.kg:1].
+    + by proc; call (_:true); skip => /=; smt(cs_pos).
+    conseq h.
+  + have h : choare [ToOrcl(S).orcl : true ==> true] time ['0; S.enc:1].
+    + by proc; call (_:true); skip => /=; smt(cs_pos).
+    conseq h.
+    move=> O LR Llr Ll Lo;proc;call (La LR _) => //.
+    by call Ll.
+  have -> : Pr[INDL(ToOrcl(S), ToAdv(A)).main() @ &m : res /\ H.Count.c <= H.q] =
+            Pr[INDL(ToOrcl(S), ToAdv(A)).main() @ &m : res].
+  + byequiv => //.
+    conseq (_: ={glob A,glob S} ==> ={res}) (_: true ==> H.Count.c <= H.q) => //; last by sim.
+    proc; inline *; wp. by call AL_bound; wp; call (:true); wp.
+  have -> : Pr[INDR(ToOrcl(S), ToAdv(A)).main() @ &m : res /\ H.Count.c <= H.q] =
+            Pr[INDR(ToOrcl(S), ToAdv(A)).main() @ &m : res].
+  + byequiv => //.
+    conseq (_: ={glob A,glob S} ==> ={res}) (_: true ==> H.Count.c <= H.q) => //; last by sim.
+    by proc; inline *; wp; call AR_bound; wp; call(:true); auto.
+  move=> <-; congr; last congr.
+  + have -> : Pr[INDL(ToOrcl(S), HybGame2(ToAdv(A))).main() @ &m : res /\ H.HybOrcl.l <= H.q /\ H.Count.c <= 1] =
+              Pr[INDL(ToOrcl(S), HybGame2(ToAdv(A))).main() @ &m : res ].
+    + byequiv => //.
+      conseq (_: ={glob A,glob S} ==> ={res}) (_: true ==>  H.HybOrcl.l <= H.q /\ H.Count.c <= 1) => //; last by sim.
+      proc; inline *; wp; call AHL_bound; auto; call(:true); auto=> />.
+      smt (DInterval.supp_dinter q_gt0).
+    byequiv (_: ={glob S,glob A} ==> ={res,glob H.HybOrcl}) => //.
+    proc.
+    inline
+      H.Count.init
+      CPAL(S, B(S, A)).A.main
+      HybGame2(ToAdv(A), ToOrcl(S), OrclL(ToOrcl(S))).main.
+    inline ToAdv(A, ToOrcl(S), HybOrcl2(ToOrcl(S), OrclL(ToOrcl(S)))).main.
+    wp.
+    call (_: ={glob S,glob H.HybOrcl, K.pk}).
+      proc;wp.
+      if => //.
+        by call (_: ={glob S, K.pk});first sim.
+      if => //.
+        call (_: ={glob S, K.pk}) => //.
+        by inline ToOrcl(S).orcl H.Count.incr;wp;call (_: true);wp.
+      by call (_: ={glob S, K.pk});first sim.
+    swap{1} [3..4] -2;inline ToOrcl(S).leaks;wp.
+    by call (_:true); auto=> />; smt(DInterval.supp_dinter q_gt0).
+  have -> : Pr[INDR(ToOrcl(S), HybGame2(ToAdv(A))).main() @ &m : res /\ H.HybOrcl.l <= H.q /\ H.Count.c <= 1] =
+            Pr[INDR(ToOrcl(S), HybGame2(ToAdv(A))).main() @ &m : res].
+  + byequiv => //.
+    conseq (_: ={glob A,glob S} ==> ={res}) (_: true ==>  H.HybOrcl.l <= H.q /\ H.Count.c <= 1) => //; last by sim.
+    proc; inline *; wp; call AHR_bound; auto; call(:true); auto.
+    smt (DInterval.supp_dinter q_gt0).
+  byequiv (_: ={glob S,glob A} ==> ={res,glob H.HybOrcl}) => //.
+  proc.
+  inline
+    H.Count.init
+    CPAR(S, B(S,A)).A.main
+    HybGame2(ToAdv(A), ToOrcl(S), OrclR(ToOrcl(S))).main.
+  inline ToAdv(A, ToOrcl(S), HybOrcl2(ToOrcl(S), OrclR(ToOrcl(S)))).main.
+  wp. 
+  call (_: ={glob S,glob H.HybOrcl, K.pk}).
+    proc;wp.
+    if => //.
+      by call (_: ={glob S, K.pk});first sim.
+    if => //.
+      call (_: ={glob S, K.pk}) => //.
+      by inline ToOrcl(S).orcl H.Count.incr;wp;call (_: true);wp.
+    by call (_: ={glob S, K.pk});first sim.
+  swap{1} [3..4] -2;inline ToOrcl(S).leaks;wp.
+  by call (_:true); auto=> />; smt (DInterval.supp_dinter q_gt0).
+qed.
+
+lemma big_b2i ['a] (P:'a -> bool) s : big predT (fun k => b2i (P k)) s = big P (fun _ => 1) s.
+proof. by rewrite (big_mkcond P); apply congr_big. qed.
+
+lemma bigi_b2i_split (k n m:int) P (F:int -> int):
+  n <= k < m =>
+  bigi P F n m = bigi P F n k + b2i (P k) * F k + bigi P F (k+1) m.
+proof.
+  move=> h; rewrite (big_cat_int k n m) 1,2:/#.
+  rewrite (big_ltn_cond k m) 1:/# /b2i; case: (P k) => *; ring.
+qed.
+
+lemma bigi_inP (n m:int) P (F:int -> int):
+  (forall i, n <= i < m => P i) =>
+  bigi P F n m = bigi predT F n m.
+proof. by move=> h; apply congr_big_int => // i /h ->. qed.
+
+lemma bigi1 (n m:int) P (F:int -> int):
+  (forall i, n <= i < m => P i => F i = 0) =>
+  bigi P F n m = 0.
+proof.
+  by move=> h; apply big1_seq => i [] hP /mem_range hin; apply h.
+qed.
+
+lemma ex_CPA1_CPAn &m : 
+  exists (B <: AdvCPA {+A,+H.HybOrcl, +K, +S}),
+    (forall (clr:int) (MLR<:LR [orcl: `{N clr}] {-H.HybOrcl}),          
+       choare[B(MLR).main : true ==> true] time
+                [ N (H.q * (cincr H.q + ceqint H.q + cltint H.q) + cdinterval H.q);
+                  S.enc: (H.q - 1);
+                  A.main : 1;
+                  MLR.orcl : 1]) /\
+    Pr[CPAL(S,A).main() @ &m : res] - Pr[CPAR(S,A).main() @ &m : res] =
+    H.q%r * (Pr[CPAL(S,B).main() @ &m : res] - Pr[CPAR(S,B).main() @ &m : res]).
+proof.
+  exists (B(S,A)); split; last by have -> := CPA1_CPAn &m; field; smt (q_gt0).
+  move=> clr MLR.
+  proc. 
+  seq 2 : (H.HybOrcl.l =0 /\ 0 <= H.HybOrcl.l0 < H.q) time [ N (H.q * (cincr H.q + ceqint H.q + cltint H.q));
+                                                             S.enc : (H.q - 1);
+                                                             A.main : 1;
+                                                             MLR.orcl : 1] => //.
+  + wp. 
+    instantiate /(_ H.q) /= h := (cost_dinterval {b' : bool, pk : pkey} 0 H.q).
+    rnd (0 <= H.q <= H.q - 0); 1: by rewrite h.
+    skip => &hr />.
+    rewrite h /=.
+    smt (DInterval.supp_dinter DInterval.dinter_ll q_gt0).
+  exlim H.HybOrcl.l0 => l0. 
+  call (: (H.HybOrcl.l = k /\ 0 <= H.HybOrcl.l0 <= H.q /\ l0 = H.HybOrcl.l0); time 
+    [ HybOrcl2(ToOrcl(S), MLR).orcl k : [N (cincr H.q + ceqint H.q + cltint H.q); 
+                                           S.enc : b2i (k <> l0); MLR.orcl : b2i(k=l0)] ]) => //=.
+  + move=> zo hzo; proc; inline *; wp := (`|H.HybOrcl.l| <= H.q).
+    if := (`|H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q) => //; 1: smt().
+    + by wp; call (:true; time []); auto => &hr />; smt (ge0_ceqint). 
+    if := (`|H.HybOrcl.l0| <= H.q /\ `|H.HybOrcl.l| <= H.q) => //. 
+    + wp; call(:true; time []); auto => &hr /> /#.
+    by wp; call (:true; time []); auto => &hr /> /#. 
+  rewrite /=.
+  skip => &hr />; move: (H.HybOrcl.l0{hr}) => {l0}l0 h0 hq .
+  rewrite bigi_constz 1:#smt:(q_gt0) /=.
+  rewrite !big_b2i !(bigi_b2i_split l0 0 H.q) 1,2:// /b2i /=.
+  rewrite !(bigi_inP _ _ (fun (k : int) => k <> l0)) 1,2:/# !bigi_constz 1:// 1:/#.
+  by rewrite !bigi1 /= /#.
 qed.
 end section.

--- a/theories/modules/RndProd.eca
+++ b/theories/modules/RndProd.eca
@@ -98,7 +98,7 @@ module O2 (Oa : ROa.RO) (Ob : ROb.RO) = {
 
 section.
 declare module D <: 
-  Distinguisher { ROa.RO, ROa.FRO, ROb.RO, ROb.FRO, ROab.RO, ROab.FRO }.
+  Distinguisher { -ROa.RO, -ROa.FRO, -ROb.RO, -ROb.FRO, -ROab.RO, -ROab.FRO }.
 
 local module O3 (Oa : ROa.RO) (Ob : ROb.RO) = {
   proc init () = {

--- a/theories/newth/SmtMap.ec
+++ b/theories/newth/SmtMap.ec
@@ -193,7 +193,7 @@ op empty ['a 'b] : ('a, 'b) fmap = ofmap (cst None).
 
 lemma nosmt empty_valE ['a, 'b] : tomap empty<:'a, 'b> = cst None.
 proof.
-by rewrite /empty ofmapK //; exists [] => /=.
+by rewrite /empty ofmapK //; exists [] => /= *; rewrite Map.cstE.
 qed.
 
 (* -------------------------------------------------------------------- *)
@@ -832,6 +832,60 @@ rewrite !(restrP, remE); rewrite /in_dom_with; case (z = x)=> // ->.
 rewrite negb_and => -[Nxm|]; first by rewrite (iffLR _ _ (domNE m x)).
 by case: m.[x] => //= x' ->.
 qed.
+
+(* --------------------------------------------------------------------------- *)
+(* Some definitions for cost of operations in fmap                             *)
+(* --------------------------------------------------------------------------- *)
+
+schema cost_empty ['a 'b] `{P} :
+  cost [P: empty<:'a, 'b>] = '1.
+hint simplify cost_empty.
+
+op bounded ['from 'to] (m : ('from, 'to)fmap) (size:int) = 
+   card (fdom m) <= size.
+
+lemma bounded_set ['from 'to] (m : ('from, 'to)fmap) (size:int) x e : 
+  bounded m size => bounded (m.[x<-e]) (size + 1).
+proof. by rewrite /bounded fdom_set fcardU fcard1; smt (fcard_ge0). qed.
+
+lemma bounded_empty ['from 'to] : bounded empty<:'from, 'to> 0.
+proof. by rewrite /bounded fdom0 fcards0. qed.
+
+(* This theory assume that the type of key for map is finite *)
+abstract theory FMapCost.
+  type from.
+  op cget : int -> int.
+  op cset : int -> int.
+  op cin  : int -> int.
+
+  axiom cget_pos (x:int) : 0 <= cget x.
+  axiom cset_pos (x:int) : 0 <= cset x.
+  axiom cin_pos (x:int) : 0 <= cin x.
+
+  schema cost_get_P ['b] `{P} {m:(from, 'b) fmap, x:from} (max_size: int):
+    cost [P /\ bounded m max_size : m.[x]] = cost[P:m] + cost[P:x] + N (cget max_size).
+  hint simplify cost_get_P.
+
+  schema cost_set_P ['b] `{P} {m:(from, 'b) fmap, x:from, e:'b} (max_size : int) :
+    cost [P /\ bounded m max_size : m.[x<-e]] = cost[P:m] + cost[P:x] + cost[P:e] + N (cset max_size).
+
+  schema cost_in_P ['b] `{P} {m:(from, 'b) fmap, x:from} (max_size : int) :
+    cost [P /\ bounded m max_size: x \in m] = cost[P:m] + cost[P:x] + N (cin max_size).
+
+  hint simplify cost_get_P, cost_set_P, cost_in_P.
+
+  schema cost_get ['b] {m:(from, 'b) fmap, x:from} (max_size:int) :
+    cost [bounded m max_size : m.[x]] = cost[true:m] + cost[true:x] + N (cget max_size).
+
+  schema cost_set ['b] {m:(from, 'b) fmap, x:from, e:'b} (max_size:int) :
+    cost [bounded m max_size : m.[x<-e]] = cost[true:m] + cost[true:x] + cost[true:e] + N (cset max_size).
+
+  schema cost_in ['b] {m:(from, 'b) fmap, x:from} (max_size:int):
+    cost [bounded m max_size: x \in m] = cost[true:m] + cost[true:x] + N (cin max_size).
+
+  hint simplify cost_get, cost_set, cost_in.
+
+end FMapCost.
 
 (* -------------------------------------------------------------------- *)
 (*                             Merging map                              *)

--- a/theories/oldlibs/CyclicGroup.ec
+++ b/theories/oldlibs/CyclicGroup.ec
@@ -5,7 +5,7 @@
  *
  * Distributed under the terms of the CeCILL-B-V1 license
  * -------------------------------------------------------------------- *)
-
+require import Int Xint.
 require PrimeField.
 
 clone export PrimeField as FD.
@@ -20,10 +20,24 @@ op ( ^ ): group -> t -> group.       (* exponentiation *)
 op log  : group -> t.                (* discrete logarithm *)
 op g1 = g ^ F.zero.
 
+op cgpow :  int.
+op cgmul: int.
+op cgdiv: int.
+op cgeq : int.
+axiom ge0_cg : 0 <= cgpow /\ 0 <= cgmul /\ 0 <= cgdiv /\ 0 <= cgeq.
+
+schema cost_gen `{P} : cost [P:g] = '0.
+schema cost_pow `{P} {g:group, x:t} : cost[P: g ^ x] = cost[P:g] + cost[P:x] + N cgpow.
+schema cost_gmul `{P} {g1 g2:group} : cost[P:g1 * g2] = cost[P:g1] + cost[P:g2] + N cgmul.
+schema cost_geq  `{P} {g1 g2:group} : cost[P:g1 = g2] = cost[P:g1] + cost[P:g2] + N cgeq.
+schema cost_gdiv `{P} {g1 g2:group} : cost[P:g1 / g2] = cost[P:g1] + cost[P:g2] + N cgdiv.
+
+hint simplify cost_gen, cost_pow, cost_gmul, cost_gdiv, cost_geq.
+
 axiom gpow_log (a:group): g ^ (log a) = a.
 axiom log_gpow x : log (g ^ x) = x.
 
-lemma nosmt log_bij x y: x = y <=> log x = log y by smt full.
+lemma nosmt log_bij x y: x = y <=> log x = log y by smt (gpow_log).
 lemma nosmt pow_bij (x y:F.t): x = y <=> g^x =g^y by [].
 
 

--- a/theories/oldlibs/PrimeField.ec
+++ b/theories/oldlibs/PrimeField.ec
@@ -7,6 +7,7 @@
  * -------------------------------------------------------------------- *)
 
 require Int IntDiv.
+require import Xint.
 
 
   (* prime fields GF(q) for q prime *)
@@ -185,6 +186,9 @@ theory FDistr.
   require import Real.
   (* distrinution *)
   op dt: t distr.
+  op cdt : {int | 0 <= cdt } as ge0_cdt.
+  schema cost_dt `{P}: cost [P: dt] = N cdt.
+  hint simplify cost_dt.
 
   axiom dt_fu: is_full dt.
 
@@ -197,5 +201,23 @@ theory FDistr.
 
   hint exact random : dt_fu dt_ll dt_funi.
 
+
 end FDistr.
 
+(* ------------------------------------------------------------------------- *)
+op cfeq  : int.
+op cfadd : int.
+op cfsub : int.
+op cfmul : int.
+op cfdiv : int.
+
+axiom ge0_cf : 0 <= cfeq /\ 0 <= cfadd /\ 0 <= cfsub /\ 0 <= cfmul /\ 0 <= cfdiv /\ 0 <= FDistr.cdt.
+
+schema cost_F0 `{P} : cost[P:F.zero] = '0.
+schema cost_feq `{P} {x y : t} : cost [P: x = y] = cost[P:x] + cost[P:y] + N cfeq.
+schema cost_fadd `{P} {x1 x2:t} : cost[P:x1 + x2] = cost[P:x1] + cost[P:x2] + N cfadd.
+schema cost_fsub `{P} {x y: t} : cost [P:x - y] = cost[P:x] + cost[P:y] + N cfsub.
+schema cost_fmul `{P} {x1 x2:t} : cost[P:x1 * x2] = cost[P:x1] + cost[P:x2] + N cfmul.
+schema cost_fdiv `{P} {x y: t} : cost [P:x / y] = cost[P:x] + cost[P:y] + N cfdiv.
+
+hint simplify cost_F0, cost_feq, cost_fadd, cost_fsub, cost_fmul, cost_fdiv.

--- a/theories/query_counting/Counter.eca
+++ b/theories/query_counting/Counter.eca
@@ -43,7 +43,8 @@ module Counter(S : System) = {
 
 section.
   declare module S <: System.
-  declare module D <: Distinguisher { S }.
+  declare module D <: Distinguisher { -S }.
+
 
   lemma ind_counting (E : (glob S) -> bool) &m:
       Pr[D(S).distinguish() @ &m: E (glob S)]
@@ -61,14 +62,14 @@ end section.
 op q : { int | 0 <= q } as ge0_q.
 
 section.
-  declare module D <: Distinguisher { Counter }.
+  declare module D <: Distinguisher { -Counter }.
 
-  declare axiom D_bounded (S <: System { Counter, D }) c0 &m:
+  declare axiom D_bounded (S <: System { -Counter, -D }) c0 &m:
     islossless S.oracle =>
     Counter.c{m} = c0 =>
     Pr[D(Counter(S)).distinguish() @ &m : Counter.c <= c0 + q] = 1%r.
 
-  lemma D_ll (S <: System { Counter, D }):
+  lemma D_ll (S <: System { -Counter, -D }):
     islossless S.oracle => islossless D(Counter(S)).distinguish.
   proof.
   move=> S_ll.
@@ -78,7 +79,7 @@ section.
   by rewrite -pr_E1 Pr [mu_sub].
   qed.
 
-  lemma D_bounded_hoare (S <: System { Counter, D }) c0:
+  lemma D_bounded_hoare (S <: System { -Counter, -D }) c0:
     islossless S.oracle =>
     hoare [D(Counter(S)).distinguish: Counter.c = c0 ==> Counter.c <= c0 + q].
   proof.

--- a/theories/query_counting/OracleBounds.ec
+++ b/theories/query_counting/OracleBounds.ec
@@ -50,7 +50,7 @@ module Count (O:Oracle) = {
 }.
 
 section.
-  declare module O <: Oracle {Count}.
+  declare module O <: Oracle {-Count}.
 
   lemma CountO_fL: islossless O.f => islossless Count(O).f.
   proof strict.
@@ -102,11 +102,11 @@ module IND (O:Oracle, A:Adv) = {
 }.
 
 section.
-  declare module O <: Oracle {Count}.
+  declare module O <: Oracle {-Count}.
   declare axiom O_fL: islossless O.f.
 
-  declare module A <: Adv {Count(O)}.
-  declare axiom A_distinguishL (O <: Oracle {A}):
+  declare module A <: Adv {-Count(O)}.
+  declare axiom A_distinguishL (O <: Oracle {-A}):
     islossless O.f =>
     islossless A(O).distinguish.
 
@@ -139,11 +139,12 @@ theory EnfPen.
   }.
 
   section.
-    declare module O <: Oracle {Count}.
+    declare module O <: Oracle {-Count}.
     declare axiom O_fL: islossless O.f.
 
-    declare module A <: Adv {Count(O)}.
-    declare axiom A_distinguishL (O <: Oracle {A}):
+    declare module A <: Adv {-Count(O)}.
+    declare axiom A_distinguishL (O <: Oracle {-A}):
+
       islossless O.f =>
       islossless A(O).distinguish.
 
@@ -182,11 +183,11 @@ theory PenBnd.
   axiom leq0_bound: 0 <= bound.
 
   section.
-    declare module O <: Oracle {Count}.
+    declare module O <: Oracle {-Count}.
     declare axiom O_fL: islossless O.f.
 
-    declare module A <: Adv {Count(O)}.
-    declare axiom A_distinguishL (O <: Oracle {A}):
+    declare module A <: Adv {-Count(O)}.
+    declare axiom A_distinguishL (O <: Oracle {-A}):
       islossless O.f =>
       islossless A(O).distinguish.
     declare axiom A_distinguishC:
@@ -226,11 +227,11 @@ theory BndPen.
   module EnforcedAdv (A:Adv, O:Oracle) = A(Enforce(O)).
 
   section.
-    declare module O <: Oracle {Count}.
+    declare module O <: Oracle {-Count}.
     declare axiom O_fL: islossless O.f.
 
-    declare module A <: Adv {Count(O)}.
-    declare axiom A_distinguishL (O <: Oracle {A}):
+    declare module A <: Adv {-Count(O)}.
+    declare axiom A_distinguishL (O <: Oracle {-A}):
       islossless O.f =>
       islossless A(O).distinguish.
 

--- a/theories/structure/Discrete.ec
+++ b/theories/structure/Discrete.ec
@@ -134,7 +134,7 @@ theory IntPair.
        0 <= n1 => 0 <= p1
     => 0 <= n2 => 0 <= p2
     => exp 2 n1 * exp 3 p1 = exp 2 n2 * exp 3 p2
-    => n1 = n2 /\ p1 = p2.
+    => n1 = n2 && p1 = p2.
   proof.
   move=> ge0_n1 ge0_p1 ge0_n2 ge0_p2; case: (n1 = n2) => /= [<-|neq_n].
   (* FIXME: move/ieexprIn fails *)

--- a/theories/tactics/CHoareTactic.ec
+++ b/theories/tactics/CHoareTactic.ec
@@ -1,0 +1,190 @@
+(* --------------------------------------------------------------------
+ * Copyright (c) - 2012--2016 - IMDEA Software Institute
+ * Copyright (c) - 2012--2018 - Inria
+ * Copyright (c) - 2012--2018 - Ecole Polytechnique
+ *
+ * Distributed under the terms of the CeCILL-B-V1 license
+ * -------------------------------------------------------------------- *)
+
+(* -------------------------------------------------------------------- *)
+require import AllCore List Ring StdOrder StdBigop.
+require (*--*) Bigop.
+(*---*) import IntID IntOrder Bigint.
+
+(* This lemma ensure the correctness of our rules for seq, wp ... *)
+lemma subrK (x y : xint) : is_inf x \/ is_int y => (x - y) + y = x.
+proof. case y => //; case x => //= *; ring. qed.
+
+(* -------------------------------------------------------------------- *)
+lemma add0x : left_id '0 xadd.
+proof. by case. qed.
+
+lemma addx0 : right_id '0 xadd.
+proof. by case. qed.
+
+hint simplify [reduce] add0x, addx0.
+
+lemma addxA : associative xadd.
+proof. by case=> [x|] [y|] [z|] => //=; rewrite addrA. qed.
+
+lemma addxC : commutative xadd.
+proof. by case=> [x|] [y|] => //=; rewrite addrC. qed.
+
+(* -------------------------------------------------------------------- *)
+lemma mul1x : left_id '1 xmul.
+proof. by case. qed.
+
+lemma mulx1 : right_id '1 xmul.
+proof. by case. qed.
+
+lemma mulxA : associative xmul.
+proof. by case=> [x|] [y|] [z|] => //=; rewrite mulrA. qed.
+
+lemma mulxC : commutative xmul.
+proof. by case=> [x|] [y|] => //=; rewrite mulrC. qed.
+
+(* -------------------------------------------------------------------- *)
+
+lemma xaddInfx (x:xint) : Inf + x = Inf.
+proof. by case: x. qed.
+
+lemma xaddxInf (x:xint) : x + Inf = Inf.
+proof. by case: x. qed.
+
+lemma xmulInfx (x:xint) : Inf * x = Inf.
+proof. by case: x. qed.
+
+lemma xmulxInf (x:xint) : x * Inf = Inf.
+proof. by case: x. qed.
+
+hint simplify xaddInfx, xaddxInf, xmulInfx, xmulxInf.
+
+(* -------------------------------------------------------------------- *)
+op xle (x y : xint) =
+  with x = N x, y = N y => (x <= y)
+  with x = N x, y = Inf => true
+  with x = Inf, y = N y => false
+  with x = Inf, y = Inf => true.
+
+abbrev (<=) = xle.
+
+lemma lexx : reflexive (<=).
+proof. by case. qed.
+
+lemma lexx_rw (x y : xint) : x = y => x <= y.
+proof. by move=> ->; apply lexx. qed.
+
+hint simplify lexx_rw.
+
+lemma lex_anti (x y : xint) : x <= y <= x => x = y.
+proof. by case: x y => [x|] [y|] //=; apply: ler_anti. qed.
+
+lemma lex_trans : transitive (<=).
+proof. by case=> [x|] [y|] [z|] //=; apply: ler_trans. qed.
+
+lemma lex_inf (x : xint) : x <= Inf.
+proof. by case: x. qed.
+
+lemma lex_add2r (x1 x2 y : xint) :
+  x1 <= x2 => x1 + y <= x2 + y.
+proof.
+by case: x1 x2 y => [x1|] [x2|] [y|] //=; apply: ler_add2r.
+qed.
+
+lemma is_int_le x y : x <= y => is_int y => is_int x.
+proof. by case: x => //; case: y. qed.
+
+lemma lex_add2l (x1 x2 y : xint) :
+  x1 <= x2 => y + x1 <= y + x2.
+proof. by rewrite !(@addxC y) &(lex_add2r). qed.
+
+op xmax (x y : xint) = 
+  with x = N x, y = N y => N (max x y)
+  with x = N _, y = Inf => Inf
+  with x = Inf, y = N _ => Inf
+  with x = Inf, y = Inf => Inf.
+
+lemma sub_completness (t1 t2 t:xint) : 
+   t1 + t2 <= t <=>
+   t1 <= t - t2 /\ (is_int t2 \/ is_inf t).
+proof.
+  case: t t1 t2 => [i | ] [i1 | ] [i2 | ] //=; smt().
+qed.
+
+(* -------------------------------------------------------------------- *)
+theory Bigxint.
+clone include Bigop
+  with type t <- xint,
+         op Support.idm <- ('0),
+         op Support.(+) <- xadd
+  proof *.
+
+realize Support.Axioms.addmA by exact/addxA.
+realize Support.Axioms.addmC by exact/addxC.
+realize Support.Axioms.add0m by exact/add0x.
+
+lemma nosmt big_morph_N (P : 'a -> bool) (f : 'a -> int) s:
+  big P (fun i => N (f i)) s = N (BIA.big P (fun i => f i) s).
+proof.
+elim: s => [|x s ih] //=.
+by rewrite !(big_cons, BIA.big_cons) ih /=; case: (P x).
+qed.
+
+lemma nosmt big_const_Nx (P : 'a -> bool) x s:
+  big P (fun _ => N x) s = (count P s) ** N x.
+proof. by rewrite big_morph_N /= big_constz mulrC. qed.
+
+lemma nosmt big_constx (P : 'a -> bool) x s: x <> Inf =>
+  big P (fun _ => x) s = (count P s) ** x.
+proof. by case: x => //= x; apply: big_const_Nx. qed.
+
+lemma big_constNz x (s: 'a list) :
+  big predT (fun _ => N x) s = N (size s * x).
+proof. by rewrite big_const_Nx count_predT. qed.
+
+lemma bigi_constz x (n m:int) : 
+   n <= m =>
+   bigi predT (fun _ => N x) n m = N ((m - n) * x).
+proof. by move=> hnm;rewrite big_constNz size_range /#. qed.
+
+end Bigxint.
+export Bigxint.
+
+(* ------------------------------------------------------------------------------ *)
+lemma is_int_xopp (x:xint) : is_int x => is_int (-x).
+proof. by case: x. qed.
+
+lemma is_int_xadd (x y: xint) : 
+  is_int x => is_int y => is_int (x + y).
+proof. by case: x; case y. qed.
+
+lemma is_int_xmul (x y: xint) : 
+  is_int x => is_int y => is_int (x * y).
+proof. by case: x; case y. qed.
+
+hint simplify is_int_xopp, is_int_xadd, is_int_xmul.
+
+lemma is_int_big (P: 'a -> bool) (f:'a -> xint) (s:'a list) : 
+    (forall x, is_int (f x)) =>
+    is_int (big P f s).
+proof.
+  move=> h; elim: s. 
+  + by rewrite big_nil.
+  move=> x l hl; rewrite big_cons; case: (P x) => ? //.
+  by apply is_int_xadd => //; apply h.
+qed.
+
+hint simplify is_int_big.
+
+(* -------------------------------------------------------------------- *)
+lemma N_D (x y : int) : N (x + y) = N x + N y.
+proof. by []. qed.
+
+lemma N_N (x : int) : N (-x) = -N x.
+proof. by []. qed.
+
+lemma N_B (x y : int) : N (x-y) = N x - N y.
+proof. by []. qed.
+
+lemma mono_N_le (x y : int): x <= y <=> N x <= N y.
+proof. by []. qed.


### PR DESCRIPTION
** Breaking change:

- to be consistent with oracle calls restrictions,
  negative memory restrictions are now set using a minus symbol
  (e.g. `(M <: T {-H})` instead of `(M <: T {H})`).

- use `pragma +old_mem_restr` to retrieve old behaviour on memory restrictions

** Additions:
- added a new hoare logic for cost, using predicates of
  the form `choare [H.f: pre ==> post] time [c]`, meaning:

  from any initial memory satisfying `pre`, the final memory obtained
  after the execution of `H.f` satisfies `post`, in time at most `c`

- in choare predicates, the cost `c` is a cost-vector, comprising:

  + a concrete cost of type `xint`, where `xint` is a algebraic data-type
    with two constructors, `N of int` (for bounded running times) and `Inf`
    (for potentially unbounded running times).

  + a list of abstract procedures together with an integer indicated the
    number of times they can be called (e.g. `ROM.o : 42`).

- complexity restrictions can be attached to module types procedures,
  restricting their instantiations.

- added a new predicate, `cost`, to establish the cost of evaluating an
  expression (while `choare` upper-bound the cost of a statement).

- (small) examples showing how to use the cost hoare logic can be found
  in the sub-directory `examples/cost/`

- more advanced examples, using a new UC framework in EasyCrypt, can
  be found in

  `examples/UC/composition_cost.ec`

  `examples/UC/dh_enc_cost.ec`