### PR TITLE
[breaking] remove support for `proc *` tags in module types

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -415,7 +415,7 @@ module type CC = {
 }.
 
 module type FCC = {
-  proc * init () : unit
+  proc init () : unit
   include CC
 }.
 
@@ -1104,7 +1104,9 @@ section PROOFS.
       + by proc; inline *; auto => /> &2; case: (p{2}).
       proc; inline *; auto => /> &2; case: (c{2}) => /> n a c t.
       by rewrite /dec /get /= => ->.
-    by apply (CCA_CPA_UFCMA St _ A _ &m) => //; apply A_ll.
+    apply (CCA_CPA_UFCMA St _ _ A _ &m) => //.
+    + by proc *; inline *; sim.
+    by apply A_ll.
   qed.
 
   local module G3 (S:SKE) = CPA_game(CCA_CPA_Adv(A), RealOrcls(S)).

--- a/examples/ChaChaPoly/ske.ec
+++ b/examples/ChaChaPoly/ske.ec
@@ -7,7 +7,7 @@ type plaintext.
 type ciphertext.
 
 module type SKE = {
-  proc * init(): unit {}
+  proc init(): unit {}
   proc kg(): key
   proc enc(k:key,p:plaintext): ciphertext 
   proc dec(k:key,c:ciphertext): plaintext option
@@ -31,7 +31,7 @@ abstract theory SKE_RND.
 clone include SKE.
 
 module type Oracles = {
-  proc * init() : unit
+  proc init() : unit
   proc enc(p:plaintext): ciphertext 
   proc dec(c:ciphertext): plaintext option
 }.
@@ -137,7 +137,7 @@ axiom dec_enc :
     forall gs p, dec gs k (enc gs k p) = Some p.
 
 module type StLOrcls = {
-  proc * init () : globS
+  proc init () : globS
   proc kg () : key
 }.
 
@@ -168,6 +168,8 @@ section PROOFS.
 
   declare module St <: StLOrcls { -StLSke, -Mem }.
 
+  declare axiom st_init_is_init :
+    equiv [ St.init ~ St.init: true ==> ={glob St, res} ].
   declare axiom valid_kg : hoare [St.kg : true ==> valid_key res].
 
   declare module A <: CCA_Adv { -StLSke, -Mem, -St }.
@@ -193,7 +195,7 @@ section PROOFS.
     wp; conseq (_: ={glob A} ==> ={glob A, StLSke.gs, Mem.k}) (_: true ==> valid_key Mem.k) _ => />.
     + smt (mem_empty).
     + by call valid_kg.
-    by sim.
+    by call (: true); call st_init_is_init.
   qed.
 
   lemma CCA_CPA_UFCMA &m : 

--- a/examples/PRG.ec
+++ b/examples/PRG.ec
@@ -25,14 +25,14 @@ hint exact random: dout_ll.
 (** We use a public RF that, on input a seed, produces a seed and
     an output...                                                        *)
 module type RF = {
-  proc * init() : unit
+  proc init() : unit
   proc f(x:seed): seed * output
 }.
 
 (** ...to build a PRG that produces random outputs... **)
 (** We let our PRG have internal state, which we need to initialize **)
 module type PRG = {
-  proc * init(): unit
+  proc init(): unit
   proc prg()   : output
 }.
 

--- a/examples/Upto.ec
+++ b/examples/Upto.ec
@@ -25,7 +25,7 @@ module type Oracle = {
 }.
 
 module type A (O : Oracle) ={
-  proc * run () : ret_adv { O.f}
+  proc run () : ret_adv { O.f}
 }.
 
 module Experiment (O : Oracle) (AdvF : A) = {
@@ -95,7 +95,7 @@ move=> hg hbnd hinint hinit2 hf hf2 hbound_bad hll1 hll2 hlladv hIm.
 apply (ler_trans (Pr [Experiment(O2, Adv).main() @ &m : P res \/ (Experiment.WO.bad /\
                                                                   Experiment.WO.cO <= qO /\
                                                                   Experiment.WO.cO = m (glob O2))]) _).
-+ byequiv (: true ==>
++ byequiv (: ={glob Adv} ==>
              (!Experiment.WO.bad{2} => ={res}) /\
               Experiment.WO.cO{2} <= qO /\
               Experiment.WO.cO{2} = m (glob O2){2})=> //.

--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -2107,7 +2107,6 @@ module Fsubst = struct
 
     PreOI.mk
       (List.map sx (PreOI.allowed oi))
-      (PreOI.is_in oi)
       costs
 
   and mr_subst ~tx s mr : form p_mod_restr =

--- a/src/ecCoreModules.ml
+++ b/src/ecCoreModules.ml
@@ -588,8 +588,6 @@ module PreOI : sig
   val hash : ('a -> int) -> 'a t -> int
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
-  val is_in : 'a t -> bool
-
   val cost_self : 'a t -> [`Bounded of 'a | `Unbounded]
   val cost : 'a t -> xpath -> [`Bounded of 'a | `Zero | `Unbounded]
   val cost_calls : 'a t -> [`Bounded of 'a Mx.t | `Unbounded]
@@ -598,7 +596,7 @@ module PreOI : sig
   val allowed : 'a t -> xpath list
   val allowed_s : 'a t -> Sx.t
 
-  val mk : xpath list -> bool -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
+  val mk : xpath list -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
   (* val change_calls : 'a t -> xpath list -> 'a t *)
   val filter : (xpath -> bool) -> 'a t -> 'a t
 end = struct
@@ -613,11 +611,8 @@ end = struct
    * Remark: there is redundancy between oi_calls and oi_costs. *)
   type 'a t = {
     oi_calls : xpath list;
-    oi_in    : bool;
     oi_costs : ('a * 'a Mx.t) option;
   }
-
-  let is_in t = t.oi_in
 
   let allowed oi = oi.oi_calls
 
@@ -636,11 +631,11 @@ end = struct
 
   let costs oi = omap_dfl (fun x -> `Bounded x) `Unbounded oi.oi_costs
 
-  let mk oi_calls oi_in oi_costs = match oi_costs with
+  let mk oi_calls oi_costs = match oi_costs with
     | `Bounded oi_costs ->
-      { oi_calls; oi_in; oi_costs = Some (oi_costs) ; }
+      { oi_calls; oi_costs = Some (oi_costs) ; }
     | `Unbounded ->
-      { oi_calls; oi_in; oi_costs = None; }
+      { oi_calls; oi_costs = None; }
 
   (* let change_calls oi calls =
    *   mk calls oi.oi_in
@@ -650,7 +645,7 @@ end = struct
     let costs = match oi.oi_costs with
       | Some (self,costs) -> `Bounded (self, Mx.filter (fun x _ -> f x) costs)
       | None -> `Unbounded in
-    mk (List.filter f oi.oi_calls) oi.oi_in costs
+    mk (List.filter f oi.oi_calls) costs
 
   let equal a_equal oi1 oi2 =
     let check_costs_eq c1 c2 =
@@ -667,8 +662,7 @@ end = struct
           a_equal s1 s2
         with Not_equal -> false in
 
-    oi1.oi_in = oi2.oi_in
-    && List.all2 EcPath.x_equal oi1.oi_calls oi1.oi_calls
+    List.all2 EcPath.x_equal oi1.oi_calls oi1.oi_calls
     && check_costs_eq oi1.oi_costs oi2.oi_costs
 
   let hash ahash oi =
@@ -678,8 +672,7 @@ end = struct
              (Why3.Hashcons.combine_pair EcPath.x_hash ahash)
              (ahash self) (Mx.bindings costs))) oi.oi_costs in
 
-    Why3.Hashcons.combine2
-      (if oi.oi_in then 0 else 1)
+    Why3.Hashcons.combine
       (Why3.Hashcons.combine_list EcPath.x_hash 0
          (List.sort EcPath.x_compare oi.oi_calls))
       costs_hash
@@ -706,7 +699,7 @@ let has_compl_restriction mr =
 
 let mr_is_empty mr =
      not (has_compl_restriction mr)
-  && Msym.for_all (fun _ oi -> [] = PreOI.allowed oi && PreOI.is_in oi) mr.mr_oinfos
+  && Msym.for_all (fun _ oi -> [] = PreOI.allowed oi) mr.mr_oinfos
 
 let mr_xpaths_fv (m : mr_xpaths) : int Mid.t =
   EcPath.Sx.fold

--- a/src/ecCoreModules.mli
+++ b/src/ecCoreModules.mli
@@ -130,8 +130,6 @@ module PreOI : sig
   val hash : ('a -> int) -> 'a t -> int
   val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
-  val is_in : 'a t -> bool
-
   val cost_self : 'a t -> [`Bounded of 'a | `Unbounded]
   val cost : 'a t -> xpath -> [`Bounded of 'a | `Zero | `Unbounded]
   val cost_calls : 'a t -> [`Bounded of 'a Mx.t | `Unbounded]
@@ -140,7 +138,7 @@ module PreOI : sig
   val allowed : 'a t -> xpath list
   val allowed_s : 'a t -> Sx.t
 
-  val mk : xpath list -> bool -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
+  val mk : xpath list -> [`Bounded of 'a * 'a Mx.t | `Unbounded] -> 'a t
   (* val change_calls : 'a t -> xpath list -> 'a t *)
   val filter : (xpath -> bool) -> 'a t -> 'a t
 end

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -2409,7 +2409,7 @@ module NormMp = struct
             Sm.mem ftop mparams in
           let calls = List.filter filter (EcPath.Sx.elements all_calls) in
 
-          Msym.add f.f_name (OI.mk calls true `Unbounded) oi in
+          Msym.add f.f_name (OI.mk calls `Unbounded) oi in
 
       let oi = List.fold_left comp_oi Msym.empty me.me_comps in
 

--- a/src/ecLowGoal.ml
+++ b/src/ecLowGoal.ml
@@ -168,7 +168,6 @@ module LowApply = struct
           (* FIXME: poor API ==> poor error recovery *)
           try
             let obl = EcTyping.check_modtype env mp mt emt in
-            EcPV.check_module_in env mp emt;
 
             let f = match obl with
               | `Ok ->  f

--- a/src/ecModules.ml
+++ b/src/ecModules.ml
@@ -17,8 +17,6 @@ module OI : sig
   val hash : t -> int
   val equal : t -> t -> bool
 
-  val is_in : t -> bool
-
   val cost_self : t -> [`Bounded of form | `Unbounded]
   val cost : t -> xpath -> [`Bounded of form | `Zero | `Unbounded]
   val cost_calls : t -> [`Bounded of form Mx.t | `Unbounded]
@@ -27,13 +25,12 @@ module OI : sig
   val allowed : t -> xpath list
   val allowed_s : t -> Sx.t
 
-  val mk : xpath list -> bool -> [`Bounded of form * form Mx.t | `Unbounded] -> t
+  val mk : xpath list -> [`Bounded of form * form Mx.t | `Unbounded] -> t
   (* val change_calls : t -> xpath list -> t *)
   val filter : (xpath -> bool) -> t -> t
 end = struct
   type t = EcCoreFol.form PreOI.t
 
-  let is_in        = PreOI.is_in
   let allowed      = PreOI.allowed
   let allowed_s    = PreOI.allowed_s
   let cost_self    = PreOI.cost_self
@@ -94,7 +91,7 @@ let change_oicalls restr f ocalls =
     | oi ->
       let filter x = List.mem x ocalls in
       OI.filter filter oi
-    | exception Not_found -> OI.mk ocalls true `Unbounded in
+    | exception Not_found -> OI.mk ocalls `Unbounded in
   add_oinfo restr f oi
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecModules.mli
+++ b/src/ecModules.mli
@@ -13,8 +13,6 @@ module OI : sig
   val hash : t -> int
   val equal : t -> t -> bool
 
-  val is_in : t -> bool
-
   val cost_self : t -> [`Bounded of form | `Unbounded]
   val cost : t -> xpath -> [`Bounded of form | `Zero | `Unbounded]
   val cost_calls : t -> [`Bounded of form Mx.t | `Unbounded]
@@ -23,7 +21,7 @@ module OI : sig
   val allowed : t -> xpath list
   val allowed_s : t -> Sx.t
 
-  val mk : xpath list -> bool -> [`Bounded of form * form Mx.t | `Unbounded] -> t
+  val mk : xpath list -> [`Bounded of form * form Mx.t | `Unbounded] -> t
   (* val change_calls : t -> xpath list -> t *)
   val filter : (xpath -> bool) -> t -> t
 end

--- a/src/ecPV.mli
+++ b/src/ecPV.mli
@@ -195,4 +195,3 @@ end
 (* -------------------------------------------------------------------- *)
 val i_eqobs_in_refl : env -> instr -> PV.t -> PV.t
 val eqobs_inF_refl  : env -> EcPath.xpath -> PV.t -> PV.t
-val check_module_in : env -> mpath -> module_type -> unit

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1588,8 +1588,7 @@ fun_def_body:
 
 fun_decl:
 | x=lident pd=param_decl ty=prefix(COLON, loc(type_exp))?
-    { let frestr = { pmre_in    = true;
-		     pmre_name  = x;
+    { let frestr = { pmre_name  = x;
 		     pmre_orcls = None;
 		     pmre_compl = None;	} in
 
@@ -1710,10 +1709,9 @@ fun_restr:
     { (None, Some cl) }
 
 mod_restr_el:
-  | i=iboption(STAR) f=lident COLON fr=fun_restr
+  | f=lident COLON fr=fun_restr
     { let orcl, cmpl = fr in
-      { pmre_in = not i;
-	pmre_name = f;
+      { pmre_name = f;
 	pmre_orcls = orcl;
 	pmre_compl = cmpl; } }
 
@@ -1774,8 +1772,7 @@ signature_item:
       `Include (i, xs, qs) }
 | PROC x=lident pd=param_decl COLON ty=loc(type_exp) fr=fun_restr?
     { let orcl, compl = odfl (None,None) fr in
-      let frestr = { pmre_in    = true;
-		     pmre_name  = x;
+      let frestr = { pmre_name  = x;
 		     pmre_orcls = orcl;
 		     pmre_compl = compl; } in
 

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1772,9 +1772,9 @@ signature_item:
     { let qs = omap (List.map (fun x -> { inp_in_params = false;
 					  inp_qident    = x;     })) qs in
       `Include (i, xs, qs) }
-| PROC i=boption(STAR) x=lident pd=param_decl COLON ty=loc(type_exp) fr=fun_restr?
+| PROC x=lident pd=param_decl COLON ty=loc(type_exp) fr=fun_restr?
     { let orcl, compl = odfl (None,None) fr in
-      let frestr = { pmre_in    = not i;
+      let frestr = { pmre_in    = true;
 		     pmre_name  = x;
 		     pmre_orcls = orcl;
 		     pmre_compl = compl; } in

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -264,7 +264,6 @@ and poracles = qident_inparam list
 and pcompl = PCompl of pformula * (qident_inparam * pformula) list
 
 and pmod_restr_el = {
-  pmre_in    : bool;
 	pmre_name  : psymbol;
   pmre_orcls : poracles option;  (* None means no restriction *)
   pmre_compl : pcompl option;    (* None means no restriction *)

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -1850,8 +1850,7 @@ and pp_orclinfo_bare ppe fmt oi =
     (pp_costs ppe) costs
 
 and pp_orclinfo ppe fmt (sym, oi) =
-  Format.fprintf fmt "@[<hv>%s%a : %a@]"
-    (if OI.is_in oi then "" else " *")
+  Format.fprintf fmt "@[<hv>%a : %a@]"
     pp_symbol sym
     (pp_orclinfo_bare ppe) oi
 

--- a/src/ecProofTerm.ml
+++ b/src/ecProofTerm.ml
@@ -812,7 +812,6 @@ and check_pterm_oarg ?loc pe (x, xty) f arg =
       | PVAModule (mp, mt) -> begin
           try
             let obl = EcTyping.check_modtype env mp mt emt in
-            EcPV.check_module_in env mp emt;
 
             let f = Fsubst.f_subst_mod x mp f in
             let f = match obl with

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -940,9 +940,7 @@ let restr_proof_obligation env (mp_in : mpath) sym (mt : module_type) : form lis
             | `Unbounded ->
               let k_id = mk_ident () in
               let k = f_N (f_local k_id tint) in
-              let oi' =
-                OI.mk (OI.allowed oi) (OI.is_in oi)
-                  (`Bounded (k,Mx.empty)) in
+              let oi' = OI.mk (OI.allowed oi) (`Bounded (k,Mx.empty)) in
               let param_restr' = add_oinfo param_restr' fn.fs_name oi' in
               (param_restr', k_id :: ints)
           ) (param_restr,ints) param_ms.mis_body in
@@ -2274,17 +2272,16 @@ and trans_restr_fun env env_in (params : Sm.t) (r_el : pmod_restr_el) =
                   |> List.filter_map (fun (f,_) ->
                      if List.mem f r_orcls then None else Some f)) in
 
-  let r_in =  r_el.pmre_in in
-  ( r_in, name, c_compl, r_orcls )
+  ( name, c_compl, r_orcls )
 
 (* See [trans_restr_fun] for the requirements on [env], [env_in], [params]. *)
 and transmod_restr env env_in (params : Sm.t) (mr : pmod_restr) =
   let r_mem = trans_restr_mem env mr.pmr_mem in
 
   let r_procs = List.fold_left (fun r_procs r_elem ->
-      let r_in, name, c_compl, r_orcls =
+      let name, c_compl, r_orcls =
         trans_restr_fun env env_in params r_elem in
-      Msym.add name (OI.mk r_orcls r_in c_compl) r_procs
+      Msym.add name (OI.mk r_orcls c_compl) r_procs
     ) Msym.empty mr.pmr_procs in
 
   { mr_xpaths = fst r_mem;
@@ -2379,11 +2376,11 @@ and transmodsig_body
 
       let resty = transty_for_decl env f.pfd_tyresult in
 
-      let uin, rname, compl, calls = trans_restr_fun env env sa f.pfd_uses in
+      let rname, compl, calls = trans_restr_fun env env sa f.pfd_uses in
 
       assert (rname = name.pl_desc);
 
-      let oi = OI.mk calls uin compl in
+      let oi = OI.mk calls compl in
 
       let sig_ = { fs_name   = name.pl_desc;
                    fs_arg    = ttuple (List.map ov_type tyargs);

--- a/src/phl/ecPhlCall.ml
+++ b/src/phl/ecPhlCall.ml
@@ -311,10 +311,10 @@ let t_call side ax tc =
 let mk_inv_spec (_pf : proofenv) env inv fl fr =
   match NormMp.is_abstract_fun fl env with
   | true ->
-    let (topl, _, oil, sigl),
+    let (topl, _, _, sigl),
       (topr, _, _  , sigr) = EcLowPhlGoal.abstract_info2 env fl fr in
     let eqglob = f_eqglob topl mleft topr mright in
-    let lpre = if OI.is_in oil then [eqglob;inv] else [inv] in
+    let lpre = [eqglob;inv] in
     let eq_params =
       f_eqparams
         sigl.fs_arg sigl.fs_anames mleft
@@ -465,11 +465,11 @@ let process_call side info tc =
         let (_,fl,_) = fst (tc1_last_call tc es.es_sl) in
         let (_,fr,_) = fst (tc1_last_call tc es.es_sr) in
         let bad,invP,invQ = EcPhlFun.process_fun_upto_info info tc in
-        let (topl,fl,oil,sigl),
+        let (topl,fl,_,sigl),
             (topr,fr,_  ,sigr) = EcLowPhlGoal.abstract_info2 env fl fr in
         let bad2 = Fsubst.f_subst_mem mhr mright bad in
         let eqglob = f_eqglob topl mleft topr mright in
-        let lpre = if OI.is_in oil then [eqglob;invP] else [invP] in
+        let lpre = [eqglob;invP] in
         let eq_params =
           f_eqparams
             sigl.fs_arg sigl.fs_anames mleft

--- a/src/phl/ecPhlEqobs.ml
+++ b/src/phl/ecPhlEqobs.ml
@@ -294,8 +294,7 @@ and f_eqobs_in fl fr sim eqO =
             PV.check_depend env fvr topr
           with TcError _ -> raise EqObsInError
         end;
-        let eqi = if OI.is_in oil then Mpv2.add_glob env top top eqi else eqi in
-        sim, eqi
+        sim, (Mpv2.add_glob env top top eqi)
 
       | FBdef funl, FBdef funr ->
         let local = Mpv2.empty_local in

--- a/src/phl/ecPhlFun.ml
+++ b/src/phl/ecPhlFun.ml
@@ -369,7 +369,7 @@ module FunAbsLow = struct
           if   EcPath.x_equal o_l o_r
           then check_oracle_use pf env topl o_r;
           false
-        with _ when OI.is_in oil -> true
+        with _ -> true
       in
 
       let fo_l = EcEnv.Fun.by_xpath o_l env in
@@ -397,7 +397,7 @@ module FunAbsLow = struct
         sigr.fs_arg sigr.fs_anames mr in
 
     let eq_res = f_eqres sigl.fs_ret ml sigr.fs_ret mr in
-    let lpre   = if OI.is_in oil then [eqglob;inv] else [inv] in
+    let lpre   = [eqglob;inv] in
     let pre    = f_ands (eq_params::lpre) in
     let post   = f_ands [eq_res; eqglob; inv] in
 
@@ -519,7 +519,7 @@ module UpToLow = struct
 
     let eq_res = f_eqres sigl.fs_ret ml sigr.fs_ret mr in
 
-    let pre  = if OI.is_in oil then [eqglob;invP] else [invP] in
+    let pre  = [eqglob;invP] in
     let pre  = f_if_simpl bad2 invQ (f_ands (eq_params::pre)) in
     let post = f_if_simpl bad2 invQ (f_ands [eq_res;eqglob;invP]) in
 

--- a/theories/crypto/MAC.ec
+++ b/theories/crypto/MAC.ec
@@ -5,7 +5,7 @@ type message.
 type tag.
 
 module type Scheme = {
-  proc * init(): unit {}
+  proc init(): unit {}
   proc keygen(): key
   proc mac(k:key,m:message): tag
   proc verify(k:key,m:message,t:tag): bool

--- a/theories/crypto/PKS.ec
+++ b/theories/crypto/PKS.ec
@@ -7,7 +7,7 @@ type message.
 type signature.
 
 module type Scheme = {
-  proc * init(): unit {}
+  proc init(): unit {}
   proc keygen(): (pkey * skey)
   proc sign(sk:skey, m:message): signature
   proc verify(pk:pkey, m:message, s:signature): bool
@@ -21,7 +21,7 @@ module type AdvCMA(O:AdvOracles) = {
 
 theory EF_CMA.
   module type Oracles = {
-    proc * init(): pkey {}
+    proc init(): pkey {}
     proc sign(m:message): signature
     proc verify(m:message,s:signature): bool
     proc fresh(m:message): bool
@@ -84,7 +84,7 @@ end EF_CMA.
 
 theory NM_CMA.
   module type Oracles = {
-    proc * init(): pkey {}
+    proc init(): pkey {}
     proc sign(m:message): signature
     proc verify(m:message,s:signature): bool
     proc fresh(m:message,s:signature): bool

--- a/theories/crypto/SymmetricEncryption.ec
+++ b/theories/crypto/SymmetricEncryption.ec
@@ -5,7 +5,7 @@ type plaintext.
 type ciphertext.
 
 module type Scheme = {
-  proc * init(): unit {}
+  proc init(): unit {}
   proc kg(): key
   proc enc(k:key,p:plaintext): ciphertext
   proc dec(k:key,c:ciphertext): plaintext option
@@ -99,21 +99,23 @@ module INDCCA (S:Scheme, A:Adv_INDCCA) = {
   }
 }.
 
-module ToCCA (A:Adv_INDCPA, O:CCA_Oracles) = A(O).
+module ToCCA (A : Adv_INDCPA) (O : CCA_Oracles) = A(O).
 
 lemma CCA_implies_CPA (S <: Scheme {-INDCPA}) (A <: Adv_INDCPA {-S, -INDCPA}) &m:
-  Pr[INDCPA(S,A).main() @ &m: res] = Pr[INDCCA(S,ToCCA(A)).main() @ &m: res].
-proof strict.
-byequiv (_: ={glob A} ==> ={res})=> //; proc.
-call{2} (_: Wrap.qs = [] ==> !res); first by proc; skip; smt.
-conseq [-frame] (_: _ ==> Wrap.qs{2} = [] /\ (b = b'){1} = (b = b'){2}); first smt.
-call (_: ={glob Wrap, glob S} /\ Wrap.qs{2} = []);
-  first by proc; call (_: true).
-call (_: ={glob Wrap, glob S});
-  first by call (_: true).
+     equiv [S.init ~ S.init: true ==> ={glob S}]
+  => Pr[INDCPA(S,A).main() @ &m: res] = Pr[INDCCA(S,ToCCA(A)).main() @ &m: res].
+proof.
+move=> init_is_init.
+byequiv (: ={glob A} ==> ={res})=> //; proc.
+call{2} (: Wrap.qs = [] ==> !res); first by proc; skip; smt.
+conseq (: _ ==> Wrap.qs{2} = [] /\ (b = b'){1} = (b = b'){2}); first smt.
+call (: ={glob Wrap, glob S} /\ Wrap.qs{2} = []).
++ by proc; call (: true).
+call (: ={glob Wrap, glob S}).
++ by call (: true).
 wp; rnd.
-call (_: ={glob Wrap, glob S} /\ Wrap.qs{2} = []);
-  first by proc; call (_: true).
-by call (_: true ==> ={glob Wrap, glob S} /\ Wrap.qs{2} = []);
-     first by proc; wp; sim.
+call (_: ={glob Wrap, glob S} /\ Wrap.qs{2} = []).
++ by proc; call (: true).
+call (: ={glob A} ==> ={glob Wrap, glob S} /\ Wrap.qs{2} = [])=> //.
+by proc; wp; call (: true); call init_is_init.
 qed.

--- a/theories/query_counting/OracleBounds.ec
+++ b/theories/query_counting/OracleBounds.ec
@@ -11,7 +11,7 @@ require import Int Real Distr StdOrder.
      3) refactoring to remove the use of Count.
    This is independent of any counting done inside the oracles. *)
 module type Counter = {
-  proc * init(): unit {}
+  proc init(): unit {}
   proc incr(): unit
 }.
 


### PR DESCRIPTION
This is a breaking change.

This removes support for `proc *` tags in module types, which are currently causing soundness issues (see #206) and would benefit from being re-integrated later on as part of a more general and less trusted procedure annotation mechanism.

Formal developments that use `proc *`, or rely on `proc *` annotations in the standard library will need to update proofs.

Where the `proc *` annotation is in fact necessary for a result to hold (for example, when initial memories are different), it can be replaced with a hypothesis of the form `equiv [M.p ~ M.p: ={arg} ==> ={glob M, res}]` on the relevant procedures. In this case, instances of `sim` and `call (: true)` relevant to the procedure will need refined to take explicit account of the hypothesis.

Where the `proc *` annotation is not necessary for a result to hold, proofs may need adapted slightly to account for the improved generality of the stated result. In particular, `transitivity`, `seq` and `conseq` may require minor contract additions, and some instances of `call` may generate more non-trivial goals. These may manifest as unrelated failures, especially `smt` failures.

In some cases, the `proc *` annotation is not necessary for a top-level result to hold, but is required for proving some supporting lemmas as stated. In such instances, it may be necessary to weaken the supporting lemmas to require equality on one or more abstract module's global variables.

Fixes #206.