### PR TITLE
Add camlp-streams dependency to nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,7 @@ let why3 = why3_local; in
       ocaml
       findlib
       batteries
+      camlp-streams
       dune_2
       dune-build-info
       dune-site


### PR DESCRIPTION
Fix failing nix-shell build, as discussed on Zulip