### PR TITLE
various small lemmas (Logic, FSet, Distr, DInterval, Bigop) 

### DIFF
--- a/theories/algebra/Bigop.eca
+++ b/theories/algebra/Bigop.eca
@@ -346,10 +346,12 @@ proof. by rewrite -bigU 1:/#; apply: eq_bigl => /#. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt big_reindex ['a 'b]
-  (P : 'a -> bool) (F : 'a -> t) (f : 'b -> 'a) (f' : 'a -> 'b) s
-:
-  cancel f' f => big P F s = big (P \o f) (F \o f) (map f' s).
-proof. by move=> bij_ff'; rewrite -big_map -map_comp id_map. qed.
+  (P : 'a -> bool) (F : 'a -> t) (f : 'b -> 'a) (f' : 'a -> 'b) (s : 'a list) :
+     (forall x, x \in s => f (f' x) = x) 
+  => big P F s = big (P \o f) (F \o f) (map f' s).
+proof. 
+by move => /eq_in_map id_ff'; rewrite -big_map -map_comp id_ff' id_map.
+qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt big_pair_pswap ['a 'b] p f s :

--- a/theories/datatypes/FSet.ec
+++ b/theories/datatypes/FSet.ec
@@ -54,7 +54,8 @@ op card ['a] (s : 'a fset) = size (elems s) axiomatized by cardE.
 op mem ['a] (s : 'a fset) (x : 'a) = mem (elems s) x
   axiomatized by memE.
 
-abbrev (\in) (z : 'a) (s : 'a fset) = mem s z.
+abbrev (\in)    (z : 'a) (s : 'a fset) =  mem s z.
+abbrev (\notin) (z : 'a) (s : 'a fset) = !mem s z.
 
 lemma mem_oflist (s : 'a list):
   forall x, mem (oflist s) x <=> mem s x.
@@ -506,16 +507,32 @@ lemma nosmt fcardD (A B : 'a fset) :
 proof. by rewrite -(fcardID A B) addzAC subzz. qed.
 
 (* -------------------------------------------------------------------- *)
+
+lemma fcardI1 (A : 'a fset) x : 
+  card (A `&` fset1 x) = b2i (x \in A).
+proof.
+by rewrite fsetI1; case: (x \in A) => _; rewrite ?fcard1 ?fcards0.
+qed.
+
+lemma fcardU1 (A : 'a fset) x : 
+  card (A `|` fset1 x) = b2i (x \notin A) + card A.
+proof. by rewrite fcardU fcard1 fcardI1 /#. qed.
+
 lemma nosmt fcardD1 (A : 'a fset) (x : 'a) :
   card A = card (A `\` fset1 x) + (if mem A x then 1 else 0).
-proof.
-(* FIXME: This feels like it wasn't thought about very deeply... *)
-case: (mem A x) => Ax //=; last first.
-+ congr; apply/fsetP=> y; rewrite !inE.
-  by move: Ax; case: (mem A y); case: (y = x).
-rewrite -(fcard1 x) -fcardUI addzC eq_sym eq_fcards0 /=.
-+ by apply/fsetP=> y; rewrite !inE; case: (y = x).
-by congr; apply/fsetP=> y; rewrite !inE; case: (y = x).
+proof. by rewrite fcardD fcardI1; ring. qed.
+
+(* -------------------------------------------------------------------- *)
+
+lemma fcard_oflist (s : 'a list) : card (oflist s) <= size s.
+proof. by rewrite /card -(perm_eq_size _ _ (oflistK s)) size_undup. qed.
+
+lemma uniq_card_oflist (s : 'a list) : uniq s => card (oflist s) = size s.
+proof. by rewrite /card => /oflist_uniq/perm_eq_size => <-. qed.
+
+lemma card_iota (n : int) : 0 <= n => card (oflist (iota_ 1 n)) = n.
+proof. 
+by move=> n_ge0; rewrite uniq_card_oflist ?iota_uniq size_iota /#. 
 qed.
 
 (* -------------------------------------------------------------------- *)
@@ -684,3 +701,13 @@ proof.
   rewrite -{1}(undup_id (filter (predC1 a) (elems A))) 2:oflistK//.
   by apply/filter_uniq/uniq_elems.
 qed.
+
+(* -------------------------------------------------------------------- *)
+
+op rangeset (m n : int) = oflist (range m n).
+
+lemma card_rangeset m n : card (rangeset m n) = max 0 (n - m).
+proof. by rewrite uniq_card_oflist ?range_uniq size_range. qed.
+
+lemma mem_rangeset m n i : i \in rangeset m n <=> m <= i && i < n.
+proof. by rewrite mem_oflist mem_range. qed.

--- a/theories/distributions/DInterval.ec
+++ b/theories/distributions/DInterval.ec
@@ -1,5 +1,5 @@
 (* -------------------------------------------------------------------- *)
-require import AllCore List StdBigop StdOrder IntDiv Distr.
+require import AllCore List StdBigop StdOrder IntDiv Distr Finite.
 (*---*) import IntOrder Bigint MUniform Range.
 
 (* -------------------------------------------------------------------- *)
@@ -24,11 +24,33 @@ lemma supp_dinter (i j : int) x:
   x \in (dinter i j) <=> i <= x <= j.
 proof. by rewrite /support /in_supp dinter1E; case (i <= x <= j)=> //= /#. qed.
 
+lemma supp_dinter1E (x : int) (i j : int) :
+  x \in (dinter i j) => mu1 (dinter i j) x = 1%r / (j - i + 1)%r.
+proof. by rewrite supp_dinter dinter1E => ->. qed.
+
 lemma dinter_ll (i j : int): i <= j => is_lossless (dinter i j).
 proof. move=> Hij;apply /drange_ll => /#. qed.
 
 lemma dinter_uni (i j : int): is_uniform (dinter i j).
 proof. apply drange_uni. qed.
+
+lemma finite_dinter (i j : int) : is_finite (support (dinter i j)).
+proof.
+rewrite is_finiteE; exists (range i (j+1)).
+by rewrite range_uniq /= => x; rewrite mem_range supp_dinter /#.
+qed.
+
+lemma perm_eq_dinter (i j : int) : 
+  perm_eq (to_seq (support (dinter i j))) (range i (j+1)).
+proof. 
+apply: uniq_perm_eq; first exact/uniq_to_seq/finite_dinter.
+- exact: range_uniq.
+by move=> x; rewrite mem_to_seq ?finite_dinter // supp_dinter mem_range /#.
+qed.
+
+lemma perm_eq_dinter_pred (i j : int) : 
+    perm_eq (to_seq (support (dinter i (j-1)))) (range i j).
+proof. by have /# := perm_eq_dinter i (j-1). qed.  
 
 (* -------------------------------------------------------------------- *)
 lemma duni_range_dvd (p q : int) : 0 < p => 0 < q => q %| p =>

--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -1565,6 +1565,15 @@ rewrite big_seq1 /= dlet1E  (@sumE_fin _ [b]) //= => [b'|].
 by rewrite big_seq1 /= dunitE.
 qed.
 
+lemma finite_dprod (da : 'a distr) (db : 'b distr) : 
+     is_finite (support da) 
+  => is_finite (support db) 
+  => is_finite (support (da `*` db)).
+proof.
+move=> *; rewrite dprod_dlet finite_dlet // => *.
+by apply finite_dlet => // *; apply finite_dunit.
+qed.
+
 lemma dmap_dprod ['a1 'a2 'b1 'b2]
   (d1 : 'a1 distr ) (d2 : 'a2 distr )
   (f1 : 'a1 -> 'b1) (f2 : 'a2 -> 'b2)

--- a/theories/prelude/Logic.ec
+++ b/theories/prelude/Logic.ec
@@ -369,6 +369,14 @@ lemma  if_arg b x (fT fF : 'a -> 'b) :
   (if b then fT else fF) x = if b then fT x else fF x
 by [].
 
+lemma ifT (b : bool) (e1 e2 : 'a) : 
+  b => (if b then e1 else e2) = e1 
+by [].
+
+lemma ifF (b : bool) (e1 e2 : 'a) : 
+ !b => (if b then e1 else e2) = e2
+by [].
+
 lemma  iffP p q r :
   (r <=> q) => (p => q) => (q => p) => r <=> p
 by [].


### PR DESCRIPTION
This PR adds a variety of lemmas that I found useful for developing the CV2EC theories.

The only changes (other than adding new lemmas) are:
- generalizing `reindex` to restict the cancellation property to the index list (possible source of minor incompatibility)
- resolving the FIXME in the proof of `fcardD1`