### PR TITLE
Additions to Word and BitWord: cancellation of ofword using mkseq, plus integer values of onew and zerow

### DIFF
--- a/theories/datatypes/BitWord.eca
+++ b/theories/datatypes/BitWord.eca
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
-require import Bool Core Int Xint List.
+require import AllCore Bool Int Xint List BitEncoding.
+import (*---*) BS2Int.
 require (*--*) FinType Word Ring.
 
 pragma +implicits.
@@ -141,6 +142,14 @@ move=> x y; rewrite /unitw !wordP => + i Hi -/(_ i Hi).
 by rewrite andwE onewE Hi /#.
 qed.
 
+(* -------------------------------------------------------------------- *)
+lemma zerow_int:
+  bs2int (ofword zerow) = 0.
+proof. by rewrite ofwordKmkseq mkseq_nseq bs2int_nseq_false. qed.
+
+lemma onew_int:
+  bs2int (ofword onew) = 2 ^ n - 1.
+proof. by rewrite ofwordKmkseq mkseq_nseq bs2int_nseq_true 1:ge0_n. qed.
 
 (* -------------------------------------------------------------------- *)
 abstract theory Cost.

--- a/theories/datatypes/Word.eca
+++ b/theories/datatypes/Word.eca
@@ -150,6 +150,12 @@ qed.
 lemma offunE f i: 0 <= i < n => (offun f).[i] = f i.
 proof. by move=> lt_in; rewrite offunifE lt_in. qed.
 
+lemma ofwordKmkseq (f : int -> t):
+  ofword (offun f) = mkseq f n.
+proof.
+by rewrite ofwordK 1:size_mkseq 1:StdOrder.IntOrder.ler_maxr 1:ge0_n.
+qed.
+
 (* -------------------------------------------------------------------- *)
 op map (f : t -> t) (w : word) : word = mkword (map f (ofword w)).
 


### PR DESCRIPTION
Added cancellation variant for ofword that uses mkseq to Word.eca, and added lemmas about the integer values of onew and zerow to BitWord.eca.