### PR TITLE
[nix] pin the Why3 version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,17 @@
 
 with import <nixpkgs> {};
 
+let why3_local =
+  why3.overrideAttrs (o : rec {
+    version = "1.5.1";
+    src = fetchurl {
+      url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
+      sha256 = "sha256-vNR7WeiSvg+763GcovoZBFDfncekJMeqNegP4fVw06I=";
+    };
+  });
+in
+let why3 = why3_local; in
+
 let provers =
   if withProvers then [
     alt-ergo

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,16 @@
 { withProvers ? true, devDeps ? [] }:
 
+let why3_local =
+  why3.overrideAttrs (o : rec {
+    version = "1.5.1";
+    src = fetchurl {
+      url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
+      sha256 = "sha256-vNR7WeiSvg+763GcovoZBFDfncekJMeqNegP4fVw06I=";
+    };
+  });
+in
+let why3 = why3_local; in
+
 with import <nixpkgs> {};
 
 let provers =


### PR DESCRIPTION
This makes it easier to bump versions and rely on CI.

In particular, it should facilitate the Why3 version bump awaiting in #352 and avoid temporary breakage one way or another as the corresponding version bump makes its way through to nixpkgs (https://github.com/NixOS/nixpkgs/pull/220986)