### PR TITLE
Fix to pretty-printing of matches in applications

### DIFF
--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -567,6 +567,15 @@ let maybe_paren (onm, (outer, side)) (inm, inner) pp =
 let maybe_paren_nosc outer inner pp =
   maybe_paren ([], outer) ([], inner) pp
 
+(* when a construct is bracketed with words, e.g., `match ... end`,
+   only introduce explicit parentheses in an application *)
+let maybe_paren_bracketed_with_words (_, (_, side)) pp =
+  let parens outer =
+    (match side with
+     | `ILeft | `IRight -> true
+     | _                -> false)
+  in pp_maybe_paren (parens side) pp
+
 (* -------------------------------------------------------------------- *)
 let t_prio_fun  = (10, `Infix `Right)
 let t_prio_tpl  = (20, `NonAssoc)
@@ -578,9 +587,6 @@ let e_bin_prio_if     = ( 5, `Prefix)
 let e_bin_prio_letin  = ( 5, `Prefix)
 let e_bin_prio_impl   = (10, `Infix `Right)
 let e_bin_prio_iff    = (12, `NonAssoc)
-(* don't need, as closed with end:
-let e_bin_prio_match  = (15, `Prefix)
-*)
 let e_bin_prio_nop    = (19, `Infix `Left)
 let e_bin_prio_or     = (20, `Infix `Right)
 let e_bin_prio_and    = (25, `Infix `Right)
@@ -838,7 +844,7 @@ let pp_match_form (ppe : PPEnv.t) pp_sub outer fmt (b, bs) =
       (pp_sub ppe (fst outer, (min_op_prec, `NonAssoc))) b
       (fun fmt -> pp_list "@ " pp_branch fmt bs)
 
-  in pp fmt (b, bs)  (* has end, so don't need maybe_paren *)
+  in maybe_paren_bracketed_with_words outer pp fmt (b, bs)
 
 (* -------------------------------------------------------------------- *)
 let pp_tuple mode (ppe : PPEnv.t) pp_sub osc fmt es =


### PR DESCRIPTION
Commit b2106aa6c3d89068a599a4037101b933bfb43804 suppressed  additional parentheses around `match ... end` in all circumstances, even though on the left and right of applications the parser requires parentheses, the theory being this makes it easier for humans to scan. So this commit inserts parentheses around matches in applications, but not elsewhere (e.g., not in infix operators). See below for examples. [The pretty printer needs a major redesign, so this is another stopgap measure.]

require import AllCore List. type t = [ A of int |  B of bool].

(* the following formulas now parse and pretty-print the same *)

lemma foo1 (f : int -> bool) :
  f (match A 3 with | A a => a | B b => if b then 1 else 2 end).
proof. abort.

lemma foo2 :
  (match A 3 with | A a => fun _ => a | B b => fun _ => 2 end) 3 = 4.
proof. abort.

lemma foo3 (f : (int -> int) -> (int -> int)) :
  f (match A 3 with | A a => fun _ => a | B b => fun _ => 2 end) 3 = 4.
proof. abort.

lemma foo4 (f : int -> bool) :
  f (1 + match A 3 with | A a => a | B b => if b then 1 else 2 end).
proof. abort.

lemma foo5 (f : int -> bool) :
  f (match A 3 with | A a => a | B b => if b then 1 else 2 end + 1).
proof. abort.

lemma foo6 (f : int -> bool) :
  f (3 + match A 3 with | A a => a | B b => if b then 1 else 2 end + 1).
proof. abort.