### PR TITLE
[ec-runtest]: add the possibility to exclude file based on the name

### DIFF
--- a/scripts/testing/runtest
+++ b/scripts/testing/runtest
@@ -7,11 +7,13 @@ import collections
 import contextlib as clib
 import curses
 import datetime
+import fnmatch
 import glob
 import itertools
 import math
 import multiprocessing as mp
 import os
+import pathlib
 import re
 import signal
 import socket
@@ -44,6 +46,10 @@ async def awaitable(the):
         await the.wait()
 
 clib.awaitable = awaitable
+
+# --------------------------------------------------------------------
+def is_tuple_prefix(prefix, subject):
+    return subject[:len(prefix)] == prefix
 
 # --------------------------------------------------------------------
 class Object:
@@ -121,7 +127,13 @@ def _options():
     options.jobs     = cmdopt.jobs
     options.report   = cmdopt.report
 
-    defaults = dict(args = '', exclude = '', okdirs = '', kodirs = '')
+    defaults = dict(
+        args         = '',
+        exclude      = '',
+        file_exclude = '',
+        okdirs       = '',
+        kodirs       = '',
+    )
 
     config = cp.ConfigParser(defaults)
     config.read(args[0])
@@ -152,10 +164,11 @@ def _options():
 
     for test in [x for x in config.sections() if x.startswith('test-')]:
         scenario = Object()
-        scenario.args    = config.get(test, 'args').split()
-        scenario.okdirs  = config.get(test, 'okdirs')
-        scenario.kodirs  = config.get(test, 'kodirs')
-        scenario.exclude = config.get(test, 'exclude').split()
+        scenario.args     = config.get(test, 'args').split()
+        scenario.okdirs   = config.get(test, 'okdirs')
+        scenario.kodirs   = config.get(test, 'kodirs')
+        scenario.dexclude = config.get(test, 'exclude').split()
+        scenario.fexclude = config.get(test, 'file_exclude').split()
         options.scenarios[test[5:]] = scenario
 
     for x in options.targets:
@@ -289,12 +302,22 @@ class CurseWrapper(metaclass = Singleton):
 # --------------------------------------------------------------------
 class Gather:
     @staticmethod
-    def is_excluded(src, excludes):
+    def is_dir_excluded(src, excludes):
+        src = pathlib.Path(src).parts
         for path in excludes:
+            rec = False
             if path.startswith('!'):
-                if src.startswith(path[1:]):
-                    return True
-            elif src == path:
+                rec, path = True, path[1:]
+            path = pathlib.Path(path).parts
+            if (is_tuple_prefix(path, src) if rec else path == src):
+                return True
+        return False
+
+    @staticmethod
+    def is_file_excluded(src, excludes):
+        for exclude in excludes:
+            print(os.path.basename(src), exclude)
+            if fnmatch.fnmatch(src, exclude):
                 return True
         return False
 
@@ -337,9 +360,13 @@ class Gather:
                          for x in expand(scenario.okdirs)])
         dirs.extend([Object(src = x, valid = False, args = scenario.args) \
                          for x in expand(scenario.kodirs)])
-        dirs = [x for x in dirs if not cls.is_excluded(x.src,scenario.exclude)]
+        dirs = [x for x in dirs if not cls.is_dir_excluded(x.src, scenario.dexclude)]
         dirs = map(lambda x : cls.gather(x, scenario), dirs)
-        return list(itertools.chain.from_iterable(dirs))
+
+        files = list(itertools.chain.from_iterable(dirs))
+        files = [x for x in files if not cls.is_file_excluded(x.filename, scenario.fexclude)]
+
+        return files
 
     @classmethod
     def gatherall(cls, scenarios, targets):


### PR DESCRIPTION
The entry is `file_exclude`. It is a space-separated list of globs. A file is excluded if its basename matches any of the glob.

See `fnmatch.fnmatch` of the standard Python libraries to get a description of which glob patterns are supported.

Fix #303