### PR TITLE
[breaking] Unify meaning of `by []` in proofs and lemma declarations

### DIFF
--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -1039,10 +1039,8 @@ module Ax = struct
       match tc with
       | Some tc -> tc
       | None    ->
-          let dtc = Plogic (Psmt empty_pprover) in
-          let dtc = { pl_loc = loc; pl_desc = dtc } in
-          let dtc = { pt_core = dtc; pt_intros = []; } in
-          [dtc]
+          let dtc = { pl_loc = loc; pl_desc = Pby None; } in
+          [{ pt_core = dtc; pt_intros = []; }]
     in
 
     let tc = { pl_loc = loc; pl_desc = Pby (Some tc) } in

--- a/theories/core/Bool.ec
+++ b/theories/core/Bool.ec
@@ -5,19 +5,19 @@ require import FinType.
 op (^^) (b1 b2:bool) = b1 = !b2.
 
 lemma nosmt xor_false b: b ^^ false = b
-by smt().
+by case: b.
 
 lemma nosmt xor_true b: b ^^ true = !b
-by smt().
+by case: b.
 
 lemma nosmt xorA b1 b2 b3: (b1 ^^ b2) ^^ b3 = b1 ^^ (b2 ^^ b3)
-by smt().
+by case: b1 b2 b3=> - [] [].
 
 lemma nosmt xorC b1 b2: b1 ^^ b2 = b2 ^^ b1
-by smt().
+by case: b1 b2=> - [].
 
 lemma nosmt xorK b: b ^^ b = false
-by smt().
+by case: b.
 
 clone FinType as BoolFin with
   type t    <- bool,

--- a/theories/core/Bool.ec
+++ b/theories/core/Bool.ec
@@ -5,19 +5,19 @@ require import FinType.
 op (^^) (b1 b2:bool) = b1 = !b2.
 
 lemma nosmt xor_false b: b ^^ false = b
-by [].
+by smt().
 
 lemma nosmt xor_true b: b ^^ true = !b
-by [].
+by smt().
 
 lemma nosmt xorA b1 b2 b3: (b1 ^^ b2) ^^ b3 = b1 ^^ (b2 ^^ b3)
-by [].
+by smt().
 
 lemma nosmt xorC b1 b2: b1 ^^ b2 = b2 ^^ b1
-by [].
+by smt().
 
 lemma nosmt xorK b: b ^^ b = false
-by [].
+by smt().
 
 clone FinType as BoolFin with
   type t    <- bool,

--- a/theories/core/Core.ec
+++ b/theories/core/Core.ec
@@ -34,8 +34,12 @@ proof. by case: ox. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt frefl  (f     : 'a -> 'b): f == f by [].
-lemma nosmt fsym   (f g   : 'a -> 'b): f == g => g == f by smt().
-lemma nosmt ftrans (f g h : 'a -> 'b): f == g => g == h => f == h by smt().
+
+lemma nosmt fsym   (f g   : 'a -> 'b): f == g => g == f.
+proof. by move=> + x - /(_ x) ->. qed.
+
+lemma nosmt ftrans (f g h : 'a -> 'b): f == g => g == h => f == h.
+proof. by move=> + + x - /(_ x) -> /(_ x). qed.
 
 (* -------------------------------------------------------------------- *)
 lemma econgr1 ['a 'b] (f g : 'a -> 'b) x y: f == g => x = y => f x = g y.
@@ -43,8 +47,12 @@ proof. by move/fun_ext=> -> ->. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt f2refl  (f     : 'a -> 'b -> 'c): f === f by [].
-lemma nosmt f2sym   (f g   : 'a -> 'b -> 'c): f === g => g === f by smt().
-lemma nosmt f2trans (f g h : 'a -> 'b -> 'c): f === g => g === h => f === h by smt().
+
+lemma nosmt f2sym   (f g   : 'a -> 'b -> 'c): f === g => g === f.
+proof. by move=> + x y - /(_ x y) ->. qed.
+
+lemma nosmt f2trans (f g h : 'a -> 'b -> 'c): f === g => g === h => f === h.
+proof. by move=> + + x y - /(_ x y) -> /(_ x y). qed.
 
 lemma rel_ext (f g : 'a -> 'b -> 'c) : f = g <=> f === g.
 proof.
@@ -196,39 +204,40 @@ pred (< ) (p q:'a -> bool) = (* proper *)
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt subpred_eqP (p1 p2 : 'a -> bool):
-  (forall x, p1 x <=> p2 x) <=> (p1 <= p2 /\ p2 <= p1)
-by smt().
+  (forall x, p1 x <=> p2 x) <=> (p1 <= p2 /\ p2 <= p1).
+proof.
+split=> [PQ|[] + + x].
++ by split=> x /PQ.
+by move=> /(_ x) + /(_ x).
+qed.
 
 lemma nosmt subpred_refl (X : 'a -> bool): X <= X
 by [].
 
 lemma nosmt subpred_asym (X Y:'a -> bool):
-  X <= Y => Y <= X => X = Y
-by (rewrite fun_ext; smt).
+  X <= Y => Y <= X => X = Y.
+proof. by rewrite pred_ext subpred_eqP. qed.
 
 lemma nosmt subpred_trans (X Y Z:'a -> bool):
-  X <= Y => Y <= Z => X <= Z
-by smt().
+  X <= Y => Y <= Z => X <= Z.
+proof. by move=> + + x - /(_ x) Xx /(_ x) Yx /Xx /Yx. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt pred1E (c : 'a) : pred1 c = ((=) c).
 proof. by apply fun_ext=> x; rewrite (eq_sym c). qed.
 
 lemma nosmt predU1l (x y : 'a) b : x = y => (x = y) \/ b by [].
-lemma nosmt predU1r (x y : 'a) b : b => (x = y) \/ b by smt().
-lemma nosmt eqVneq (x y : 'a) : x = y \/ x <> y by smt().
+lemma nosmt predU1r (x y : 'a) b : b => (x = y) \/ b by case: b.
+lemma nosmt eqVneq (x y : 'a) : x = y \/ x <> y by case: (x = y).
 
-lemma nosmt predT_comp ['a 'b] (p : 'a -> 'b) : predT \o p = predT.
-proof. by []. qed.
+lemma nosmt predT_comp ['a 'b] (p : 'a -> 'b) : predT \o p = predT by [].
 
 lemma nosmt predIC (p1 p2 : 'a -> bool) : predI p1 p2 = predI p2 p1.
 proof. by apply fun_ext=> x; rewrite /predI andbC. qed.
 
-lemma nosmt predIT ['a] p : predI<:'a> p predT = p.
-proof. by []. qed.
+lemma nosmt predIT ['a] p : predI<:'a> p predT = p by [].
 
-lemma nosmt predTI ['a] p : predI<:'a> predT p = p.
-proof. by []. qed.
+lemma nosmt predTI ['a] p : predI<:'a> predT p = p by [].
 
 lemma nosmt predCI (p : 'a -> bool) : predI (predC p) p = pred0.
 proof. by apply/fun_ext=> x /=; delta => /=; rewrite andNb. qed.
@@ -237,20 +246,20 @@ lemma nosmt predCU (p : 'a -> bool) : predU (predC p) p = predT.
 proof. by apply/fun_ext=> x /=; delta => /=; case: (p x). qed.
 
 lemma nosmt subpredUl (p1 p2 : 'a -> bool):
-  p1 <= predU p1 p2
-by smt().
+  p1 <= predU p1 p2.
+proof. by move=> x @/predU ->. qed.
 
 lemma nosmt subpredUr (p1 p2 : 'a -> bool):
-  p2 <= predU p1 p2
-by smt().
+  p2 <= predU p1 p2.
+proof. by move=> x @/predU ->. qed.
 
 lemma nosmt predIsubpredl (p1 p2 : 'a -> bool):
-  predI p1 p2 <= p1
-by smt().
+  predI p1 p2 <= p1.
+proof. by move=> x @/predI [] ->. qed.
 
 lemma nosmt predIsubpredr (p1 p2 : 'a -> bool):
-  predI p1 p2 <= p2
-by smt().
+  predI p1 p2 <= p2.
+proof. by move=> x @/predI [] _ ->. qed.
 
 lemma nosmt predTofV (f : 'a -> 'b): predT \o f = predT.
 proof. by apply/fun_ext=> x. qed.

--- a/theories/core/Core.ec
+++ b/theories/core/Core.ec
@@ -34,8 +34,8 @@ proof. by case: ox. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt frefl  (f     : 'a -> 'b): f == f by [].
-lemma nosmt fsym   (f g   : 'a -> 'b): f == g => g == f by [].
-lemma nosmt ftrans (f g h : 'a -> 'b): f == g => g == h => f == h by [].
+lemma nosmt fsym   (f g   : 'a -> 'b): f == g => g == f by smt().
+lemma nosmt ftrans (f g h : 'a -> 'b): f == g => g == h => f == h by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma econgr1 ['a 'b] (f g : 'a -> 'b) x y: f == g => x = y => f x = g y.
@@ -43,8 +43,8 @@ proof. by move/fun_ext=> -> ->. qed.
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt f2refl  (f     : 'a -> 'b -> 'c): f === f by [].
-lemma nosmt f2sym   (f g   : 'a -> 'b -> 'c): f === g => g === f by [].
-lemma nosmt f2trans (f g h : 'a -> 'b -> 'c): f === g => g === h => f === h by [].
+lemma nosmt f2sym   (f g   : 'a -> 'b -> 'c): f === g => g === f by smt().
+lemma nosmt f2trans (f g h : 'a -> 'b -> 'c): f === g => g === h => f === h by smt().
 
 lemma rel_ext (f g : 'a -> 'b -> 'c) : f = g <=> f === g.
 proof.
@@ -197,7 +197,7 @@ pred (< ) (p q:'a -> bool) = (* proper *)
 (* -------------------------------------------------------------------- *)
 lemma nosmt subpred_eqP (p1 p2 : 'a -> bool):
   (forall x, p1 x <=> p2 x) <=> (p1 <= p2 /\ p2 <= p1)
-by [].
+by smt().
 
 lemma nosmt subpred_refl (X : 'a -> bool): X <= X
 by [].
@@ -208,15 +208,15 @@ by (rewrite fun_ext; smt).
 
 lemma nosmt subpred_trans (X Y Z:'a -> bool):
   X <= Y => Y <= Z => X <= Z
-by [].
+by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt pred1E (c : 'a) : pred1 c = ((=) c).
 proof. by apply fun_ext=> x; rewrite (eq_sym c). qed.
 
 lemma nosmt predU1l (x y : 'a) b : x = y => (x = y) \/ b by [].
-lemma nosmt predU1r (x y : 'a) b : b => (x = y) \/ b by [].
-lemma nosmt eqVneq (x y : 'a) : x = y \/ x <> y by [].
+lemma nosmt predU1r (x y : 'a) b : b => (x = y) \/ b by smt().
+lemma nosmt eqVneq (x y : 'a) : x = y \/ x <> y by smt().
 
 lemma nosmt predT_comp ['a 'b] (p : 'a -> 'b) : predT \o p = predT.
 proof. by []. qed.
@@ -238,19 +238,19 @@ proof. by apply/fun_ext=> x /=; delta => /=; case: (p x). qed.
 
 lemma nosmt subpredUl (p1 p2 : 'a -> bool):
   p1 <= predU p1 p2
-by [].
+by smt().
 
 lemma nosmt subpredUr (p1 p2 : 'a -> bool):
   p2 <= predU p1 p2
-by [].
+by smt().
 
 lemma nosmt predIsubpredl (p1 p2 : 'a -> bool):
   predI p1 p2 <= p1
-by [].
+by smt().
 
 lemma nosmt predIsubpredr (p1 p2 : 'a -> bool):
   predI p1 p2 <= p2
-by [].
+by smt().
 
 lemma nosmt predTofV (f : 'a -> 'b): predT \o f = predT.
 proof. by apply/fun_ext=> x. qed.

--- a/theories/crypto/PRP.eca
+++ b/theories/crypto/PRP.eca
@@ -294,7 +294,7 @@ lemma collision_stable (m:(D,D) fmap) y y':
   collision m =>
   y \notin m =>
   collision m.[y <- y']
-by [].
+by smt(collision_add).
 
 (** To factor out the difficult step, we parameterize the PRP by a
     procedure that samples its output, and provide two instantiations
@@ -595,8 +595,8 @@ section CollisionProbability.
   + proc; inline*.
     if => //=.
     auto => /> &1 &2 h1 h2 h3 h4 r _.
-    rewrite fdom_set fcardUI_indep 2:fcard1; 1: by rewrite fsetI1 mem_fdom h4. 
-    smt (get_setE mem_frng rngE collision_add).
+    rewrite fdom_set fcardUI_indep 2:fcard1; 1: by rewrite fsetI1 mem_fdom h4.
+    smt(get_setE mem_frng rngE collision_add).
   auto; smt (size_eq0 fdom0 fcards0 frng0 in_fset0 mem_empty).
   qed.
 

--- a/theories/crypto/PRP.eca
+++ b/theories/crypto/PRP.eca
@@ -293,8 +293,8 @@ qed.
 lemma collision_stable (m:(D,D) fmap) y y':
   collision m =>
   y \notin m =>
-  collision m.[y <- y']
-by smt(collision_add).
+  collision m.[y <- y'].
+proof. by move=> h /collision_add /= ->; rewrite h. qed.
 
 (** To factor out the difficult step, we parameterize the PRP by a
     procedure that samples its output, and provide two instantiations

--- a/theories/datatypes/Int.ec
+++ b/theories/datatypes/Int.ec
@@ -307,9 +307,9 @@ lemma odd0 : !odd 0. proof. by rewrite /odd iter0. qed.
 lemma odd1 :  odd 1. proof. by rewrite /odd iter1. qed.
 lemma odd2 : !odd 2. proof. by rewrite /odd iter2. qed.
 
-lemma oddN z : odd (-z) = odd z by [].
-lemma odd_abs z : odd `|z| = odd z by [].
-lemma oddS z : odd (z + 1) = !(odd z) by [].
+lemma oddN z : odd (-z) = odd z by smt().
+lemma odd_abs z : odd `|z| = odd z by smt().
+lemma oddS z : odd (z + 1) = !(odd z) by smt(iterS).
 
 lemma odd3 : odd 3.
 proof. by rewrite (oddS 2) odd2. qed.

--- a/theories/datatypes/Real.ec
+++ b/theories/datatypes/Real.ec
@@ -23,8 +23,12 @@ lemma nosmt fromint0 : 0%r = CoreReal.zero by [].
 lemma nosmt fromint1 : 1%r = CoreReal.one  by [].
 
 lemma nosmt fromintN (z     : int) : (-z)%r = - z%r by smt().
+
 lemma nosmt fromintD (z1 z2 : int) : (z1 + z2)%r = z1%r + z2%r by smt().
-lemma nosmt fromintB (z1 z2 : int) : (z1 - z2)%r = z1%r - z2%r by smt().
+
+lemma nosmt fromintB (z1 z2 : int) : (z1 - z2)%r = z1%r - z2%r.
+proof. by rewrite fromintD fromintN. qed.
+
 lemma nosmt fromintM (z1 z2 : int) : (z1 * z2)%r = z1%r * z2%r by smt().
 
 lemma nosmt eq_fromint (z1 z2 : int) :

--- a/theories/datatypes/Real.ec
+++ b/theories/datatypes/Real.ec
@@ -22,24 +22,24 @@ abbrev b2r (b:bool) = if b then from_int 1 else from_int 0.
 lemma nosmt fromint0 : 0%r = CoreReal.zero by [].
 lemma nosmt fromint1 : 1%r = CoreReal.one  by [].
 
-lemma nosmt fromintN (z     : int) : (-z)%r = - z%r by [].
-lemma nosmt fromintD (z1 z2 : int) : (z1 + z2)%r = z1%r + z2%r by [].
-lemma nosmt fromintB (z1 z2 : int) : (z1 - z2)%r = z1%r - z2%r by [].
-lemma nosmt fromintM (z1 z2 : int) : (z1 * z2)%r = z1%r * z2%r by [].
+lemma nosmt fromintN (z     : int) : (-z)%r = - z%r by smt().
+lemma nosmt fromintD (z1 z2 : int) : (z1 + z2)%r = z1%r + z2%r by smt().
+lemma nosmt fromintB (z1 z2 : int) : (z1 - z2)%r = z1%r - z2%r by smt().
+lemma nosmt fromintM (z1 z2 : int) : (z1 * z2)%r = z1%r * z2%r by smt().
 
 lemma nosmt eq_fromint (z1 z2 : int) :
   (z1%r = z2%r) <=> (z1 = z2)
-by [].
+by smt().
 
 lemma nosmt le_fromint (z1 z2 : int) :
   (z1%r <= z2%r) <=> (z1 <= z2)
-by smt ml=0.
+by smt().
 
 lemma nosmt lt_fromint (z1 z2 : int) :
   (z1%r < z2%r) <=> (z1 < z2)
-by smt ml=0.
+by smt().
 
-lemma nosmt fromint_abs  (z : int) : `|z|%r = `|z%r| by smt ml=0.
+lemma nosmt fromint_abs  (z : int) : `|z|%r = `|z%r| by smt().
 
 hint rewrite lte_fromint : le_fromint lt_fromint.
 
@@ -237,22 +237,22 @@ lemma nosmt upto2_abs (x1 x2 x3 x4 x5:real):
    x1 <= x5 =>
    x3 <= x5 =>
    x2 = x4 =>
-   `|x1 + x2 - (x3 + x4)| <= x5 by [].
+   `|x1 + x2 - (x3 + x4)| <= x5 by smt().
 
 lemma nosmt upto2_notbad (ev1 ev2 bad1 bad2:bool) :
   ((bad1 <=> bad2) /\ (!bad2 => (ev1 <=> ev2))) =>
-  ((ev1 /\ !bad1) <=> (ev2 /\ !bad2)) by [].
+  ((ev1 /\ !bad1) <=> (ev2 /\ !bad2)) by smt().
 
 lemma nosmt upto2_imp_bad (ev1 ev2 bad1 bad2:bool) :
   ((bad1 <=> bad2) /\ (!bad2 => (ev1 <=> ev2))) =>
   (ev1 /\ bad1) => bad2 by [].
 
 lemma nosmt upto_bad_false (ev bad2:bool) :
-  !((ev /\ !bad2) /\ bad2) by [].
+  !((ev /\ !bad2) /\ bad2) by smt().
 
 lemma nosmt upto_bad_or (ev1 ev2 bad2:bool) :
    (!bad2 => ev1 => ev2) => ev1 =>
-    ev2 /\ !bad2 \/ bad2 by [].
+    ev2 /\ !bad2 \/ bad2 by smt().
 
 lemma nosmt upto_bad_sub (ev bad:bool) :
   ev /\ ! bad => ev by [].

--- a/theories/prelude/Logic.ec
+++ b/theories/prelude/Logic.ec
@@ -302,7 +302,7 @@ by [].
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt andaE a b : (a && b) <=> (a /\ b) by [].
-lemma nosmt oraE  a b : (a || b) <=> (a \/ b) by [].
+lemma nosmt oraE  a b : (a || b) <=> (a \/ b) by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma eqboolP (b1 b2 : bool) : (b1 = b2) <=> (b1 <=> b2) by [].
@@ -319,39 +319,39 @@ op (^) b1 b2  = if b1 then !b2 else b2.
 (* -------------------------------------------------------------------- *)
 lemma nosmt negP: forall (x:bool), (x => false) <=> !x by [].
 
-lemma nosmt eqT : forall (x:bool), (x = true) <=> x by [].
-lemma nosmt neqF : forall (x:bool), (x = false) <=> !x by [].
+lemma nosmt eqT : forall (x:bool), (x = true) <=> x by smt().
+lemma nosmt neqF : forall (x:bool), (x = false) <=> !x by smt().
 
 lemma nosmt negbT b  : b = false => !b by [].
-lemma nosmt negbTE b : !b => b = false by [].
-lemma nosmt negbF b  : b => !b = false by [].
-lemma nosmt negbFE b : !b = false => b by [].
+lemma nosmt negbTE b : !b => b = false by smt().
+lemma nosmt negbF b  : b => !b = false by smt().
+lemma nosmt negbFE b : !b = false => b by smt().
 lemma nosmt negbK    : involutive [!]  by [].
 lemma nosmt negbNE b : !!b => b        by [].
 
-lemma nosmt negb_inj : injective [!]      by [].
-lemma nosmt negbLR b c : b = !c => !b = c by [].
-lemma nosmt negbRL b c : !b = c => b = !c by [].
+lemma nosmt negb_inj : injective [!]      by smt().
+lemma nosmt negbLR b c : b = !c => !b = c by smt().
+lemma nosmt negbRL b c : !b = c => b = !c by smt().
 
-lemma nosmt contra   c b : (c => b) => !b => !c by [].
-lemma nosmt contraL  c b : (c => !b) => b => !c by [].
-lemma nosmt contraR  c b : (!c => b) => !b => c by [].
-lemma nosmt contraLR c b : (!c => !b) => b => c by [].
+lemma nosmt contra   c b : (c => b) => !b => !c by smt().
+lemma nosmt contraL  c b : (c => !b) => b => !c by smt().
+lemma nosmt contraR  c b : (!c => b) => !b => c by smt().
+lemma nosmt contraLR c b : (!c => !b) => b => c by smt().
 lemma nosmt contraT  b   : (!b => false) => b   by [].
 
-lemma nosmt absurd (b a : bool) : (!a => !b) => b => a by [].
+lemma nosmt absurd (b a : bool) : (!a => !b) => b => a by smt().
 
-lemma nosmt wlog_neg b : (!b => b) => b by [].
+lemma nosmt wlog_neg b : (!b => b) => b by smt().
 
 lemma nosmt contraFT c b : (!c => b) => b = false => c by [].
 lemma nosmt contraFN c b : (c => b) => b = false => !c by [].
-lemma nosmt contraTF c b : (c => !b) => b => c = false by [].
-lemma nosmt contraNF c b : (c => b) => !b => c = false by [].
-lemma nosmt contraFF c b : (c => b) => b = false => c = false by [].
+lemma nosmt contraTF c b : (c => !b) => b => c = false by smt().
+lemma nosmt contraNF c b : (c => b) => !b => c = false by smt().
+lemma nosmt contraFF c b : (c => b) => b = false => c = false by smt().
 
 lemma nosmt contraNneq (b : bool) (x y : 'a):
   (x = y => b) => !b => x <> y
-by [].
+by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt iffLR (a b : bool) : (a <=> b) => a => b by [].
@@ -371,27 +371,27 @@ by [].
 
 lemma  if_neg b (vT vF : 'a) :
   (if !b then vT else vF) = if b then vF else vT
-by [].
+by smt().
 
 lemma  fun_if ['a 'b] (f:'a -> 'b) b x1 x2 :
   f (if b then x1 else x2) = (if b then f x1 else f x2)
-by [].
+by smt().
 
 lemma  fun_if2 ['a 'b 'c] (f:'a -> 'b -> 'c) b x1 x2 x :
   f (if b then x1 else x2) x = (if b then f x1 x else f x2 x)
-by [].
+by smt().
 
 lemma  if_arg b x (fT fF : 'a -> 'b) :
   (if b then fT else fF) x = if b then fT x else fF x
-by [].
+by smt().
 
 lemma ifT (b : bool) (e1 e2 : 'a) : 
   b => (if b then e1 else e2) = e1 
-by [].
+by move=> ->.
 
 lemma ifF (b : bool) (e1 e2 : 'a) : 
  !b => (if b then e1 else e2) = e2
-by [].
+by move=> ->.
 
 lemma  iffP p q r :
   (r <=> q) => (p => q) => (q => p) => r <=> p
@@ -406,7 +406,7 @@ lemma nosmt andTb : left_id true (/\)       by [].
 lemma nosmt andFb : left_zero false (/\)    by [].
 lemma nosmt andbT : right_id true (/\)      by [].
 lemma nosmt andbF : right_zero false (/\)   by [].
-lemma nosmt andbb : idempotent (/\)         by [].
+lemma nosmt andbb : idempotent (/\)         by smt().
 lemma nosmt andbC : commutative (/\)        by move=> [] /#.
 lemma nosmt andbA : associative (/\)        by move=> [] /#.
 lemma nosmt andbCA : left_commutative (/\)  by move=> [] /#.
@@ -417,52 +417,52 @@ lemma nosmt orTb : forall b, true \/ b     by [].
 lemma nosmt orFb : left_id false (\/)      by [].
 lemma nosmt orbT : forall b, b \/ true     by [].
 lemma nosmt orbF : right_id false (\/)     by [].
-lemma nosmt orbb : idempotent (\/)         by [].
-lemma nosmt orbC : commutative (\/)        by [].
-lemma nosmt orbA : associative (\/)        by [].
-lemma nosmt orbCA : left_commutative (\/)  by [].
-lemma nosmt orbAC : right_commutative (\/) by [].
-lemma nosmt orbACA : interchange (\/) (\/) by [].
+lemma nosmt orbb : idempotent (\/)         by smt().
+lemma nosmt orbC : commutative (\/)        by smt().
+lemma nosmt orbA : associative (\/)        by smt().
+lemma nosmt orbCA : left_commutative (\/)  by smt().
+lemma nosmt orbAC : right_commutative (\/) by smt().
+lemma nosmt orbACA : interchange (\/) (\/) by smt().
 
-lemma nosmt andbN b : (b /\ !b) <=> false by [].
-lemma nosmt andNb b : (!b /\ b) <=> false by [].
-lemma nosmt orbN b  : (b \/ !b) <=> true  by [].
-lemma nosmt orNb b  : (!b \/ b) <=> true  by [].
+lemma nosmt andbN b : (b /\ !b) <=> false by smt().
+lemma nosmt andNb b : (!b /\ b) <=> false by smt().
+lemma nosmt orbN b  : (b \/ !b) <=> true  by smt().
+lemma nosmt orNb b  : (!b \/ b) <=> true  by smt().
 
 lemma nosmt andb_orl : left_distributive  (/\) (\/) by move=> [] /#.
 lemma nosmt andb_orr : right_distributive (/\) (\/) by move=> [] /#.
 lemma nosmt orb_andl : left_distributive  (\/) (/\) by move=> [] /#.
 lemma nosmt orb_andr : right_distributive (\/) (/\) by move=> [] /#.
 
-lemma nosmt andb_idl a b : (b => a) => a /\ b <=> b by [].
-lemma nosmt andb_idr a b : (a => b) => a /\ b <=> a by [].
+lemma nosmt andb_idl a b : (b => a) => a /\ b <=> b by smt().
+lemma nosmt andb_idr a b : (a => b) => a /\ b <=> a by smt().
 
-lemma nosmt andb_id2l a b c : (a => b = c) => a /\ b <=> a /\ c by [].
-lemma nosmt andb_id2r a b c : (b => a = c) => a /\ b <=> c /\ b by [].
+lemma nosmt andb_id2l a b c : (a => b = c) => a /\ b <=> a /\ c by smt().
+lemma nosmt andb_id2r a b c : (b => a = c) => a /\ b <=> c /\ b by smt().
 
-lemma nosmt orb_idl a b : (a => b) => a \/ b <=> b by [].
-lemma nosmt orb_idr a b : (b => a) => a \/ b <=> a by [].
+lemma nosmt orb_idl a b : (a => b) => a \/ b <=> b by smt().
+lemma nosmt orb_idr a b : (b => a) => a \/ b <=> a by smt().
 
-lemma nosmt orb_id2l a b c : (!a => b = c) => a \/ b <=> a \/ c by [].
-lemma nosmt orb_id2r a b c : (!b => a = c) => a \/ b <=> c \/ b by [].
+lemma nosmt orb_id2l a b c : (!a => b = c) => a \/ b <=> a \/ c by smt().
+lemma nosmt orb_id2r a b c : (!b => a = c) => a \/ b <=> c \/ b by smt().
 
-lemma nosmt negb_and a b : !(a /\ b) <=> !a \/ !b by [].
-lemma nosmt negb_or  a b : !(a \/ b) <=> !a /\ !b by [].
+lemma nosmt negb_and a b : !(a /\ b) <=> !a \/ !b by smt().
+lemma nosmt negb_or  a b : !(a \/ b) <=> !a /\ !b by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt negb_exists (P : 'a -> bool) :
   !(exists a, P a) <=> forall a, !P a
-by [].
+by smt().
 
 lemma nosmt negb_forall (P : 'a -> bool) :
   !(forall a, P a) <=> exists a, !P a
-by [].
+by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt andbK a b : a /\ b \/ a <=> a  by [].
-lemma nosmt andKb a b : a \/ b /\ a <=> a  by [].
-lemma nosmt orbK a b : (a \/ b) /\ a <=> a by [].
-lemma nosmt orKb a b : a /\ (b \/ a) <=> a by [].
+lemma nosmt andbK a b : a /\ b \/ a <=> a  by smt().
+lemma nosmt andKb a b : a \/ b /\ a <=> a  by smt().
+lemma nosmt orbK a b : (a \/ b) /\ a <=> a by smt().
+lemma nosmt orKb a b : a /\ (b \/ a) <=> a by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt implybT b : b => true         by [].
@@ -471,50 +471,50 @@ lemma nosmt implyFb b : false => b        by [].
 lemma nosmt implyTb b : (true => b) = b   by [].
 lemma nosmt implybb b : b => b            by [].
 
-lemma nosmt negb_imply a b : !(a => b) <=> a /\ !b by [].
+lemma nosmt negb_imply a b : !(a => b) <=> a /\ !b by smt().
 
-lemma nosmt implybE  a b : (a => b) <=> !a \/ b by [].
-lemma nosmt implyNb  a b : (!a => b) <=> a \/ b by [].
-lemma nosmt implybN  a b : (a => !b) <=> (b => !a) by [].
-lemma nosmt implybNN a b : (!a => !b) <=> (b => a) by [].
+lemma nosmt implybE  a b : (a => b) <=> !a \/ b by smt().
+lemma nosmt implyNb  a b : (!a => b) <=> a \/ b by smt().
+lemma nosmt implybN  a b : (a => !b) <=> (b => !a) by smt().
+lemma nosmt implybNN a b : (!a => !b) <=> (b => a) by smt().
 
-lemma nosmt implyb_idl a b : (!a => b) => (a => b) <=> b by [].
-lemma nosmt implyb_idr a b : (b => !a) => (a => b) <=> !a by [].
+lemma nosmt implyb_idl a b : (!a => b) => (a => b) <=> b by smt().
+lemma nosmt implyb_idr a b : (b => !a) => (a => b) <=> !a by smt().
 
 lemma nosmt implyb_id2l (a b c : bool) :
   (a => b <=> c) => (a => b) <=> (a => c)
-by [].
+by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt addFb : left_id false (^)               by [].
 lemma nosmt addbF : right_id false (^)              by [].
-lemma nosmt addbb : self_inverse false (^)          by [].
-lemma nosmt addbC : commutative (^)                 by [].
-lemma nosmt addbA : associative (^)                 by [].
-lemma nosmt addbCA : left_commutative (^)           by [].
-lemma nosmt addbAC : right_commutative (^)          by [].
-lemma nosmt addbACA : interchange (^) (^)           by [].
-lemma nosmt andb_addl : left_distributive (/\) (^)  by [].
-lemma nosmt andb_addr : right_distributive (/\) (^) by [].
-lemma nosmt addKb : left_loop idfun (^)             by [].
-lemma nosmt addbK : right_loop idfun (^)            by [].
-lemma nosmt addIb : left_injective (^)              by [].
-lemma nosmt addbI : right_injective (^)             by [].
+lemma nosmt addbb : self_inverse false (^)          by smt().
+lemma nosmt addbC : commutative (^)                 by smt().
+lemma nosmt addbA : associative (^)                 by smt().
+lemma nosmt addbCA : left_commutative (^)           by smt().
+lemma nosmt addbAC : right_commutative (^)          by smt().
+lemma nosmt addbACA : interchange (^) (^)           by smt().
+lemma nosmt andb_addl : left_distributive (/\) (^)  by smt().
+lemma nosmt andb_addr : right_distributive (/\) (^) by smt().
+lemma nosmt addKb : left_loop idfun (^)             by smt().
+lemma nosmt addbK : right_loop idfun (^)            by smt().
+lemma nosmt addIb : left_injective (^)              by smt().
+lemma nosmt addbI : right_injective (^)             by smt().
 
 lemma nosmt addTb b : true ^ b <=> !b by [].
 lemma nosmt addbT b : b ^ true <=> !b by [].
 
-lemma nosmt addbN a b : a ^ !b <=> !(a ^ b) by [].
+lemma nosmt addbN a b : a ^ !b <=> !(a ^ b) by smt().
 lemma nosmt addNb a b : !a ^ b <=> !(a ^ b) by [].
 
-lemma nosmt addbP a b : (!a <=> b) <=> (a ^ b) by [].
+lemma nosmt addbP a b : (!a <=> b) <=> (a ^ b) by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt andaP b1 b2 : b1 => (b1 => b2) => b1 /\ b2 by [].
-lemma nosmt oraP  b1 b2 : b1 \/ b2 <=> b1 \/ (!b1 => b2) by [].
+lemma nosmt andaP b1 b2 : b1 => (b1 => b2) => b1 /\ b2 by smt().
+lemma nosmt oraP  b1 b2 : b1 \/ b2 <=> b1 \/ (!b1 => b2) by smt().
 
 lemma nosmt andabP b1 b2 : b1 && b2 <=> b1 /\ b2 by [].
-lemma nosmt orabP  b1 b2 : b1 || b2 <=> b1 \/ b2 by [].
+lemma nosmt orabP  b1 b2 : b1 || b2 <=> b1 \/ b2 by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt forall_orl (P : bool) (Q : 'a -> bool) :

--- a/theories/prelude/Tactics.ec
+++ b/theories/prelude/Tactics.ec
@@ -1,98 +1,97 @@
 (* -------------------------------------------------------------------- *)
-lemma nosmt unitW (P : unit -> bool): P 
-tt => forall x, P x by [].
+lemma nosmt unitW (P : unit -> bool): P tt => forall x, P x by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt trueI : true by [].
+lemma nosmt trueI : true by smt().
 
-lemma nosmt falseW (c : bool) : false => c by [].
+lemma nosmt falseW (c : bool) : false => c by smt().
 
 lemma nosmt boolW (P : bool -> bool) :
-  P true => P false => forall b, P b by [].
+  P true => P false => forall b, P b by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt andW a b c : (a => b => c) => (a /\ b) => c by [].
+lemma nosmt andW a b c : (a => b => c) => (a /\ b) => c by smt().
 
-lemma nosmt andWl a b : (a /\ b) => a by [].
-lemma nosmt andWr a b : (a /\ b) => b by [].
+lemma nosmt andWl a b : (a /\ b) => a by smt().
+lemma nosmt andWr a b : (a /\ b) => b by smt().
 
-lemma nosmt andI a b : a => b => (a /\ b) by [].
-
-(* -------------------------------------------------------------------- *)
-lemma nosmt orW a b c : (a => c) => (b => c) => (a \/ b) => c by [].
-
-lemma nosmt orIl a b : a => a \/ b by [].
-lemma nosmt orIr a b : b => a \/ b by [].
+lemma nosmt andI a b : a => b => (a /\ b) by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt andaW a b c : (a => b => c) => (a && b) => c by [].
+lemma nosmt orW a b c : (a => c) => (b => c) => (a \/ b) => c by smt().
 
-lemma nosmt andaWl a b : (a && b) => a by [].
-lemma nosmt andaWr a b : (a && b) => (a => b) by [].
-
-lemma nosmt andaI a b : a => (a => b) => (a && b) by [].
+lemma nosmt orIl a b : a => a \/ b by smt().
+lemma nosmt orIr a b : b => a \/ b by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt oraW a b c : (a => c) => (!a => b => c) => (a || b) => c by [].
+lemma nosmt andaW a b c : (a => b => c) => (a && b) => c by smt().
 
-lemma nosmt oraIl a b : a => a || b by [].
-lemma nosmt oraIr a b : (!a => b) => a || b by [].
+lemma nosmt andaWl a b : (a && b) => a by smt().
+lemma nosmt andaWr a b : (a && b) => (a => b) by smt().
+
+lemma nosmt andaI a b : a => (a => b) => (a && b) by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt iffW a b c : ((a => b) => (b => a) => c) => (a <=> b) => c by [].
-lemma nosmt iffI a b : (a => b) => (b => a) => (a <=> b) by [].
+lemma nosmt oraW a b c : (a => c) => (!a => b => c) => (a || b) => c by smt().
 
-lemma nosmt iffLR a b : (a <=> b) => a => b by [].
-lemma nosmt iffRL a b : (a <=> b) => b => a by [].
+lemma nosmt oraIl a b : a => a || b by smt().
+lemma nosmt oraIr a b : (!a => b) => a || b by smt().
+
+(* -------------------------------------------------------------------- *)
+lemma nosmt iffW a b c : ((a => b) => (b => a) => c) => (a <=> b) => c by smt().
+lemma nosmt iffI a b : (a => b) => (b => a) => (a <=> b) by smt().
+
+lemma nosmt iffLR a b : (a <=> b) => a => b by smt().
+lemma nosmt iffRL a b : (a <=> b) => b => a by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt ifW a bt bf c :
   (a => bt => c) => (!a => bf => c) => (if a then bt else bf) => c
-by [].
+by smt().
 
 lemma nosmt ifI a bt bf :
   (a => bt) => (!a => bf) => if a then bt else bf
-by [].
+by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt orDandN : forall a b, ((b /\ a) \/ (!b /\ a)) = a by [].
-lemma nosmt andDorN : forall a b, ((b /\ a) /\ (!b /\ a)) = false by [].
+lemma nosmt orDandN : forall a b, ((b /\ a) \/ (!b /\ a)) = a by smt().
+lemma nosmt andDorN : forall a b, ((b /\ a) /\ (!b /\ a)) = false by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt cut_ a b : a => (a => b) => b by [].
+lemma nosmt cut_ a b : a => (a => b) => b by smt().
 
 lemma nosmt boolWE (p : bool -> bool) x :
    (x => p true) => (!x => p false) => p x
-by [].
+by smt().
 
-lemma nosmt dup p q : (p => p => q) => p => q by [].
+lemma nosmt dup p q : (p => p => q) => p => q by smt().
 
-lemma nosmt negeqF: forall (x:bool), !x => (x =  false) by [].
-lemma nosmt negbTE: forall (x:bool), !x => (x => false) by [].
+lemma nosmt negeqF: forall (x:bool), !x => (x =  false) by smt().
+lemma nosmt negbTE: forall (x:bool), !x => (x => false) by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt eq_refl  : forall (x : 'a), x = x by [].
-lemma nosmt eq_sym   : forall (x y : 'a), x = y <=> y = x by [].
-lemma nosmt eq_trans : forall (x y z : 'a), x = y => y = z => x = z by [].
-lemma nosmt eq_iff   : forall a b, (a = b) <=> (a <=> b) by [].
+lemma nosmt eq_refl  : forall (x : 'a), x = x by smt().
+lemma nosmt eq_sym   : forall (x y : 'a), x = y <=> y = x by smt().
+lemma nosmt eq_trans : forall (x y z : 'a), x = y => y = z => x = z by smt().
+lemma nosmt eq_iff   : forall a b, (a = b) <=> (a <=> b) by smt().
 
-lemma nosmt eq_sym_imp : forall (x y : 'a), x = y => y = x by [].
-lemma nosmt eq_iff_imp : forall (x y : bool), (x <=> y) => (x = y) by [].
+lemma nosmt eq_sym_imp : forall (x y : 'a), x = y => y = x by smt().
+lemma nosmt eq_iff_imp : forall (x y : bool), (x <=> y) => (x = y) by smt().
 
 (* -------------------------------------------------------------------- *)
 lemma nosmt congr1 ['b 'a] :
   forall (f : 'a -> 'b) (x1 x2 : 'a),
     x1 = x2 => f x1 = f x2
-by [].
+by smt().
 
 lemma nosmt if_congr ['a] (e e' : bool) (c1 c2 c1' c2': 'a) :
      e = e' => c1 = c1' => c2 = c2'
   => (if e then c1 else c2) = (if e' then c1' else c2')
-by [].
+by smt().
 
-lemma nosmt eq_ind ['a] x y (f:'a -> bool) : x = y => f x => f y by [].
+lemma nosmt eq_ind ['a] x y (f:'a -> bool) : x = y => f x => f y by smt().
 
 (* -------------------------------------------------------------------- *)
-lemma nosmt and3_s1 b1 b2 b3 : b1 => b2 && b3 => b1 && b2 && b3 by [].
-lemma nosmt and3_s2 b1 b2 b3 : b2 => b1 && b3 => b1 && b2 && b3 by [].
-lemma nosmt and3_s3 b1 b2 b3 : b3 => b1 && b2 => b1 && b2 && b3 by [].
+lemma nosmt and3_s1 b1 b2 b3 : b1 => b2 && b3 => b1 && b2 && b3 by smt().
+lemma nosmt and3_s2 b1 b2 b3 : b2 => b1 && b3 => b1 && b2 && b3 by smt().
+lemma nosmt and3_s3 b1 b2 b3 : b3 => b1 && b2 => b1 && b2 && b3 by smt().


### PR DESCRIPTION
This changes the semantics of `lemma ... by [].` to avoid hiding an unrestricted SMT call, and aligns `by []` with the `by done` semantics it has inside standard proof environments.

This is breaking: some proofs that went by SMT will now fail by `trivial`. The old behaviour can be recovered by replacing failing instances of `lemma ... by [].` with `lemma ... by smt.` However, we recommend avoiding the simple fix, and attempting to give more robust proofs to such lemmas.