### PR TITLE
Add postfix notations.

### DIFF
--- a/examples/UC/RndO.ec
+++ b/examples/UC/RndO.ec
@@ -2,7 +2,7 @@
 
 prover [""].
 
-require import Core List MapAux SmtMap FSet Distr.
+require import AllCore List MapAux SmtMap FSet Distr.
 require IterProc.
 
 type flag = [ Unknown | Known ].  (* map setting known by distinguisher? *)

--- a/src/ecLexer.mll
+++ b/src/ecLexer.mll
@@ -344,6 +344,7 @@ let nop = '\\' ichar+
 let uniop = nop | ['-' '+']+ | '!'
 let binop = sop | nop
 let numop = '\'' digit+
+let pstop = '%' lident
 
 (* -------------------------------------------------------------------- *)
 rule main = parse
@@ -363,6 +364,7 @@ rule main = parse
   | "(*" binop "*)" { main lexbuf }
   | '(' blank* (binop as s) blank* ')' { [PBINOP s] }
   | '(' blank* (numop as s) blank* ')' { [PNUMOP s] }
+  | '(' blank* (pstop as s) blank* ')' { [PPSTOP s] }
 
   | '[' blank* (uniop as s) blank* ']' {
       let name = Printf.sprintf "[%s]" s in

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -365,6 +365,7 @@
 %token <EcSymbols.symbol> PUNIOP
 %token <EcSymbols.symbol> PBINOP
 %token <EcSymbols.symbol> PNUMOP
+%token <EcSymbols.symbol> PPSTOP
 
 %token <EcBigInt.zint> UINT
 %token <EcBigInt.zint * (int * EcBigInt.zint)> DECIMAL
@@ -748,6 +749,7 @@ genqident(X):
 | x=PUNIOP  { x }
 | x=PBINOP  { x }
 | x=PNUMOP  { x }
+| x=PPSTOP  { x }
 
 | x=loc(STRING)   {
     if not (EcCoreLib.is_mixfix_op (unloc x)) then
@@ -758,7 +760,6 @@ genqident(X):
 %inline _oident:
 | x=_boident      { x }
 | x=paren(PUNIOP) { x }
-
 
 %inline boident: x=loc(_boident) { x }
 %inline  oident: x=loc( _oident) { x }
@@ -903,17 +904,12 @@ sexpr_u:
 | e=sexpr PCENT p=uqident
    { PEscope (p, e) }
 
-| e=sexpr p=loc(prefix(PCENT, lident))
-   { let { pl_loc = lc; pl_desc = p; } = p in
-     if unloc p = "r" then
-       let id =
-         PEident (mk_loc lc EcCoreLib.s_real_of_int, None)
-       in PEapp (mk_loc lc id, [e])
-     else begin
-       if unloc p <> "top" then
-         parse_error p.pl_loc (Some "invalid scope name");
+| e=sexpr p=loc(prefix(PCENT, _lident))
+   { if unloc p = "top" then
        PEscope (pqsymb_of_symb p.pl_loc "<top>", e)
-     end }
+     else
+       let p = lmap (fun x -> "%" ^ x) p in
+       PEapp (mk_loc (loc p) (PEident (pqsymb_of_psymb p, None)), [e]) }
 
 | LPAREN e=expr COLONTILD ty=loc(type_exp) RPAREN
    { PEcast (e, ty) }
@@ -1173,17 +1169,13 @@ sform_u(P):
 | f=sform_r(P) PCENT p=uqident
    { PFscope (p, f) }
 
-| f=sform_r(P) p=loc(prefix(PCENT, lident))
-   { let { pl_loc = lc; pl_desc = p; } = p in
-     if unloc p = "r" then
-       let id =
-         PFident (mk_loc lc EcCoreLib.s_real_of_int, None)
-       in PFapp (mk_loc lc id, [f])
-     else begin
-       if unloc p <> "top" then
-         parse_error p.pl_loc (Some "invalid scope name");
+| f=sform_r(P) p=loc(prefix(PCENT, _lident))
+
+   { if unloc p = "top" then
        PFscope (pqsymb_of_symb p.pl_loc "<top>", f)
-     end }
+     else
+       let p = lmap (fun x -> "%" ^ x) p in
+       PFapp (mk_loc (loc p) (PFident (pqsymb_of_psymb p, None)), [f]) }
 
 | SHARP pf=pffilter* x=ident
    { PFref (x, pf) }

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -652,6 +652,10 @@ let is_binop name =
   (priority_of_binop name) <> None
 
 (* -------------------------------------------------------------------- *)
+let is_pstop name =
+  String.length name > 0 && name.[0] = '%'
+
+(* -------------------------------------------------------------------- *)
 let rec pp_type_r ppe outer fmt ty =
   match ty.ty_node with
   | Tglob m -> Format.fprintf fmt "(glob %a)" (pp_topmod ppe) m
@@ -742,7 +746,9 @@ let pp_opname fmt (nm, op) =
       if op.[0] = '*' || op.[String.length op - 1] = '*'
       then Format.sprintf "( %s )" op
       else Format.sprintf "(%s)" op
-    end else op
+    end else if is_pstop op then
+      Format.sprintf "(%s)" op
+    else op
 
   in EcSymbols.pp_qsymbol fmt (nm, op)
 
@@ -1036,7 +1042,22 @@ let pp_opapp
             Some pp
 
     end
+
     | _ -> None
+
+  and try_pp_as_post () =
+    match es with
+    | [e] when is_pstop opname -> begin
+        let pp fmt () =
+          let subpp = pp_sub ppe (fst outer, (e_uni_prio_rint, `NonAssoc)) in
+          Format.fprintf fmt "%a%s" subpp e opname
+        in
+          Some pp
+
+      end
+
+    | _ ->
+       None
 
   and try_pp_special () =
     let qs = P.toqsymbol op in
@@ -1048,13 +1069,6 @@ let pp_opapp
         let pp fmt () =
           Format.fprintf fmt "{0,1}~%a"
             (pp_sub ppe (fst outer, (max_op_prec, `NonAssoc))) e
-        in
-          Some pp
-
-    | [e] when qs = EcCoreLib.s_real_of_int ->
-        let pp fmt () =
-          Format.fprintf fmt "%a%%r"
-            (pp_sub ppe (fst outer, (e_uni_prio_rint, `NonAssoc))) e
         in
           Some pp
 
@@ -1164,6 +1178,7 @@ let pp_opapp
        (List.fpick [try_pp_special ;
                     try_pp_as_uniop;
                     try_pp_as_binop;
+                    try_pp_as_post ;
                     try_pp_record  ;
                     try_pp_proj    ;])) fmt ()
 

--- a/theories/core/CoreReal.ec
+++ b/theories/core/CoreReal.ec
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
 op from_int: int -> real.
+
 op zero = from_int 0.
 op one  = from_int 1.
 op add  : real -> real -> real.
@@ -9,6 +10,4 @@ op inv  : real -> real.
 
 op lt : real -> real -> bool.
 op le = fun x y => lt x y \/ x = y.
-
-(* -------------------------------------------------------------------- *)
 

--- a/theories/datatypes/Real.ec
+++ b/theories/datatypes/Real.ec
@@ -7,6 +7,7 @@ abbrev ( + ) = CoreReal.add.
 abbrev ([-]) = CoreReal.opp.
 abbrev ( * ) = CoreReal.mul.
 abbrev inv   = CoreReal.inv.
+abbrev (%r)  = CoreReal.from_int.
 
 abbrev ( - ) (x y : real) = x + (-y).
 abbrev ( / ) (x y : real) = x * (inv y).


### PR DESCRIPTION
Postfix operators are named "(%x)" where x is a low-ident.

This generalizes the %r notation.