### PR TITLE
Fix ordering of variables in `rndsem`

### DIFF
--- a/src/ecCoreModules.ml
+++ b/src/ecCoreModules.ml
@@ -52,6 +52,9 @@ let lv_of_list = function
   | [(pv, ty)] -> Some (LvVar (pv, ty))
   | pvs -> Some (LvTuple pvs)
 
+let lv_to_list = function
+  | LvVar (pv, _) -> [pv]
+  | LvTuple pvs -> List.fst pvs
 
 let name_of_lv lv =
   match lv with

--- a/src/ecCoreModules.mli
+++ b/src/ecCoreModules.mli
@@ -12,6 +12,7 @@ val lv_equal     : lvalue -> lvalue -> bool
 val symbol_of_lv : lvalue -> symbol
 val ty_of_lv     : lvalue -> EcTypes.ty
 val lv_of_list   : (prog_var * ty) list -> lvalue option
+val lv_to_list   : lvalue -> prog_var list
 val name_of_lv   : lvalue -> string
 
 (* --------------------------------------------------------------------- *)


### PR DESCRIPTION
The chosen ordering is the order of appearance as a left-value
in the program.

fix #220