### PR TITLE
Relate `dbiased` and `dmap`

### DIFF
--- a/theories/distributions/DBool.ec
+++ b/theories/distributions/DBool.ec
@@ -79,6 +79,15 @@ proof.
 by move=> ??;rewrite supp_dbiased.
 qed.
 
+lemma dmap_pred (d: 'a distr) (p: 'a -> bool) :
+  is_lossless d =>
+  dmap d p = dbiased (mu d p).
+proof.
+move => d_ll; apply eq_distr => x.
+rewrite dbiased1E clamp_id; first by smt(ge0_mu le1_mu).
+rewrite dmap1E /(\o) /pred1; smt(mu_not).
+qed.
+
 end Biased.
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
Add a lemma to rewrite `dmap` onto a boolean predicate as a `dbiased`.

I encountered a need for the lemma through a particular use case of the `marginal_sampling` lemma from #239, and now I'm wondering if this lemma is general/reusable enough to belong in the standard library.