### PR TITLE
Fix naming issue for the [#] intro-pattern

### DIFF
--- a/src/ecCoreGoal.ml
+++ b/src/ecCoreGoal.ml
@@ -118,7 +118,7 @@ and goal = {
 and validation =
 | VSmt                               (* SMT call *)
 | VAdmit                             (* admit *)
-| VIntros  of (handle * ident option list) (* intros *)
+| VIntros  of (handle * ident list)  (* intros *)
 | VConv    of (handle * Sid.t)       (* weakening + conversion *)
 | VLConv   of (handle * ident)       (* hypothesis conversion *)
 | VRewrite of (handle * rwproofterm) (* rewrite *)

--- a/src/ecCoreGoal.mli
+++ b/src/ecCoreGoal.mli
@@ -129,7 +129,7 @@ type pregoal = {
 type validation =
 | VSmt                               (* SMT call *)
 | VAdmit                             (* admit *)
-| VIntros  of (handle * ident option list) (* intros *)
+| VIntros  of (handle * ident list)  (* intros *)
 | VConv    of (handle * Sid.t)       (* weakening + conversion *)
 | VLConv   of (handle * ident)       (* hypothesis conversion *)
 | VRewrite of (handle * rwproofterm) (* rewrite *)

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -1413,12 +1413,13 @@ let rec process_mintros_1 ?(cf = true) ttenv pis gs =
             (List.map (fun i tc -> aux (omap ((+) (i-1)) imax) tc) ntop)
             tc
         with InvalidGoalShape ->
-          let id = EcIdent.create "_" in
           try
-            t_seq
-              (aux (omap ((+) (-1)) imax))
-              (t_generalize_hyps ~clear:`Yes [id])
-              (EcLowGoal.t_intros_i_1 [id] tc)
+            tc |> EcLowGoal.t_intro_sx_seq
+              `Fresh
+              (fun id ->
+                t_seq
+                  (aux (omap ((+) (-1)) imax))
+                  (t_generalize_hyps ~clear:`Yes [id]))
           with
           | EcCoreGoal.TcError _ when EcUtils.is_some imax ->
               tc_error !!tc "not enough top-assumptions"

--- a/src/ecLowGoal.ml
+++ b/src/ecLowGoal.ml
@@ -487,25 +487,25 @@ let t_intros_x (ids : (ident  option) mloc list) (tc : tcenv1) =
     | SFquant (Lforall, (x, gty), lazy concl) ->
         let (id, ld, sbt) = add_local hyps id sbt x gty in
         let hyps = add_ld id ld hyps in
-        (hyps, concl), sbt
+        ((hyps, concl), sbt), id
 
     | SFimp (prem, concl) ->
         let prem = Fsubst.f_subst sbt prem in
-        let id   = tg_map (function
+        let id = tg_map (function
           | None    -> EcIdent.create "_"
           | Some id -> id) id in
         let hyps = add_ld id (LD_hyp prem) hyps in
-        (hyps, concl), sbt
+        ((hyps, concl), sbt), id
 
     | SFlet (LSymbol (x, xty), xe, concl) ->
-        let id   = tg_map (function
+        let id = tg_map (function
           | None    -> EcEnv.LDecl.fresh_id hyps (EcIdent.name x)
           | Some id -> id) id in
         let xty  = sbt.fs_ty xty in
         let xe   = Fsubst.f_subst sbt xe in
         let sbt  = Fsubst.f_bind_rename sbt x (tg_val id) xty in
         let hyps = add_ld id (LD_var (xty, Some xe)) hyps in
-        (hyps, concl), sbt
+        ((hyps, concl), sbt), id
 
     | _ when sbt !=(*φ*) Fsubst.f_subst_id ->
         let concl = Fsubst.f_subst sbt concl in
@@ -519,18 +519,19 @@ let t_intros_x (ids : (ident  option) mloc list) (tc : tcenv1) =
 
   let tc = FApi.tcenv_of_tcenv1 tc in
 
-  if List.is_empty ids then tc else begin
+  if List.is_empty ids then (tc, []) else begin
     let sbt = Fsubst.f_subst_id in
-    let (hyps, concl), sbt =
-      List.fold_left intro1 (FApi.tc_flat tc, sbt) ids in
+    let ((hyps, concl), sbt), ids =
+      List.fold_left_map intro1 (FApi.tc_flat tc, sbt) ids in
     let concl = Fsubst.f_subst sbt concl in
     let (tc, hd) = FApi.newgoal tc ~hyps concl in
-    FApi.close tc (VIntros (hd, List.map tg_val ids))
+    let ids = List.map tg_val ids in
+    (FApi.close tc (VIntros (hd, ids)), ids)
   end
 
 (* -------------------------------------------------------------------- *)
 let t_intros (ids : ident mloc list) (tc : tcenv1) =
-  t_intros_x (List.map (tg_map some) ids) tc
+  fst (t_intros_x (List.map (tg_map some) ids) tc)
 
 (* -------------------------------------------------------------------- *)
 type iname  = [
@@ -543,32 +544,44 @@ type inames = [`Symbol of symbol list | `Ident of EcIdent.t list]
 
 (* -------------------------------------------------------------------- *)
 let t_intros_n (n : int) (tc : tcenv1) =
-  t_intros_x (EcUtils.List.make n (notag None)) tc
+  fst (t_intros_x (EcUtils.List.make n (notag None)) tc)
 
 (* -------------------------------------------------------------------- *)
 let t_intro_i_x (id : EcIdent.t option) (tc : tcenv1) =
-  t_intros_x [notag id] tc
+  snd_map EcUtils.as_seq1 (t_intros_x [notag id] tc)
 
 (* -------------------------------------------------------------------- *)
 let t_intro_i (id : EcIdent.t) (tc : tcenv1) =
-  t_intro_i_x (Some id) tc
+  fst (t_intro_i_x (Some id) tc)
 
 (* -------------------------------------------------------------------- *)
-let t_intro_s (id : iname) (tc : tcenv1) =
+let t_intro_sx (id : iname) (tc : tcenv1) =
   match id with
   | `Symbol x -> t_intro_i_x (Some (EcIdent.create x)) tc
   | `Ident  x -> t_intro_i_x (Some x) tc
   | `Fresh    -> t_intro_i_x None tc
 
 (* -------------------------------------------------------------------- *)
-let t_intros_i (ids : EcIdent.t list) (tc : tcenv1) =
+let t_intro_s (id : iname) (tc : tcenv1) =
+  fst (t_intro_sx id tc)
+
+(* -------------------------------------------------------------------- *)
+let t_intros_i_x (ids : EcIdent.t list) (tc : tcenv1) =
   t_intros_x (List.map (notag |- some) ids) tc
 
 (* -------------------------------------------------------------------- *)
-let t_intros_s (ids : inames) (tc : tcenv1) =
+let t_intros_i (ids : EcIdent.t list) (tc : tcenv1) =
+  fst (t_intros_i_x ids tc)
+
+(* -------------------------------------------------------------------- *)
+let t_intros_sx (ids : inames) (tc : tcenv1) =
   match ids with
-  | `Symbol x -> t_intros_i (List.map EcIdent.create x) tc
-  | `Ident  x -> t_intros_i x tc
+  | `Symbol x -> t_intros_i_x (List.map EcIdent.create x) tc
+  | `Ident  x -> t_intros_i_x x tc
+
+(* -------------------------------------------------------------------- *)
+let t_intros_s (ids : inames) (tc : tcenv1) =
+  fst (t_intros_sx ids tc)
 
 (* -------------------------------------------------------------------- *)
 let t_intros_i_1 (ids : EcIdent.t list) (tc : tcenv1) =
@@ -582,6 +595,16 @@ let t_intros_i_seq ?(clear = false) ids tt tc =
 (* -------------------------------------------------------------------- *)
 let t_intros_s_seq ids tt tc =
   FApi.t_focus tt (t_intros_s ids tc)
+
+(* -------------------------------------------------------------------- *)
+let t_intros_sx_seq ids tt tc =
+  let tc, ids = t_intros_sx ids tc in
+  FApi.t_focus (tt ids) tc
+
+(* -------------------------------------------------------------------- *)
+let t_intro_sx_seq id tt tc =
+  let tc, id = t_intro_sx id tc in
+  FApi.t_focus (tt id) tc
 
 (* -------------------------------------------------------------------- *)
 let tt_apply (pt : proofterm) (tc : tcenv) =

--- a/src/ecLowGoal.mli
+++ b/src/ecLowGoal.mli
@@ -235,15 +235,20 @@ type inames = [`Symbol of symbol list | `Ident of EcIdent.t list]
 
 val t_intros   : ident mloc list -> FApi.backward
 val t_intro_i  : ident -> FApi.backward
+val t_intro_sx : iname -> tcenv1 -> tcenv * ident
 val t_intro_s  : iname -> FApi.backward
 
-val t_intros_i : ident list -> FApi.backward
-val t_intros_s : inames -> FApi.backward
+val t_intros_i  : ident list -> FApi.backward
+val t_intros_sx : inames -> tcenv1 -> tcenv * ident list
+val t_intros_s  : inames -> FApi.backward
 
 val t_intros_i_1 : ident list -> tcenv1 -> tcenv1
 
-val t_intros_i_seq : ?clear:bool -> ident list -> FApi.backward -> FApi.backward
-val t_intros_s_seq : inames -> FApi.backward -> FApi.backward
+val t_intro_sx_seq : iname -> (ident -> FApi.backward) -> FApi.backward
+
+val t_intros_i_seq  : ?clear:bool -> ident list -> FApi.backward -> FApi.backward
+val t_intros_sx_seq : inames -> (ident list -> FApi.backward) -> FApi.backward
+val t_intros_s_seq  : inames -> FApi.backward -> FApi.backward
 
 val t_intros_n : int -> FApi.backward
 


### PR DESCRIPTION
When having a conclusion of the form "forall x, E[x]", the
intro-pattern [#] was renaming `x` as `_`.

Internal: low-level intro tactic that returns the generated intro name

fix #221