### PR TITLE
[theories]: p_max (maximum probability for atomic events)

### DIFF
--- a/theories/analysis/RealFLub.ec
+++ b/theories/analysis/RealFLub.ec
@@ -7,19 +7,63 @@ pragma +implicits.
 (* lub for functions *)
 op flub (F : 'a -> real) : real = lub (fun r => exists a, F a = r).
 
-lemma flub_upper_bound r (F : 'a -> real) x : 
-    (forall x, F x <= r) => F x <= flub F.
+op is_fub (f: 'a -> real) r = forall x, f x <= r.
+op has_fub (f: 'a -> real) = exists r, is_fub f r.
+
+lemma has_fub_lub (f: 'a -> real) :
+  has_fub f <=> has_lub (fun r => exists a, f a = r).
+proof.
+split => [[r ub_r]|has_lub_imgf].
+- split; [exists (f witness) => //; exists witness|exists r]; smt().
+by exists (flub f) => ?; apply lub_upper_bound => /#.
+qed.
+
+lemma ler_has_fub (f g: 'a -> real) :
+  (forall x, f x <= g x) => has_fub g => has_fub f
+by smt().
+
+lemma flub_upper_bound (F : 'a -> real) x : 
+    has_fub F => F x <= flub F.
 proof.
 move => H. apply lub_upper_bound; 2: by exists x.
-split; [by exists (F x) x|exists r => y [a] <-; exact H].
+by split; [ by exists (F x) x | smt() ].
 qed.
 
 lemma flub_le_ub (F : 'a -> real) r :
-    (forall x, F x <= r) => flub F <= r.
+    is_fub F r => flub F <= r.
 proof.
-move => H. 
-have ub_r : ub (fun (x : real) => exists (a : 'a), F a = x) r. 
+move => H.
+have ub_r : ub (fun (x : real) => exists (a : 'a), F a = x) r.
   move => y [a] <-; exact H.
-apply RealLub.lub_le_ub => //. 
+apply lub_le_ub => //. 
 split; [by exists (F witness) witness| by exists r].
 qed.
+
+lemma ler_flub (f g: 'a -> real) :
+  has_fub g =>
+  (forall x, f x <= g x) => flub f <= flub g.
+proof.
+move => [ym is_ub_ym] le_fg; rewrite ler_lub //=; 1: smt(); last first.
+- by exists (f witness) => /#.
+split; first exists (g witness) => /#.
+exists ym; smt(has_fub_lub).
+qed.
+
+lemma flubZ (f: 'a -> real) c : has_fub f =>
+  c >= 0%r => flub (fun x => c * f x) = c * flub f.
+proof.
+move => fub_f c_ge0 @/flub; pose E := fun r => exists a, f a = r.
+have -> : (fun r => exists a, c * f a = r) = scale_rset E c by smt().
+by rewrite lub_scale //; apply has_fub_lub.
+qed.
+
+lemma flub_const c :
+  flub (fun _ : 'a => c) = c.
+proof.
+apply eqr_le; split; first apply flub_le_ub => /#.
+move => _; apply (@flub_upper_bound (fun _ => c) witness) => /#.
+qed.
+
+lemma has_fubZ (f: 'a -> real) c: has_fub f =>
+  c >= 0%r => has_fub (fun x => c * f x).
+proof. move => [ym ub_ym] ge0_c; exists (c * ym) => /#. qed.

--- a/theories/analysis/RealLub.ec
+++ b/theories/analysis/RealLub.ec
@@ -77,3 +77,43 @@ case: (lub_adherent _ hlE (lub E - z) _); 1: by rewrite subr_gt0.
 move=> e [eE]; rewrite opprB addrCA subrr addr0.
 by rewrite ltrNge /=; apply: ub_Ez.
 qed.
+
+(* -------------------------------------------------------------------- *)
+lemma lub1 x : lub (pred1 x) = x.
+proof.
+apply eqr_le; split; [apply lub_le_ub => /#|move => _].
+apply lub_upper_bound; smt().
+qed.
+
+(* -------------------------------------------------------------------- *)
+
+(* used to prove linearity of [flub], where the lub may be a limit *)
+op scale_rset (E: real -> bool) c x = exists x0, E x0 /\ c * x0 = x.
+
+lemma lub_scale0 E : nonempty E => lub (scale_rset E 0%r) = 0%r.
+proof.
+move => [x x_E]; have -> : scale_rset E 0%r = pred1 0%r. 
+- (* CD: locally smt() does the job in a fraction of a sectiond *)
+  apply/fun_ext => z @/scale_rset @/pred1. 
+  by apply/eq_iff; split => />; exists x.
+by rewrite lub1.
+qed.
+
+lemma has_lub_scale E c : 0%r <= c =>
+  has_lub E => has_lub (scale_rset E c).
+proof.
+move => c_ge0 [[x Ex] ?]; split; 1: smt().
+exists (c * lub E) => cx; smt(lub_upper_bound).
+qed.
+
+lemma lub_scale E c : has_lub E =>
+  c >= 0%r => lub (scale_rset E c) = c * lub E.
+proof.
+move => has_lubE ge0_c.
+case (c > 0%r) => [gt0_c|]; last by smt(lub_scale0).
+apply eqr_le; split => [|_].
+- apply lub_le_ub; first by apply has_lub_scale.
+  smt(lub_upper_bound).
+rewrite -ler_pdivl_mull //; apply lub_le_ub => // x Ex.
+by rewrite ler_pdivl_mull //; smt(lub_upper_bound has_lub_scale). 
+qed.

--- a/theories/core/Core.ec
+++ b/theories/core/Core.ec
@@ -300,3 +300,5 @@ proof. by move=> x @/predI [] _ ->. qed.
 
 lemma nosmt predTofV (f : 'a -> 'b): predT \o f = predT.
 proof. by apply/fun_ext=> x. qed.
+
+lemma pred_0Vmem (p : 'a -> bool) : p = pred0 \/ exists x, p x by smt().

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -3433,6 +3433,18 @@ qed.
 
 end section ListMax.
 
+lemma maxr_seq (f : 'a -> real) (s : 'a list) x0 : 
+  x0 \in s => exists x, x \in s /\ forall y, y \in s => f y <= f x.
+proof.
+by case: s => // x s _; elim: s x => {x0} [|y s IHs] x; smt().
+qed.
+
+lemma maxz_seq (f : 'a -> int) (s : 'a list) x0 : 
+  x0 \in s => exists x, x \in s /\ forall y, y \in s => f y <= f x.
+proof.
+by case: s => // x s _; elim: s x => {x0} [|y s IHs] x; smt().
+qed.
+
 (* -------------------------------------------------------------------- *)
 (*                          Order lifting                               *)
 (* -------------------------------------------------------------------- *)

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -25,8 +25,8 @@ op sdist (d1 d2 : 'a distr) = flub (fun E => `|mu d1 E - mu d2 E|).
 lemma sdist_upper_bound (d1 d2 : 'a distr) E : 
   `|mu d1 E - mu d2 E| <= sdist d1 d2.
 proof.
-apply (flub_upper_bound 1%r (fun E => `|mu d1 E - mu d2 E|)).
-move => {E} E /=; smt(mu_bounded).
+apply (flub_upper_bound (fun E => `|mu d1 E - mu d2 E|)).
+by exists 1%r; smt(mu_bounded).
 qed.
  
 lemma sdist_le_ub (d1 d2 : 'a distr) r :
@@ -121,7 +121,8 @@ have <- : `| Sp - Sn | = `|weight d1 - weight d2|.
   by congr; apply eq_sum => x /= /#.
 suff : flub F = Sp by rewrite /sdist -/F; smt(ler_def).
 apply ler_anti; split => [|_]; last first. 
-- apply (ler_trans (F pos)); 2: by apply (flub_upper_bound 1%r); smt(mu_bounded).
+- apply (ler_trans (F pos)); last first.
+  + by apply (flub_upper_bound); exists 1%r; rewrite /is_fub; smt(mu_bounded).
   rewrite /Sp /F /f !muE -sumB /=; 1,2: exact summable_mu1_cond.
   apply (ler_trans _ _ _ _ (ler_norm _)). 
   apply ler_sum;  [smt()|apply/summable_cond/summable_sdist|].


### PR DESCRIPTION
This is the theory of `op p_max (d : 'a distr) = flub (mu1 d)` the maximal probability of atomic events in the distribution. 

This includes a proof that, despite the definition using `flub`, the maximum is always attained. This in turn required a few more lemmas on `flub` and factoring out the lemma:
```
lemma mu_pos_fin (d : 'a distr) eps : 
  0%r < eps => is_finite (fun x => eps <= mu1 d x).
```
from the proof of `uniform_finite`. 

`p_max` implicitly captures min-entropy. I chose to not include the latter in this PR, because the PR is already quire big.

There's quite a few names and places (for lemmas) that I'm not sure about. Please review carefully. 