### PR TITLE
fix #189

### DIFF
--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -177,7 +177,6 @@ type tyerror =
 | ProcedureUnbounded     of symbol * symbol
 | LvMapOnNonAssign
 | NoDefaultMemRestr
-| ProcAssign             of qsymbol
 
 (* -------------------------------------------------------------------- *)
 exception TyError of EcLocation.t * EcEnv.env * tyerror
@@ -2859,16 +2858,10 @@ and transinstr
     end
 
   | PSasgn (plvalue, prvalue) -> begin
-      match unloc prvalue with
-      | PEapp ( { pl_desc = PEident (f, None) }, _)
-          when EcEnv.Fun.lookup_opt (unloc f) env <> None
-          -> tyerror prvalue.pl_loc env (ProcAssign (unloc f))
-
-      | _ ->
-        let lvalue, lty = translvalue ue env plvalue in
-        let rvalue, rty = transexp env `InProc ue prvalue in
-          unify_or_fail env ue prvalue.pl_loc ~expct:lty rty;
-          [ i_asgn_lv i.pl_loc env lvalue rvalue ]
+      let lvalue, lty = translvalue ue env plvalue in
+      let rvalue, rty = transexp env `InProc ue prvalue in
+      unify_or_fail env ue prvalue.pl_loc ~expct:lty rty;
+      [ i_asgn_lv i.pl_loc env lvalue rvalue ]
     end
 
   | PSrnd (plvalue, prvalue) ->

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -167,6 +167,7 @@ type tyerror =
 | ProcedureUnbounded     of symbol * symbol
 | LvMapOnNonAssign
 | NoDefaultMemRestr
+| ProcAssign             of qsymbol
 
 exception TymodCnvFailure of tymod_cnv_failure
 exception TyError of EcLocation.t * env * tyerror

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -167,7 +167,6 @@ type tyerror =
 | ProcedureUnbounded     of symbol * symbol
 | LvMapOnNonAssign
 | NoDefaultMemRestr
-| ProcAssign             of qsymbol
 
 exception TymodCnvFailure of tymod_cnv_failure
 exception TyError of EcLocation.t * env * tyerror

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -566,6 +566,11 @@ end = struct
            set the %s pragma to retrieve the old behaviour"
         EcGState.old_mem_restr
 
+    | ProcAssign q ->
+        msg "the right-hand side of this assignment cannot be typed as an expression;
+             if you meant to call procedure `%a', assign its result using `<@' rather than `<-'"
+            pp_qsymbol q
+
   let pp_restr_error env fmt (w, e) =
     let ppe = EcPrinting.PPEnv.ofenv env in
 

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -566,9 +566,6 @@ end = struct
            set the %s pragma to retrieve the old behaviour"
         EcGState.old_mem_restr
 
-    | ProcAssign f ->
-        msg "`%a' is a procedure name. Assign its result to a variable using `<@` instead" pp_qsymbol f
-
   let pp_restr_error env fmt (w, e) =
     let ppe = EcPrinting.PPEnv.ofenv env in
 


### PR DESCRIPTION
This fixes #189 by properly leveraging syntactic expectations.

The first commit removes the error message entirely—in case a user attempts to assign the result of a procedure call using `<-`, they will simply get a type error (likely "unknown operator").

The second commit puts some error information back in—if the right-hand side fails to type as an expression and happens to be interpretable as a procedure call, then we inform the user that it is an invalid expression and make recommendations for handling the procedure call. Precise typing errors are lost in this (rare) case.

This PR also incidentally starts and sets the Changelog format; which might benefit from being separated out and reviewed independently.