### PR TITLE
Implement a naive termination checker

### DIFF
--- a/src/ecTypes.ml
+++ b/src/ecTypes.ml
@@ -917,7 +917,7 @@ let e_map fty fe e =
       let bd' = fe bd in
       ExprSmart.e_quant (e, (q, b, bd)) (q, b', bd')
 
-let e_fold fe state e =
+let e_fold (fe : 'a -> expr -> 'a) (state : 'a) (e : expr) =
   match e.e_node with
   | Eint _                -> state
   | Elocal _              -> state
@@ -930,6 +930,9 @@ let e_fold fe state e =
   | Eif (e1, e2, e3)      -> List.fold_left fe state [e1; e2; e3]
   | Ematch (e, es, _)     -> List.fold_left fe state (e :: es)
   | Equant (_, _, e1)     -> fe state e1
+
+let e_iter (fe : expr -> unit) (e : expr) =
+  e_fold (fun () e -> fe e) () e
 
 module MSHe = EcMaps.MakeMSH(struct type t = expr let tag e = e.e_tag end)
 module Me = MSHe.M

--- a/src/ecTypes.mli
+++ b/src/ecTypes.mli
@@ -276,6 +276,8 @@ val e_map :
 val e_fold :
   ('state -> expr -> 'state) -> 'state -> expr -> 'state
 
+val e_iter : (expr -> unit) -> expr -> unit
+
 (* -------------------------------------------------------------------- *)
 type e_subst = {
   es_freshen : bool; (* true means realloc local *)

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -110,6 +110,7 @@ type fxerror =
 | FXE_CtorUnk
 | FXE_CtorAmbiguous
 | FXE_CtorInvalidArity of (symbol * int * int)
+| FXE_SynCheckFailure
 
 type filter_error =
 | FE_InvalidIndex of int

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -100,6 +100,7 @@ type fxerror =
 | FXE_CtorUnk
 | FXE_CtorAmbiguous
 | FXE_CtorInvalidArity of (symbol * int * int)
+| FXE_SynCheckFailure
 
 type filter_error =
 | FE_InvalidIndex of int

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -275,6 +275,9 @@ end = struct
           "the constructor %s expects %d argument(s) (%d argument(s) given)"
           cname i j
 
+    | FXE_SynCheckFailure ->
+        msg "syntactic termination check failure"
+
   let pp_tyerror env1 fmt error =
     let env   = EcPrinting.PPEnv.ofenv env1 in
     let msg x = Format.fprintf fmt x in

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -3430,7 +3430,7 @@ op lex (e : 'a -> 'a -> bool) s1 s2 =
   with s1 = []      , s2 = y2 :: s2 => true
   with s1 = y1 :: s1, s2 = []       => false
   with s1 = y1 :: s1, s2 = y2 :: s2 =>
-    if e y1 y2 then if e y2 y1 then lex e s1 s1 else true else false.
+    if e y1 y2 then if e y2 y1 then lex e s1 s2 else true else false.
 
 lemma lex_total (e : 'a -> 'a -> bool):
      (forall x y, e x y \/ e y x)


### PR DESCRIPTION
Termination is done via a simple subterm check on the last inductive argument.

Ref #62, #144