### PR TITLE
Improve nix local infra, test nix build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ env:
   OPAMJOBS: 2
 
 jobs:
-  compile:
-    name: EasyCrypt compilation
+  compile-opam:
+    name: EasyCrypt compilation (opam)
     runs-on: ubuntu-20.04
     container:
       image: easycryptpa/ec-build-box
@@ -23,9 +23,29 @@ jobs:
     - name: Compile EasyCrypt
       run: opam config exec -- make
 
+  compile-nix:
+    name: EasyCrypt compilation (nix)
+    env:
+      HOME: /home/runner
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Nix
+      uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: Setup Cachix
+      uses: cachix/cachix-action@v10
+      with:
+        name: formosa-crypto
+        authToken: '${{ secrets.CACHIX_WRITE_TOKEN }}'
+    - name: Build and cache EasyCrypt and dependencies
+      run: |
+        nix-build
+
   check:
     name: Check EasyCrypt Libraries
-    needs: compile
+    needs: compile-opam
     runs-on: ubuntu-20.04
     container:
       image: easycryptpa/ec-build-box
@@ -60,7 +80,7 @@ jobs:
 
   external:
     name: Check EasyCrypt External Projects
-    needs: compile
+    needs: compile-opam
     runs-on: ubuntu-20.04
     container:
       image: easycryptpa/ec-build-box
@@ -100,7 +120,7 @@ jobs:
 
   notification:
     name: Notification
-    needs: [compile, check, external]
+    needs: [compile-opam, compile-nix, check, external]
     if: |
       (github.event_name == 'push') ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ default: build
 
 build:
 	rm -f src/ec.exe ec.native
-	$(DUNE) build
+	dune build -p easycrypt
 	ln -sf src/ec.exe ec.native
 ifeq ($(UNAME_P)-$(UNAME_S),arm-Darwin)
 	-codesign -f -s - src/ec.exe

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{ withProvers ? true, devDeps ? [] }:
+
+with import <nixpkgs> {};
+
+let provers =
+  if withProvers then [
+    alt-ergo
+    z3
+  ] else []; in
+
+pkgs.mkShell {
+  buildInputs = devDeps ++ [ git ] ++ (with ocamlPackages; [
+    ocaml
+    findlib
+    batteries
+    camlp-streams
+    dune_3
+    dune-build-info
+    dune-site
+    inifiles
+    menhir
+    menhirLib
+    merlin
+    yojson
+    why3
+    zarith
+  ]) ++ (with python3Packages; [
+    pyyaml
+  ]);
+}


### PR DESCRIPTION
This PR:
- creates a `shell.nix` which more robustly presents the user with a shell ready for EasyCrypt development; (Although it currently lacks a default set of dev tools, they can be passed in as arguments.)
- improves the `default.nix` to better align with those used in nixpkgs and jasmin-lang;
- checks in CI that this `default.nix` successfully builds, also caching the resulting binary on cachix.
