### PR TITLE
[while (phl, >=)]: be more restrictive on the variant delta lower-bound

### DIFF
--- a/src/ecPV.mli
+++ b/src/ecPV.mli
@@ -104,7 +104,7 @@ module PV : sig
   val mem_pv   : env -> prog_var -> t -> bool
   val mem_glob : env -> mpath -> t -> bool
 
-  val fv : env -> EcIdent.t -> form -> t
+  val fv : env -> EcMemory.memory -> form -> t
 
   val pp : env -> Format.formatter -> t -> unit
 

--- a/src/phl/ecPhlWhile.ml
+++ b/src/phl/ecPhlWhile.ml
@@ -218,7 +218,7 @@ let t_bdhoare_while_rev_r inv tc =
 let t_bdhoare_while_rev_geq_r inv vrnt k eps tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
 
-  let bhs    = tc1_as_bdhoareS tc in
+  let bhs = tc1_as_bdhoareS tc in
 
   if bhs.bhs_cmp = FHle then
     tc_error !!tc "only judgments with an lower/eq-bounded are supported";
@@ -228,6 +228,11 @@ let t_bdhoare_while_rev_geq_r inv vrnt k eps tc =
   let mem    = bhs.bhs_m in
 
   let (lp_guard_exp, lp_body), rem_s = tc1_last_while tc bhs.bhs_s in
+
+  if not (PV.indep env (s_write env lp_body) (PV.fv env (EcMemory.memory mem) eps)) then
+    tc_error !!tc
+      "The variant decreasing rate lower-bound cannot "
+      "depend on variables written by the loop body";
 
   if not (List.is_empty rem_s.s_node) then
     tc_error !!tc  "only single loop statements are accepted";


### PR DESCRIPTION
The lower-bound should be independent from the variables written by the loop body.