### PR TITLE
[stdlib] SmtMap lemmas, and bounding collisions for ROmap. 

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -1157,7 +1157,7 @@ section PROOFS.
     case: (mk_rs (oget RO.m{2}.[(n, C.ofint 0)])) => r s /=.
     case: (t = poly1305 r s (topol a c)) => // heq _.
     apply List.hasP; exists (topol a c, t) => /=;split; 2:by rewrite heq.
-    by apply mapP; exists (n, a, c, t) => /=; apply mem_filter.
+    by apply mapP; exists (n, a, c, t) => /=; apply List.mem_filter.
   qed.
 
   local lemma step2_3 &m : 
@@ -1251,7 +1251,7 @@ proof.
   case: (valid_topol a m) => hv /=;last by rewrite mu0; smt (ge0_qdec size_ge0 ge0_pr_zeropol).
   pose lc' := List.map _ _; apply (ler_trans ((size lc')%r*pr_zeropol));
    last by rewrite size_map size_filter //= ler_wpmul2r //= 1: ge0_pr_zeropol; smt (count_size size_ge0).
-  apply mu_has_leM => /= ? /mapP [] [n' a' m' t'] /> /mem_filter |> ??.
+  apply mu_has_leM => /= ? /mapP [] [n' a' m' t'] /> /List.mem_filter |> ??.
   case: (topol a' m' <> topol a m) => ? /=; last by rewrite mu0; smt (ge0_pr_zeropol).
   by apply pr_zeropol_spec.
 qed.
@@ -2494,7 +2494,7 @@ section PROOFS.
     have:= H16; rewrite mapP /= => [#][] t2 [#] h <<- <<-; have:=h.
     rewrite mapP /==> [#] [][] x1 x2 x3 x4 /=; rewrite mem_filter /= => [#] <<- ? ->>.
     smt(get_setE).
-  smt(mem_filter mem_cat mapP).
+  smt(List.mem_filter mem_cat mapP).
   qed.
 
   local clone EventPartitioning as EP with 

--- a/theories/distributions/Mu_mem.ec
+++ b/theories/distributions/Mu_mem.ec
@@ -1,24 +1,30 @@
 (* -------------------------------------------------------------------- *)
-require import AllCore List FSet Distr.
+require import AllCore List FSet SmtMap Distr.
 require import Ring Number StdRing StdOrder.
 (*---*) import RField RealOrder.
+
+lemma mu_mem_le_gen (s:'a fset) (d:'b distr) p (bd:real) : 
+  (forall (x : 'a), mem s x => mu d (p x) <= bd) =>
+  mu d (fun r => exists x, x \in s /\ p x r) <= (card s)%r * bd.
+proof.
+elim/fset_ind: s; first by rewrite mu0_false; smt(in_fset0 fcards0).
+move => x s x_fresh IH H. 
+rewrite (@mu_eq _ _ (predU (p x)
+  (fun (r : 'b) => exists (x : 'a), (x \in s) /\ p x r))); 1: smt(in_fsetU1).
+rewrite mu_or; apply ler_naddr; 1: smt(mu_bounded).
+by rewrite fcardU1 x_fresh fromintD mulrDl /b2i /=; smt(in_fsetU1).
+qed.
 
 lemma mu_mem_le (s:'a fset): forall (d:'a distr) (bd:real),
   (forall (x : 'a), mem s x => mu d (pred1 x) <= bd) =>
   mu d (mem s) <= (card s)%r * bd.
-proof.
-  elim/fset_ind s=> [d bd mu_bound|x s x_notin_s ih d bd mu_bound].
-    by rewrite (mu_eq d _ pred0) 2:mu0 2:fcards0 // => x; rewrite inE.
-  rewrite fcardUI_indep 1:fsetP 2:fcard1.
-    by move=> x0; rewrite !inE; split=> [[h ->>]|].
-  rewrite addzC fromintD mulrDl /=.
-  rewrite (mu_eq d _ (predU (pred1 x) (mem s))).
-    by move=> z; rewrite !inE orbC.
-  rewrite mu_disjoint.
-    by rewrite /predI /pred1 /pred0=> z [->].
-  rewrite ler_add 1:mu_bound // 1:!inE //.
-  by apply ih=> z z_in_s; rewrite mu_bound // !inE; left.
+proof. 
+by move => d bd; have X := mu_mem_le_gen s d pred1 bd; smt(mu_eq).
 qed.
+
+(* NOTE: In order to generalize mu_mem_ge in the same way as mu_mem_le
+above, we would need to assume disjointness of the sets [p x], so we
+don't do this here for now *)
 
 lemma mu_mem_ge (s:'a fset): forall (d:'a distr) (bd:real),
   (forall (x : 'a), mem s x => mu d (pred1 x) >= bd) =>
@@ -86,4 +92,16 @@ proof.
     exact/(mu_mem_le_card l d bd mu_bound).
   rewrite cardE -(perm_eq_size (undup l)) 1:oflistK //.
   by rewrite ler_wpmul2r // le_fromint size_undup.
+qed.
+
+lemma mu_mem_le_fsize (m : ('a, 'b) fmap) (d : 'c distr) p bd :
+  (forall u, u \in m => mu d (p u) <= bd) =>
+  mu d (fun r => exists u, u \in m /\ p u r) <= (fsize m)%r * bd.
+proof.
+elim/fmapW : m; first by rewrite mu0_false; smt(mem_empty fsize_empty).
+move => m k v fresh_k IH H.
+rewrite (@mu_eq _ _ (predU (p k)
+  (fun (r : 'c) => exists (u : 'a), (u \in m) /\ p u r))); 1: smt(mem_set).
+rewrite mu_or; apply ler_naddr; 1: smt(mu_bounded).
+by rewrite fsize_set -mem_fdom fresh_k fromintD mulrDl; smt(mem_set).
 qed.


### PR DESCRIPTION
This adds two new operators (`fsize` and `fcoll`) and a few lemmas to `SmtMap`. These are then used to bound the probability of collisions occurring when using the `ROmap` oracle from `PROM`. 

Note that the `Mu_mem` lemma for `fmap` uses a generalization of the `Mu_mem` lemmas for `fset`, which could also be applied to the latter. Input on this would be appreciated. 