### PR TITLE
rename depext to opam-depext

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ packages manager.
   2. Optionally, use opam to install the system dependencies:
 
       ```
-      $> opam install depext
+      $> opam install opam-depext
       $> opam depext easycrypt
       ```
 


### PR DESCRIPTION
The `depext` package fails to install with recent versions of opam.
The fix suggested in the package information is to use the renamed package `opam-depext`.