### PR TITLE
Add a warning for useless delta-unfolding

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -935,10 +935,10 @@ proof.
   move=> /(congr1 bytes_of_poly_in); rewrite insubdK=> // ->.
   move=> /(congr1 bytes_of_poly_out); rewrite insubdK=> // ->.
   rewrite insubdK.
-  + rewrite size_drop 1:ge0_poly_in_size valP /block_size /poly_size.
+  + rewrite size_drop 1:ge0_poly_in_size valP /poly_size.
     smt(ge0_poly_in_size ge0_poly_out_size ge0_extra_block_size).
   rewrite insubdK.
-  + rewrite size_take 1:ge0_poly_in_size valP /poly_size /block_size.
+  + rewrite size_take 1:ge0_poly_in_size valP /poly_size.
     smt(ge0_poly_in_size ge0_poly_out_size ge0_extra_block_size).
   by rewrite cat_take_drop valKd.
 qed.
@@ -1781,7 +1781,7 @@ section PROOFS.
     + case: (forged{2}) => //; case: ((UFCMA.bad1\/UFCMA.bad2){2}) => //= H12 H13.
       - have[|]->//=:=H12.
       have:=H12; rewrite negb_or => /> *.
-      rewrite /test_poly /= /poly1305 /= /test_bad.
+      rewrite /test_poly /= /poly1305 /=.
       pose f := fun (c : ciphertext) => c.`4 - poly1305_eval r3 (topol c.`2 c.`3).
       pose m := List.filter _ _.
       rewrite  hasP /=.
@@ -2246,7 +2246,7 @@ section PROOFS.
       + by rewrite /n1 !size_filter count_map /preim.
       rewrite -BRA.mulr_suml ler_wpmul2r 1:ge0_pr_zeropol -sumr_ofint le_fromint IntOrder.lerr_eq.
       rewrite hn1 eq_sym  -big_count -BIA.big_filter /= /l1 //= (BIA.big_nth witness); apply BIA.congr_big_seq=> />.
-      move=> x; rewrite /(\o) /predT /= mem_range !size_filter /pred1 /transpose //==> [#] * /=.
+      move=> x; rewrite /(\o) /predT /= mem_range !size_filter /pred1 //==> [#] * /=.
       by rewrite count_map.
 
     case: (0 < size l2)=> * />; last first.
@@ -2281,8 +2281,8 @@ section PROOFS.
       + by rewrite /n2 !size_filter count_map /preim.
       rewrite -BRA.mulr_suml ler_wpmul2r; 1:smt(mu_bounded).
       rewrite -sumr_ofint le_fromint IntOrder.lerr_eq.
-      rewrite hn2 eq_sym  -big_count -BIA.big_filter /= /l1 //= (BIA.big_nth witness); apply BIA.congr_big_seq=> />.
-      move=> x; rewrite /(\o) /predT /= mem_range !size_filter /pred1 /transpose //==> [#] * /=.
+      rewrite hn2 eq_sym  -big_count -BIA.big_filter /= //= (BIA.big_nth witness); apply BIA.congr_big_seq=> />.
+      move=> x; rewrite /(\o) /predT /= mem_range !size_filter /pred1 //==> [#] * /=.
       by rewrite count_map.
 
   move=> &h /> ? H0 *.

--- a/examples/SchnorrPK.ec
+++ b/examples/SchnorrPK.ec
@@ -112,7 +112,7 @@ section SchnorrPKSecurity.
     rewrite /R /R_DL; move => sigmarel.
     byphoare (_: h = x /\ w' = w ==> _) => //; rewrite sigmarel.
     proc; inline*; swap 3 -2; swap 8 -7.
-    wp; rewrite /snd /=; auto => &hr />.
+    wp; auto => &hr />.
     rewrite FDistr.dt_ll => /> *; algebra.
   qed.
 

--- a/examples/UC/RndO.ec
+++ b/examples/UC/RndO.ec
@@ -184,7 +184,7 @@ equiv RO_FRO_get : RO.get ~ FRO.get :
    ={x} /\ RO.m{1} = noflags FRO.m{2} ==> ={res} /\ RO.m{1} = noflags FRO.m{2}.
 proof.
   proc; auto=> &1 &2 [] 2!-> /= ? -> /=.
-  rewrite /noflags mem_map !map_set /fst /= get_set_sameE oget_some => |>; progress.
+  rewrite /noflags mem_map !map_set /= get_set_sameE oget_some => |>; progress.
   + by rewrite mapE oget_omap_some 1:-domE.
   + by rewrite eq_sym set_eq 1:mapE /= 1:get_some.
 qed.
@@ -514,7 +514,7 @@ proof.
     rewrite get_set_sameE /mx2 /= eq_except_setr.
     rewrite -fmap_eqP=> z; rewrite get_setE; case (z = x{2})=> [-> |].
     by rewrite m_R_x2_eq.
-    move=> ne_z_x2; rewrite eq_exceptP in eq_exc; by rewrite eq_exc /pred1.
+    by move=> ne_z_x2; rewrite eq_exceptP in eq_exc; rewrite eq_exc.
 qed.
 
 lemma eager_rem :
@@ -538,7 +538,7 @@ proof.
               (FRO.m.[x] = None){2}).
     + inline *; auto=> &1 &2 [#] 2-> Hidm /=.
       split=> [| _ c _]; first apply sampleto_ll.
-      rewrite (eq_except_rem _ FRO.m{2} (pred1 x{2}) x{2}) /pred1 //
+      rewrite (eq_except_rem _ FRO.m{2} (pred1 x{2}) x{2}) //
               1:eq_except_setl /= remE -memE in_fsetD1 negb_and /=
               restr_rem Hidm /=.
       congr; by rewrite fdom_rem.
@@ -570,7 +570,7 @@ proof.
   rewrite -fmap_eqP=> z; rewrite remE.
   case (z = x{mr})=> [-> | ne_z_xmr];
     [by rewrite m_R_x |
-     by rewrite eq_exceptP in Heqx; rewrite Heqx /pred1].
+     by rewrite eq_exceptP in Heqx; rewrite Heqx].
 qed.
 
 lemma eager_sample :
@@ -625,7 +625,7 @@ proof.
     by rewrite get_set_sameE m_R_x /mx2.
     rewrite get_setE ne_z_xmr /=.
     rewrite eq_exceptP in Hex'.
-    by rewrite Hex' /pred1.
+    by rewrite Hex'.
   rcondf{2} 2; 1:by auto. 
   swap{1} 2 -1; inline*; auto.
   while (={l, FRO.m} /\ (dom FRO.m x){1}); auto.
@@ -806,7 +806,7 @@ proof.
     + move=> &mr [] _ ->; apply mem_eq0=> z;
         rewrite -memE mem_fdom dom_restr /in_dom_with mapE mem_map domE.
      by case (RO.m{m}.[_]).
-     by move=> ? &mr [] 2!-> /=; rewrite /noflags map_comp /fst /= map_id.
+     by move=> ? &mr [] 2!-> /=; rewrite /noflags map_comp /= map_id.
   transitivity M.main2
      (={glob D, FRO.m} ==> ={res, glob D})
      (={glob D} /\ FRO.m{1} = map (fun _ c => (c, Known)) RO.m{2} ==>

--- a/examples/UC/dh_enc_cost.ec
+++ b/examples/UC/dh_enc_cost.ec
@@ -1081,7 +1081,7 @@ wp; call (_:
   + by move => *; inline *;auto => /#.   
   (* Backdoor F2Auth *)
   move=> m2 p; inline *; auto => /> &1 &2.
-  rewrite /staterel /leak oget_some /unblock /kstp /rcv. 
+  rewrite /staterel /leak oget_some /rcv. 
   by case (FKE.st{2}.`kst) => /> /#. 
 
 (* WRAP-UP CALL *)

--- a/examples/plug-and-pray/Plug_and_Pray_example.ec
+++ b/examples/plug-and-pray/Plug_and_Pray_example.ec
@@ -79,7 +79,7 @@ have:= PBound (G0(A)) phi psi tt &m _.
 have ->: card = q by rewrite undup_id 1:range_uniq size_range #smt:(gt0_q).
 have -> //=: Pr[Guess(G0(A)).main() @ &m: phi (glob G0(A)) res.`2 /\ res.`1 = psi (glob G0(A)) res.`2]
              = Pr[Guess(G0(A)).main() @ &m: G0.b /\ res.`1 = G0.k].
-byequiv (: ={glob G0(A)} ==> _)=> @/phi @/psi //=.
+byequiv (: ={glob G0(A)} ==> _)=> //=.
 conseq (: _ ==> ={glob G0, res} /\ 0 <= G0.k{1} < q); first by smt().
 proc; rnd; inline *; wp.
 conseq (: ={glob G0})=> //=.

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -32,6 +32,7 @@ type ttenv = {
   tt_implicits : bool;
   tt_oldip     : bool;
   tt_redlogic  : bool;
+  tt_und_delta : bool;
 }
 
 type engine = ptactic_core -> FApi.backward
@@ -545,7 +546,7 @@ let process_rewrite1_core ?mode ?(close = true) ?target (s, p, o) pt tc =
           tc_error !!tc "r-pattern does not match the rewriting rule"
 
 (* -------------------------------------------------------------------- *)
-let process_delta ?target (s, o, p) tc =
+let process_delta ~und_delta ?target (s, o, p) tc =
   let env, hyps, concl = FApi.tc1_eflat tc in
   let o = norm_rwocc o in
 
@@ -565,9 +566,14 @@ let process_delta ?target (s, o, p) tc =
       { EcReduction.no_red with
           EcReduction.delta_p = check_op;
           EcReduction.delta_h = check_id; } in
-    let target = EcReduction.simplify ri hyps target in
+    let redform = EcReduction.simplify ri hyps target in
 
-    t_change ~ri ?target:idtg target tc
+    if und_delta then begin
+      if EcFol.f_equal target redform then
+        EcEnv.notify env `Warning "unused unfold: /%s" x
+    end;
+
+    t_change ~ri ?target:idtg redform tc
 
   | _ ->
 
@@ -694,6 +700,7 @@ let process_delta ?target (s, o, p) tc =
 (* -------------------------------------------------------------------- *)
 let process_rewrite1_r ttenv ?target ri tc =
   let implicits = ttenv.tt_implicits in
+  let und_delta = ttenv.tt_und_delta in
 
   match unloc ri with
   | RWDone simpl ->
@@ -715,7 +722,7 @@ let process_rewrite1_r ttenv ?target ri tc =
       if Option.is_some px then
         tc_error !!tc "cannot use pattern selection in delta-rewrite rules";
 
-      let do1 tc = process_delta ?target (s, o, p) tc in
+      let do1 tc = process_delta ~und_delta ?target (s, o, p) tc in
 
       match r with
       | None -> do1 tc
@@ -1442,7 +1449,7 @@ let rec process_mintros_1 ?(cf = true) ttenv pis gs =
     in t_seqs [t_intros_i [h]; rwt; t_clear h] tc
 
   and intro1_unfold (_ : ST.state) (s, o) p tc =
-    process_delta (s, o, p) tc
+    process_delta ~und_delta:ttenv.tt_und_delta (s, o, p) tc
 
   and intro1_view (_ : ST.state) pe tc =
     process_view1 pe tc

--- a/src/ecHiGoal.mli
+++ b/src/ecHiGoal.mli
@@ -14,6 +14,7 @@ type ttenv = {
   tt_implicits : bool;
   tt_oldip     : bool;
   tt_redlogic  : bool;
+  tt_und_delta : bool;
 }
 
 type engine  = ptactic_core -> backward
@@ -74,7 +75,7 @@ val process_move        : ?doeq:bool -> ppterm list -> prevert -> backward
 val process_clear       : psymbol list -> backward
 val process_smt         : ?loc:EcLocation.t -> ttenv -> pprover_infos -> backward
 val process_apply       : implicits:bool -> apply_t * prevert option -> backward
-val process_delta       : ?target:psymbol -> (rwside * rwocc * pformula) -> backward
+val process_delta       : und_delta:bool -> ?target:psymbol -> (rwside * rwocc * pformula) -> backward
 val process_rewrite     : ttenv -> ?target:psymbol -> rwarg list -> backward
 val process_subst       : pformula list -> backward
 val process_cut         : ?mode:cutmode -> engine -> ttenv -> cut_t -> backward

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -236,11 +236,13 @@ module KnownFlags = struct
   let implicits = "implicits"
   let oldip     = "oldip"
   let redlogic  = "redlogic"
+  let und_delta = "und_delta"
 
   let flags = [
     (implicits, false);
     (oldip    , false);
     (redlogic , true );
+    (und_delta, false);
   ]
 end
 
@@ -439,6 +441,12 @@ module Options = struct
 
   let set_redlogic scope value =
     set scope KnownFlags.redlogic value
+
+  let get_und_delta scope =
+    get scope KnownFlags.und_delta
+
+  let set_und_delta scope value =
+    set scope KnownFlags.und_delta value
 end
 
 (* -------------------------------------------------------------------- *)
@@ -731,7 +739,8 @@ module Tactics = struct
           EcHiGoal.tt_smtmode    = htmode;
           EcHiGoal.tt_implicits  = Options.get_implicits scope;
           EcHiGoal.tt_oldip      = Options.get_oldip scope;
-          EcHiGoal.tt_redlogic   = Options.get_redlogic scope; } in
+          EcHiGoal.tt_redlogic   = Options.get_redlogic scope;
+          EcHiGoal.tt_und_delta  = Options.get_und_delta scope; } in
 
         let (hds, juc) =
           try  TTC.process ttenv tac juc

--- a/theories/algebra/Bigop.eca
+++ b/theories/algebra/Bigop.eca
@@ -326,9 +326,8 @@ qed.
 lemma nosmt bigID (P : 'a -> bool) (F : 'a -> t) (a : 'a -> bool) s:
   big P F s = big (predI P a) F s + big (predI P (predC a)) F s.
 proof.
-  rewrite !(@big_mkcond _ F) -big_split /(/\) /[!].
-  apply/eq_bigr => i _ /=.
-  by rewrite /predI /predC; case: (a i); rewrite ?addm0 ?add0m.
+rewrite !(@big_mkcond _ F) -big_split; apply/eq_bigr => i _ /=.
+by rewrite /predI /predC; case: (a i); rewrite ?addm0 ?add0m.
 qed.
 
 (* -------------------------------------------------------------------- *)

--- a/theories/algebra/Ideal.ec
+++ b/theories/algebra/Ideal.ec
@@ -354,7 +354,7 @@ hint exact : ideal_p.
 op eqv (x y : t) = p (y - x).
 
 lemma eqvxx : reflexive eqv.
-proof. by move=> x @/eqv; rewrite /eqv subrr ideal0 ideal_p. qed.
+proof. by move=> x @/eqv; rewrite subrr ideal0 ideal_p. qed.
 
 lemma eqv_sym : symmetric eqv.
 proof. by move=> x y @/eqv; rewrite -opprB idealNP // ideal_p. qed.
@@ -438,7 +438,7 @@ qed.
 
 lemma mulE x y : (pi x) * (pi y) = pi (x * y).
 proof.
-rewrite /(+) &(eqv_pi) /eqv; pose z := repr (pi x).
+rewrite &(eqv_pi) /eqv; pose z := repr (pi x).
 have ->: x = x - z + z by rewrite subrK.
 rewrite mulrDl -addrA -mulrBr (mulrC _ y) {1}/z.
 by rewrite &(idealD) ?ideal_p // idealMl ?ideal_p &(eqv_repr).

--- a/theories/algebra/IntDiv.ec
+++ b/theories/algebra/IntDiv.ec
@@ -647,7 +647,7 @@ have ge0_pE: 0 <= `|a * b| - 1.
 + have := normr_ge0 (a * b); rewrite subr_ge0 ler_eqVlt.
   rewrite ltzE /= => -[] //; rewrite eq_sym.
   by rewrite normrM mulf_eq0 !normr0P !(nz_a, nz_b).
-have pE: E (`|a * b| - 1); first move=> @/pcap @/E /=; do! split.
+have pE: E (`|a * b| - 1); first move=> @/E /=; do! split.
 + by rewrite opprB addrCA subrr /= dvd1z.
 + by rewrite opprB addrCA subrr /= dvd1z.
 have nzE: !sempty (pcap E); 1: by apply/semptyNP; exists (`|a * b| - 1).

--- a/theories/algebra/Poly.ec
+++ b/theories/algebra/Poly.ec
@@ -47,7 +47,7 @@ lemma degP p c :
   => (forall i, c <= i => p.[i] = zeror)
   => deg p = c.
 proof.
-move=> ge0_c nz_p_cB1 degc @/deg; apply: argmin_eq => @/idfun /=.
+move=> ge0_c nz_p_cB1 degc @/deg; apply: argmin_eq => /=.
 - by apply/ltrW. - by apply: degc.
 move=> j [ge0_j lt_jc]; rewrite negb_forall /=.
 by exists (c-1); apply/negP => /(_ _); first by move=> /#.
@@ -64,7 +64,7 @@ lemma gedeg_coeff (p : poly) (c : int) : deg p <= c => p.[c] = zeror.
 proof.
 move=> le_p_c; pose P p i := forall j, (i <= j)%Int => p.[j] = zeror.
 case: (of_polyP p) => [wf_p [d hd]]; move: (argminP idfun (P p)).
-move/(_ (max (d+1) 0) _ _) => @/P @/idfun /=; first exact: maxrr.
+move/(_ (max (d+1) 0) _ _) => /=; first exact: maxrr.
 - by move=> j le_d_j; apply: hd => /#.
 by apply; apply: le_p_c.
 qed.
@@ -290,7 +290,7 @@ proof.
 case: (c = zeror) => [->|nz_c]; last first.
 - apply: degP => //=; first by rewrite polyCE.
   by move=> i ge1_i; rewrite polyCE gtr_eqF //#.
-rewrite /deg; apply: argmin_eq => @/idfun //=.
+rewrite /deg; apply: argmin_eq => //=.
 - by move=> j _; rewrite poly0E.
 - by move=> j; apply: contraL => _ /#.
 qed.

--- a/theories/analysis/RealSeq.ec
+++ b/theories/analysis/RealSeq.ec
@@ -200,7 +200,7 @@ have gt0_e: 0%r < e by rewrite /e divr_gt0 ?subr_gt0.
 have [N' lte] := cvF _ gt0_e; pose n := max N N'.
 have /subr_le0 le0_s12 := le_s12 n _; first by rewrite /n maxrl.
 have := lte n _; first by rewrite /n maxrr.
-rewrite ltr_norml => -[+ _] @/F; rewrite ltr_subr_addl /F.
+rewrite ltr_norml => -[+ _]; rewrite ltr_subr_addl /F.
 move/ltr_le_trans/(_ _ le0_s12); rewrite -(@mulr1 (l1-l2)) /e.
 rewrite -mulrBr pmulr_llt0 1:subr_gt0 1:invr_lt1 //.
 by rewrite subr_lt0 ltrNge (ltrW lt_l21).

--- a/theories/analysis/RealSeries.ec
+++ b/theories/analysis/RealSeries.ec
@@ -190,7 +190,7 @@ case=> [Mf smf] [Mg smg]; exists (Mf * Mg) => J uqJ.
 pose J1 := undup (unzip1 J).
 pose F (ab : 'a * 'b) := `|f ab.`1| * `|g ab.`1 ab.`2|.
 rewrite (@eq_bigr _ _ F) /= => [ab _|]; 1: by rewrite normrM.
-rewrite /F (@sum_pair_dep ("`|_|"%Real \o f) ("`|_|"%Real \o2 g)) /(\o) /(\o2) //=.
+rewrite /F (@sum_pair_dep ("`|_|"%Real \o f) ("`|_|"%Real \o2 g)) //=.
 apply: (@ler_trans (big predT (fun i => `|f i| * Mg) J1)); last first.
 + rewrite -mulr_suml ler_wpmul2r; 1: by apply: (@smg witness [] _).
   by apply/smf/undup_uniq.
@@ -452,7 +452,7 @@ move=> J p enm sm sbl; rewrite /sum sbl /=.
 pose G f n := big predT f (pmap J (range 0 n)).
 rewrite -/(G s); have ->: G s = fun n =>
   G (fun x => `|pos s x|) n - G (fun x => `|neg s x|) n.
-+ apply/fun_ext=> i @/G @/f; rewrite sumrB; apply/eq_bigr.
++ apply/fun_ext=> i @/G; rewrite sumrB; apply/eq_bigr.
   by move=> x _ /=; rewrite !ger0_norm ?(pos_ge0, neg_ge0) pos_neg_id.
 apply/cnvtoB; apply/(@summable_pos_cnvto _ _ p) => //.
 + move=> x @/support @/pos; case: (s x < 0%r) => //.
@@ -522,10 +522,10 @@ move=> uqJ sJ; rewrite (@sumE _ (nth None (map Some J))); 1: split.
 + exists (big predT (fun x => `|s x|) (filter (fun x => s x <> 0%r) J))=> J' uniq_J'.
   rewrite -(eq_big_perm (:@perm_filterC (fun x => s x <> 0%r) J')).
   rewrite big_cat (@big1_seq _ _ (filter (fun (x : 'a) => s x = 0%r) J')) /=.
-  * by move=> x @/predT; rewrite mem_filter /abs_s /= =>- [] ->.
+  * by move=> x @/predT; rewrite mem_filter /= =>- [] ->.
   rewrite -(eq_big_perm (:@perm_filterC (fun x => mem J' x) (filter _ J))).
   rewrite -!filter_predI /predC /predI /= big_cat; apply/ler_paddr.
-  * by apply/sumr_ge0=> a //=; rewrite /abs_s normr_ge0.
+  * by apply/sumr_ge0=> a //=; rewrite normr_ge0.
   rewrite -(@eq_big_perm _ _ (filter (fun x => mem J' x /\ s x <> 0%r) J)).
   * apply/uniq_perm_eq=> [| |x]; 1,2: exact/filter_uniq.
     by rewrite !mem_filter /=; split=> //= -[] ^/sJ.

--- a/theories/crypto/PROM.ec
+++ b/theories/crypto/PROM.ec
@@ -351,7 +351,7 @@ lemma eager_get :
 proof.
 eager proc.
 wp; case ((x \in FRO.m /\ FRO.m.[x] \is Known){1}).
-+ rnd{1}; rcondf{2} 2; first by auto=> /> _ @/(\is) -> _ _ /#.
++ rnd{1}; rcondf{2} 2; first by auto=> /> _ -> _ _ /#.
   exists* x{1}, ((oget FRO.m.[x{2}]){1}); elim * => x1 mx; inline RRO.resample.
   call (iter_inv RRO.I (fun z=> x1<>z)
                        (fun o1 o2 => o1 = o2 /\ o1.[x1]= Some mx) _)=> /=.
@@ -482,7 +482,7 @@ move=> _ _ _ <- m_L m_R eq_exc m_L_x2_eq m_R_x2_eq.
 rewrite get_set_sameE in m_R_x2_eq.
 rewrite -fmap_eqP=> z; rewrite get_setE; case (z = x1)=> [-> |].
 + by rewrite -m_R_x2_eq.
-by move=> ne_z_x2; rewrite eq_exceptP in eq_exc; rewrite eq_exc /pred1.
+by move=> ne_z_x2; rewrite eq_exceptP in eq_exc; rewrite eq_exc.
 qed.
 
 lemma eager_rem :
@@ -505,7 +505,7 @@ eager proc; case ((x \in FRO.m /\ FRO.m.[x] \is Unknown){1}).
             l{1} = (elems (fdom (restr Unknown FRO.m))){2} /\ !mem l{1} x{1} /\
             (FRO.m.[x] = None){2}).
   + inline *; auto=> |> &2 x_in_m2 x_is_U2; rewrite dout_ll=> //= c _.
-    rewrite (@eq_except_remr (pred1 x{2}) _ FRO.m{2} x{2}) /pred1 //=.
+    rewrite (@eq_except_remr (pred1 x{2}) _ FRO.m{2} x{2}) //=.
     + exact/eq_except_setl.
     rewrite remE -memE in_fsetD1 negb_and /=.
     rewrite -fdom_rem; congr; congr; apply/fmap_eqP=> z.
@@ -612,7 +612,7 @@ while (   ={l, FRO.m}
        /\ (forall z, mem l z => in_dom_with FRO.m z Unknown){1}
        /\ restr Known FRO.m{1} = result{2}).
 + auto=> /> &2 inv l2_neq_nil c _; split=>[z /mem_drop z_in_l|].
-  + rewrite /in_dom_with mem_set get_setE; case: (z = head witness l{2})=> />.
+  + rewrite mem_set get_setE; case: (z = head witness l{2})=> />.
     by move: (inv _ z_in_l)=> @/in_dom_with.
   rewrite restr_set rem_id ?dom_restr //.
   move: (inv (head witness l{2}) _).
@@ -769,7 +769,7 @@ transitivity M.main1
   rcondf{2} 3.
   + auto=> />; apply/mem_eq0=> z; rewrite -memE mem_fdom dom_restr.
     by rewrite /in_dom_with domE mapE //=; case: (RO.m.[z]{m}).
-+ by auto=> /> &1; rewrite /noflags map_comp /fst /= map_id.
++ by auto=> /> &1; rewrite /noflags map_comp /= map_id.
 transitivity M.main2
    (={glob D, FRO.m, arg} ==> ={res, glob D})
    (={glob D, arg} /\ FRO.m{1} = map (fun _ c => (c, Known)) RO.m{2} ==>

--- a/theories/crypto/PRP.eca
+++ b/theories/crypto/PRP.eca
@@ -197,7 +197,7 @@ move=> dD_fu.
 proc; if=> //=; auto=> /> &m h.
 have [] x0 x0_notinr_m:= endo_dom_rng RP.m{m} _.
 + by exists x{m}.
-rewrite -/predT weight_dexcepted /b2r.
+rewrite -/predT weight_dexcepted.
 case: {-1}(mu _ _ = mu _ _)
         (eq_refl (mu dD predT = mu dD (rng RP.m{m})))=> //=.
 rewrite eqT -subr_eq0 ltr0_neq0 //.
@@ -215,7 +215,7 @@ move=> dD_fu.
 proc; if=> //=; auto=> /> &m h.
 have [] y0 y0_notinr_mi:= endo_dom_rng RP.mi{m} _.
 + by exists y{m}.
-rewrite -/predT weight_dexcepted /b2r.
+rewrite -/predT weight_dexcepted.
 case: {-1}(mu _ _ = mu _ _)
         (eq_refl (mu dD predT = mu dD (rng RP.mi{m})))=> //=.
 rewrite eqT -subr_eq0 ltr0_neq0 //.

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -64,11 +64,10 @@ theory DHIES.
     pkl = map (snd \o snd) kk =>
     menc pkl tag ptxt = dmap (mencDHIES tag ptxt kk) (List.map (snd \o snd)).
   proof.
-  rewrite /mencDHIES /menc /dlistmap /zipks /encDHIES /=. 
-  rewrite djoin_dmap.
+  rewrite /mencDHIES /menc /encDHIES /= djoin_dmap.
   move=> ->; rewrite -map_comp /(\o) /=.
   congr; congr; apply fun_ext => x.
-  by rewrite dmap_comp /(\o) /= /menc dmap_id.
+  by rewrite dmap_comp /(\o) /= dmap_id.
   qed.
 
   module DHIES = {
@@ -534,8 +533,7 @@ proof.
 move=> /eq_sym *.
 rewrite -(@map_fst_zip _ (elems s) l) // /(\o) /=.
 rewrite amap_assoc_zip //; first by apply uniq_elems.
-rewrite /map_assoc; congr.
-apply fun_ext => x; smt().
+by congr; apply: fun_ext => x /#.
 qed.
 
 lemma pkmem_foldenc pk t c pks tag mctxt:
@@ -840,7 +838,7 @@ wp; call (_: inv (glob MRPKErnd_lor){1} (glob MRPKE_lor){2} (glob ODH_Orcl){2} A
          ==> ={keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor})
         (={ro, pks, tag, m0, m1, glob MRPKErnd_lor}
          ==> ={keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor}).
-     - rewrite /inv /=; clear inv; progress.
+     - clear inv; progress.
        by exists MRPKErnd_lor.skeys{2} MRPKE_lor.b{2} MRPKE_lor.count_dec{2} MRPKE_lor.count_gen{2}
                  MRPKE_lor.count_lor{2}
                  MRPKE_lor.lorlist{2} MRPKE_lor.pklist{2} m0{2} m1{2} pks{2} ro{2} tag{2}.
@@ -849,7 +847,7 @@ wp; call (_: inv (glob MRPKErnd_lor){1} (glob MRPKE_lor){2} (glob ODH_Orcl){2} A
      - by call mrndkeys_def.
    + inline*; wp; rnd; rnd; wp; skip; rewrite /inv /=; clear inv; progress.
        by rewrite H2.
-      rewrite H2 /map_assoc -map_comp /(\o) /= unzip1_zip //.
+      rewrite H2 -map_comp /(\o) /= unzip1_zip //.
       by rewrite (supp_dlist_size _ _ _ _ H9) ?size_ge0.
      rewrite -map_comp /(\o) H2 /=.
      by rewrite -(map_fst_zip _ _ ksL) // (supp_dlist_size _ _ _ _ H9) ?size_ge0.
@@ -1087,7 +1085,7 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
          ==> ={keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor})
         (={ro, pks, tag, m0, m1, glob MRPKErnd_lor}
          ==> ={keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor}).
-     - rewrite /inv /= => /> *.
+     - move=> /= /> *.
        by exists MRPKErnd_lor.skeys{2} MRPKE_lor.b{2} MRPKE_lor.count_dec{2}
                  MRPKE_lor.count_gen{2} MRPKE_lor.count_lor{2} MRPKE_lor.lorlist{2}
                  MRPKE_lor.pklist{2} m0{2} m1{2} pks{2} ro{2} tag{2}.
@@ -1095,7 +1093,7 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
      - by inline*; wp; rnd; wp; skip.
      - by call mrndkeys_def.
    + inline*; wp; rnd; wp; rnd; wp; skip; rewrite /inv /=; clear inv; progress.
-      by rewrite zip_mapr /map_assoc /(\o).
+           by rewrite zip_mapr.
      smt (supp_dlist_size size_ge0).
   seq 1 4: (#pre /\ enclist{1} = (zip (elems pks) (map (fun k=>(g^x,k)) lctxt)){2} /\
             (size lctxt = size (elems pks) /\ aad = tag){2}).
@@ -1128,7 +1126,7 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
          ==> ={enclist, keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor})
         (={keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor}
          ==> ={enclist, keys, ro, pks, tag, m0, m1, glob MRPKErnd_lor}).
-     - rewrite /inv /=; clear inv; progress.
+     - clear inv; progress.
        by exists MRPKErnd_lor.skeys{2} MRPKE_lor.b{2} MRPKE_lor.count_dec{2}
                  MRPKE_lor.count_gen{2} MRPKE_lor.count_lor{2} MRPKE_lor.lorlist{2}
                  MRPKE_lor.pklist{2} keys{2} m0{2} m1{2} pks{2} ro{2} tag{2}.

--- a/theories/crypto/assumptions/PKSMK.ec
+++ b/theories/crypto/assumptions/PKSMK.ec
@@ -637,7 +637,7 @@ abstract theory UF1_UF.
           inline *. 
         + rcondt{2} 3; 1: by auto; smt().
         auto => /> &m1 &m2 hpki _ hpk _ _ h.
-        have := hpk pk{m2}; rewrite h /= => -[->> ->] /=; rewrite /oget /= /= => s -> /=.
+        have := hpk pk{m2}; rewrite h /= => -[->> ->] /=; rewrite /= => s -> /=.
           split; first by smt(emptyE get_setE).
           by rewrite imageU image1 /= fsetUA.
         inline *. sp 0 3. 

--- a/theories/datatypes/BitEncoding.ec
+++ b/theories/datatypes/BitEncoding.ec
@@ -557,7 +557,7 @@ op chunk r (bs : 'a list) =
 lemma nosmt chunk_le0 r (s : 'a list) : r <= 0 => chunk r s = [].
 proof.
 move/ler_eqVlt=> [->|gt0_r] @/chunk; 1: by rewrite mkseq0.
-rewrite /chunk mkseq0_le // -oppr_ge0 -divzN.
+rewrite mkseq0_le // -oppr_ge0 -divzN.
 by rewrite divz_ge0 ?size_ge0 oppr_gt0.
 qed.
 

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -674,7 +674,7 @@ qed.
 lemma filter_pred1 x (s : 'a list) :
   filter (pred1 x) s = nseq (count (pred1 x) s) x.
 proof.
-elim: s=> /= @/pred1 [|y s ih]; first by rewrite nseq0.
+elim: s=> /= [|y s ih @/pred1]; first by rewrite nseq0.
 by case: (y = x)=> //; rewrite addzC nseqS ?count_ge0.
 qed.
 
@@ -1814,7 +1814,7 @@ proof.
 elim: s => //= x s ih inj_f [xs uqs]; case _: (f x) => /= [|v] E.
 - by rewrite ih // => x' y' v' x's y's; apply/inj_f; right.
 rewrite ih //; 1: by move => x' y' v' x's y's; apply/inj_f; right.
-rewrite /oget /= pmap_map; apply/negP => /mapP.
+rewrite /= pmap_map; apply/negP => /mapP.
 case=> -[|v']; rewrite mem_filter // => -[[_ vs] @/oget /=].
 apply/negP=> <<-; move: vs; rewrite -E => /mapP.
 case=> y [ys eq_f]; suff <<-//: x = y.

--- a/theories/distributions/DBool.ec
+++ b/theories/distributions/DBool.ec
@@ -67,7 +67,7 @@ qed.
 lemma supp_dbiased (p : real) b :
   0%r < p < 1%r => b \in (dbiased p).
 proof.
-case=> gt0_p lt1_p; rewrite /support /in_supp dbiased1E /#.
+case=> gt0_p lt1_p; rewrite /support dbiased1E /#.
 qed.
 
 lemma dbiased_ll (p : real) : is_lossless (dbiased p).
@@ -107,9 +107,7 @@ lemma dbiased_ll : is_lossless dbiased.
 proof. by apply dbiased_ll;apply in01_p. qed.
 
 lemma dbiased_fu : is_full (dbiased p).
-proof.
-by move=> ?;rewrite /is_full supp_dbiased.
-qed.
+proof. by move=> ?;rewrite supp_dbiased. qed.
 
 end FixedBiased.
 

--- a/theories/distributions/DInterval.ec
+++ b/theories/distributions/DInterval.ec
@@ -18,11 +18,11 @@ proof. by rewrite duniformE undup_id 1:range_uniq size_range size_filter /#. qed
 
 lemma weight_dinter (i j : int):
   weight (dinter i j) = b2r (i <= j).
-proof. by rewrite /weight dinterE filter_predT size_range /#. qed.
+proof. by rewrite dinterE filter_predT size_range /#. qed.
 
 lemma supp_dinter (i j : int) x:
   x \in (dinter i j) <=> i <= x <= j.
-proof. by rewrite /support /in_supp dinter1E; case (i <= x <= j)=> //= /#. qed.
+proof. by rewrite /support dinter1E; case (i <= x <= j)=> //= /#. qed.
 
 lemma supp_dinter1E (x : int) (i j : int) :
   x \in (dinter i j) => mu1 (dinter i j) x = 1%r / (j - i + 1)%r.

--- a/theories/distributions/DList.ec
+++ b/theories/distributions/DList.ec
@@ -39,7 +39,7 @@ lemma dlist_add (d:'a distr) n1 n2:
     dmap (dlist d n1 `*` dlist d n2) (fun (p:'a list * 'a list) => p.`1 ++ p.`2).
 proof.
 elim: n1 => [hn2|n1 hn1 IHn1 hn2].
-  by rewrite (dlist0 d 0) //= /(\o) dmap_dprodE dlet_unit /= dmap_id_eq_in.
+  by rewrite (dlist0 d 0) //= dmap_dprodE dlet_unit /= dmap_id_eq_in.
 rewrite addzAC !dlistS 1:/# //= IHn1 //.
 rewrite !dmap_dprodE /= dlet_dlet; apply eq_dlet => //= x.
 rewrite dmap_dlet dlet_dmap; apply eq_dlet => //= x1.

--- a/theories/distributions/Dexcepted.ec
+++ b/theories/distributions/Dexcepted.ec
@@ -9,7 +9,7 @@ op (\) (d : 'a distr) (P : 'a -> bool) : 'a distr = dscale (dfilter d P).
 
 lemma supp_dexcepted (x:'a) d P :
   support (d \ P) x <=> (support d x /\ !P x).
-proof. by rewrite supp_dscale supp_dfilter /predI /predC. qed.
+proof. by rewrite supp_dscale supp_dfilter. qed.
 
 lemma dexcepted1E d P (x : 'a) :
   mu1 (d \ P) x
@@ -34,7 +34,7 @@ proof. by rewrite dscaleE weight_dfilter dfilterE. qed.
 lemma nosmt weight_dexcepted (d:'a distr) P :
   weight (d \ P) = b2r (weight d <> mu d (P)).
 proof.
-rewrite weight_dscale weight_dfilter /b2r subr_eq0.
+rewrite weight_dscale weight_dfilter subr_eq0.
 by case: (weight d = mu d (P)).
 qed.
 

--- a/theories/distributions/Dfilter.ec
+++ b/theories/distributions/Dfilter.ec
@@ -62,7 +62,7 @@ qed.
 lemma supp_dfilter ['a] (d : 'a distr) P x:
   x \in (dfilter d P) <=> (x \in d /\ !P x).
 proof.
-by rewrite /support /in_supp dfilter1E; case: (P x).
+by rewrite /support dfilter1E; case: (P x).
 qed.
 
 (* -------------------------------------------------------------------- *)

--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -919,18 +919,16 @@ qed.
 
 lemma nosmt dlet_d_unit (d:'a distr) : dlet d MUnit.dunit = d.
 proof.
-apply/eq_distr=> x; rewrite dlet1E /mlet /=.
-rewrite (@sumE_fin _ [x]) //=.
+apply/eq_distr=> x; rewrite dlet1E /= (@sumE_fin _ [x]) //=.
 + by move=> x0; rewrite MUnit.dunit1E /=; case (x0 = x).
-by rewrite big_consT big_nil /= MUnit.dunit1E.
++ by rewrite big_consT big_nil /= MUnit.dunit1E.
 qed.
 
 lemma nosmt dlet_unit (F:'a -> 'b distr) a : dlet (MUnit.dunit a) F = F a.
 proof.
-apply/eq_distr=> x; rewrite dlet1E /mlet /=.
-rewrite (@sumE_fin _ [a]) //=.
+apply/eq_distr=> x; rewrite dlet1E /= (@sumE_fin _ [a]) //=.
 + by move=> a0; rewrite MUnit.dunit1E (@eq_sym a); case (a0 = a).
-by rewrite big_consT big_nil /= MUnit.dunit1E.
++ by rewrite big_consT big_nil /= MUnit.dunit1E.
 qed.
 
 lemma dlet_dlet (d1:'a distr) (F1:'a -> 'b distr) (F2: 'b -> 'c distr):
@@ -1029,7 +1027,7 @@ lemma dmap1E (d : 'a distr) (f : 'a -> 'b) (b : 'b):
   mu1 (dmap d f) b = mu d ((pred1 b) \o f).
 proof.
 rewrite dlet1E muE; apply/eq_sum=> x /=.
-by rewrite MUnit.dunit1E /preim /pred1 /(\o); case: (f x = b).
+by rewrite MUnit.dunit1E /pred1 /(\o); case: (f x = b).
 qed.
 
 lemma dmap1E_can ['a 'b] (d : 'a distr) (f : 'a -> 'b) (g : 'b -> 'a) (b : 'b) :
@@ -1058,8 +1056,8 @@ lemma dmapE (d : 'a distr) (f : 'a -> 'b) (P : 'b -> bool):
 proof.
 rewrite dlet_muE_swap muE.
 apply/eq_sum=> a /=; rewrite (@sumE_fin _ [f a]) //=.
-+ by move=> b; rewrite (@eq_sym b) MUnit.dunit1E;case: (f a = b);rewrite /b2r.
-by rewrite big_seq1 /= MUnit.dunit1E.
++ by move=> b; rewrite (@eq_sym b) MUnit.dunit1E; case: (f a = b).
++ by rewrite big_seq1 /= MUnit.dunit1E.
 qed.
 
 lemma supp_dmap (d : 'a distr) (f : 'a -> 'b) (b : 'b):
@@ -1441,8 +1439,8 @@ lemma doptE (d : 'a distr) E :
   mu d (E \o Some) + (if E None then 1%r - weight d else 0%r).
 proof.
 rewrite !muE sumD1_None ?summable_cond ?summable_mu1 /= addrC; congr.
-  by apply eq_sum => /= x; rewrite /(\o) dopt1E.
-by case (E None) => @/predT //=; by rewrite dopt1E -weightE.
+- by apply eq_sum => /= x; rewrite /(\o) dopt1E.
+- by case (E None) => //=; rewrite dopt1E /predT /= -weightE.
 qed.
 
 lemma dopt_ll (d : 'a distr) : is_lossless (dopt d).
@@ -1501,7 +1499,7 @@ move=> isa isb; split=> [x|s uqs].
 (* FIXME: This instance should be in bigops *)
 rewrite (@partition_big ofst _ predT _ _ (undup (unzip1 s))).
 + by apply/undup_uniq.
-+ by case=> a b ab_in_s _; rewrite mem_undup map_f /mprod.
++ by case=> a b ab_in_s _; rewrite mem_undup map_f.
 pose P := fun x ab => ofst<:'a, 'b> ab = x.
 pose F := fun (ab : 'a * 'b) => mb ab.`2.
 rewrite -(@eq_bigr _ (fun x => ma x * big (P x) F s)) => /= [x _|].
@@ -1510,7 +1508,7 @@ pose s' := undup _; apply/(@ler_trans (big predT (fun x => ma x) s')).
 + apply/ler_sum=> a _ /=; apply/ler_pimulr; first by apply/ge0_isdistr.
   rewrite -big_filter -(@big_map snd predT) le1_sum_isdistr //.
   rewrite map_inj_in_uniq ?filter_uniq //; case=> [a1 b1] [a2 b2].
-  by rewrite !mem_filter => @/P @/ofst @/osnd |>.
+  by rewrite !mem_filter => @/P @/ofst |>.
 by apply/le1_sum_isdistr/undup_uniq.
 qed.
 
@@ -2397,7 +2395,7 @@ move=>h; pose s (a : 'a) (b : 'b) := f b * mu1 (df a) b * mu1 d a.
 rewrite /E -(@eq_sum (fun a => sum (s a))) /=; 1: by move=> a; rewrite sumZr.
 rewrite (@sum_swap (fun ab : _ * _ => s ab.`1 ab.`2)).
 - exists (psum (fun x => f x * mu1 (dlet d df) x)).
-  move=> J uqJ @/E; pose K := undup (unzip2 J).
+  move=> J uqJ; pose K := undup (unzip2 J).
   have uqK: uniq K by apply: undup_uniq.
   have le := ler_big_psum (fun x => f x * mu1 (dlet d df) x) K h uqK.
   apply: (ler_trans _ _ le) => {le}.
@@ -2409,9 +2407,9 @@ rewrite (@sum_swap (fun ab : _ * _ => s ab.`1 ab.`2)).
   move/BRA.eq_big_perm=> ->; apply: Bigreal.ler_sum => /=.
   move=> b _ @/s => {s}; pose s a := `|f b| * (mu1 (df a) b * mu1 d a).
   rewrite BRA.big_filter -(@BRA.eq_bigr _ (fun ba : _ * _ => s ba.`2)) /=.
-  - case=> b' a' /= ->> @/(\o) @/pswap /= @/s.
+  - case=> b' a' /= ->> @/pswap /= @/s.
     by rewrite -!mulrA !normrM; congr; rewrite !ger0_norm.
-  rewrite /(\o) {1}/pswap /s /= -BRA.mulr_sumr normrM.
+  rewrite {1}/pswap /s /= -BRA.mulr_sumr normrM.
   rewrite ler_wpmul2l 1:normr_ge0 BRA.big_map /(\o) /= -BRA.big_filter.
   rewrite ger0_norm //; pose L := List.filter _ _.
   rewrite (@BRA.sum_pair (fun x => mu1 (df x) b * mu1 d x) (fun _ => 1%r)) /=.

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -355,7 +355,7 @@ lemma distinguisher_ll (A <: Distinguisher) &m x :
   islossless A.guess => 
   is_lossless (mk (fun (z : bool) => Pr[A.guess(x) @ &m : res = z])).
 proof.
-move => A_ll; rewrite /F /is_lossless muE {1}/predT /=. 
+move => A_ll; rewrite /is_lossless muE {1}/predT /=. 
 have <- : Pr[A.guess(x) @ &m : res = true \/ res = false] = 1%r. 
   by byphoare => //; conseq (:_ ==> true) => // /#.  
 rewrite (eq_sum _ (fun (z : bool) => Pr[A.guess(x) @ &m : res = z])) => [z /=|].

--- a/theories/encryption/Indist.ec
+++ b/theories/encryption/Indist.ec
@@ -307,7 +307,7 @@ have ->:   Pr[INDb(O, A).main() @ &m : res /\ p (glob A) (glob O) Count.c]
              ==>    ={glob A,glob O, Count.c}
                  /\ res{1} = (fst res = snd res){2})=> //.
   proc.
-  inline Count.init WA.work=> @/fst @/snd //=.
+  inline Count.init WA.work=> //=.
   by swap{1} 2 -1; sim; proc (={Orclb.b, Count.c}).
 have He: equiv [INDR(O, A).main ~ WA.work:
                      x{2} = false

--- a/theories/encryption/Means.ec
+++ b/theories/encryption/Means.ec
@@ -37,7 +37,7 @@ seq 1: (v = x) (mu1 d v) pr 1%r 0%r ((glob A) = (glob A){m})=> //.
           ==> ev v (glob A) res)=> //.
   rewrite /pr; bypr=> /> &0 eqGlob <<-.
   by byequiv (: ={glob A, x} ==> ={res, glob A})=> //; proc true.
-by hoare; rewrite /fst /snd /=; call (: true); auto=> /#.
+by hoare => /=; call (: true); auto=> /#.
 qed.
 
 lemma introOrs (A <: Worker) &m (ev:input -> glob A -> output -> bool):

--- a/theories/modules/PlugAndPray.eca
+++ b/theories/modules/PlugAndPray.eca
@@ -59,5 +59,5 @@ lemma PBound_mult (G <: Game )
          res.`1 = psi (glob G) res.`2].
 proof.
   move=> h; rewrite -(PBound G phi psi x0 &m h); field.
-  by rewrite /card eq_fromint size_eq0 undup_nilp indices_not_nil. 
+  by rewrite eq_fromint size_eq0 undup_nilp indices_not_nil. 
 qed.

--- a/theories/oldlibs/OldFMap.ec
+++ b/theories/oldlibs/OldFMap.ec
@@ -93,7 +93,7 @@ lemma reduce_reduced (s : ('a * 'b) list):
 proof.
 elim: s => [|[x y] s ih]; 1: by rewrite reduce_nil.
 rewrite reduce_cons /= => -[x_notin_s /ih ->].
-rewrite (@eq_in_filter _ predT) ?filter_predT /predT //=.
+rewrite (@eq_in_filter _ predT) ?filter_predT 1:/predT //=.
 case=> x' y' /(map_f fst) x'_in_s; apply/negP => <<-.
 by move: x_notin_s.
 qed.

--- a/theories/structure/Discrete.ec
+++ b/theories/structure/Discrete.ec
@@ -72,7 +72,7 @@ exists f; split=> [i j x fiE fjE|x /h {h} [i hi]].
 + by move/fQ: fjE; move/fQ: fiE => [h1 ->] [h2 ->].
 exists (minz (transpose P x)); rewrite ge0_argmin /=.
 have hP: P (minz (transpose P x)) x.
-+ apply/(@argminP idfun (transpose P x) (int2nat i)) => @/idfun /=.
++ apply/(@argminP idfun (transpose P x) (int2nat i)) => /=.
   * by apply/ge0_int2nat. * by exists i.
 have hR: R (minz (transpose P x)) (Some x) by done.
 have h: exists x', R (minz (transpose P x)) x' by exists (Some x).
@@ -136,7 +136,7 @@ theory IntPair.
   have {ge0_p1 ge0_p2} [o1 o2] : odd x1 /\ odd x2 by rewrite !oddX // odd3.
   wlog: n1 n2 ge0_n1 ge0_n2 neq_n x1 x2 o1 o2 / (n1 <= n2)%Int.
   + move=> ih; case: (lez_total n1 n2); first by apply: ih.
-    by move=> h @/P *; rewrite eq_sym &(ih) 1?eq_sym.
+    by move=> h *; rewrite eq_sym &(ih) 1?eq_sym.
   move=> le_n; have lt_n: n1 < n2 by rewrite ltr_neqAle le_n.
   rewrite (_ : n2 = n1 + (n2 - n1)) 1:#ring exprD_nneg ?subr_ge0 //.
   apply/negP; rewrite -mulrA; have h/h := mulfI (exp 2 n1) _.

--- a/theories/structure/Finite.ec
+++ b/theories/structure/Finite.ec
@@ -218,7 +218,7 @@ lemma finite_fun ['a 'b] :
   => is_finite<:'b> predT
   => is_finite<: 'a -> 'b> predT.
 proof.
-case=> [sa [uqa @/predT /= ha]] [sb [uqb @/predT /= hb]]; apply/finiteP.
+case=> [sa [uqa @/predT /= ha]] [sb [uqb /= hb]]; apply/finiteP.
 pose F (s : ('a * 'b) list) (a : 'a) := odflt witness (assoc s a).
 exists (map F (fingraph sa sb)) => /= f.
 apply/mapP; pose s := map (fun a => (a, f a)) sa.

--- a/theories/structure/WF.ec
+++ b/theories/structure/WF.ec
@@ -620,6 +620,7 @@ have -> :
   apply fun_ext => y.
   case (wfr y x) => [wfr_y_x | not_wfr_y_x].
   by rewrite /grel_restr /predecs wfr_y_x.
-  by rewrite eq_sym choiceb_dfl /grel_restr /predecs 1:not_wfr_y_x.
-rewrite least_result.
+  rewrite eq_sym choiceb_dfl //.
+  - by rewrite /grel_restr /predecs 1:not_wfr_y_x.
+  - by rewrite least_result.
 qed.


### PR DESCRIPTION
The option name is `und_delta`. It is disabled by default.

The mechanism can emit false positive, e.g. in:

`try rewrite /foo.`