### PR TITLE
[build]: use camlp-streams

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
  (depends
   (ocaml (>= 4.08.0))
   (batteries (>= 3))
+  (camlp-streams (>= 5))
   camlzip
   dune-build-info
   dune-site

--- a/easycrypt.opam
+++ b/easycrypt.opam
@@ -3,6 +3,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
   "batteries" {>= "3"}
+  "camlp-streams" {>= "5"}
   "camlzip"
   "dune-build-info"
   "dune-site"

--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@
  (public_name easycrypt)
  (name ec)
  (promote (until-clean))
- (libraries batteries dune-build-info inifiles why3 yojson zarith))
+ (libraries batteries camlp-streams dune-build-info inifiles why3 yojson zarith))
 
 (ocamllex ecLexer)
 


### PR DESCRIPTION
This resolves the deprecation warning about the Stream module.

Fix #186