### PR TITLE
New command: proc op. This command generates an operator that

### DIFF
--- a/src/ecCommands.ml
+++ b/src/ecCommands.ml
@@ -341,6 +341,11 @@ and process_operator (scope : EcScope.scope) (pop : poperator located) =
   scope
 
 (* -------------------------------------------------------------------- *)
+and process_procop (scope : EcScope.scope) (pop : pprocop located) =
+  EcScope.check_state `InTop "operator" scope;
+  EcScope.Op.add_opsem scope pop
+
+(* -------------------------------------------------------------------- *)
 and process_predicate (scope : EcScope.scope) (p : ppredicate located) =
   EcScope.check_state `InTop "predicate" scope;
   let op, scope = EcScope.Pred.add scope p in
@@ -642,6 +647,7 @@ and process (ld : Loader.loader) (scope : EcScope.scope) g =
       | Gmodule      m    -> `Fct   (fun scope -> process_module     scope  m)
       | Ginterface   i    -> `Fct   (fun scope -> process_interface  scope  i)
       | Goperator    o    -> `Fct   (fun scope -> process_operator   scope  (mk_loc loc o))
+      | Gprocop      o    -> `Fct   (fun scope -> process_procop     scope  (mk_loc loc o))
       | Gpredicate   p    -> `Fct   (fun scope -> process_predicate  scope  (mk_loc loc p))
       | Gnotation    n    -> `Fct   (fun scope -> process_notation   scope  (mk_loc loc n))
       | Gabbrev      n    -> `Fct   (fun scope -> process_abbrev     scope  (mk_loc loc n))

--- a/src/ecCoreLib.ml
+++ b/src/ecCoreLib.ml
@@ -82,6 +82,7 @@ module CI_Int = struct
   let p_int_lt    = _Int "lt"
   let p_int_edivz = _IntDiv "edivz"
   let p_int_max   = _IntDiv "max"
+  let p_iteri     = EcPath.extend p_top ["Int"; "IterOp"; "iteri"]
 end
 
 (* -------------------------------------------------------------------- *)
@@ -171,6 +172,7 @@ module CI_Distr = struct
   let p_lossless = _Distr "is_lossless"
   let p_uniform  = _Distr "is_uniform"
   let p_full     = _Distr "is_full"
+  let p_dfold    = _Distr "dfold"
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecCoreLib.mli
+++ b/src/ecCoreLib.mli
@@ -83,6 +83,7 @@ module CI_Int : sig
   val p_int_lt    : path
   val p_int_pow   : path
   val p_int_edivz : path
+  val p_iteri     : path
 end
 
 (* -------------------------------------------------------------------- *)
@@ -156,6 +157,7 @@ module CI_Distr : sig
   val p_lossless: path
   val p_uniform : path
   val p_full    : path
+  val p_dfold   : path
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1995,6 +1995,12 @@ mcptn(BOP):
     { PPApp ((pqsymb_of_symb op.pl_loc op.pl_desc, tvi), [x1; x2]) }
 
 (* -------------------------------------------------------------------- *)
+(* Proc operators                                                       *)
+procop:
+| PROC OP x=ident EQ f=loc(fident)
+    { { ppo_name = x; ppo_target = f; } }
+
+(* -------------------------------------------------------------------- *)
 (* Predicate definitions                                                *)
 predicate:
 | locality=locality PRED x=oident
@@ -3929,6 +3935,7 @@ global_action:
 | typeclass        { Gtypeclass   $1 }
 | tycinstance      { Gtycinstance $1 }
 | operator         { Goperator    $1 }
+| procop           { Gprocop      $1 }
 | predicate        { Gpredicate   $1 }
 | notation         { Gnotation    $1 }
 | abbreviation     { Gabbrev      $1 }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -407,6 +407,11 @@ type poperator = {
   po_locality : locality;
 }
 
+and pprocop = {
+  ppo_name   : psymbol;
+  ppo_target : pgamepath;
+}
+
 type ppred_def =
   | PPabstr of pty list
   | PPconcr of ptybindings * pformula
@@ -1232,6 +1237,7 @@ type global_action =
   | Gmodule      of pmodule_def_or_decl
   | Ginterface   of pinterface
   | Goperator    of poperator
+  | Gprocop      of pprocop
   | Gpredicate   of ppredicate
   | Gnotation    of pnotation
   | Gabbrev      of pabbrev

--- a/src/ecProcSem.ml
+++ b/src/ecProcSem.ml
@@ -1,0 +1,399 @@
+(* -------------------------------------------------------------------- *)
+open EcUtils
+open EcSymbols
+open EcTypes
+open EcModules
+open EcFol
+
+module BI = EcBigInt
+
+(* -------------------------------------------------------------------- *)
+exception SemNotSupported
+
+(* -------------------------------------------------------------------- *)
+type senv = {
+  env   : EcEnv.env;
+  subst : EcIdent.t Msym.t;
+}
+
+(* -------------------------------------------------------------------- *)
+module Env = struct
+  let empty (env : EcEnv.env) =
+    { env; subst = Msym.empty; }
+
+  let fresh (env : senv) (x : symbol) =
+    let idx = EcIdent.create x in
+    let env = { env with subst = Msym.add x idx env.subst } in
+    (env, idx)
+end
+
+(* -------------------------------------------------------------------- *)
+type mode = [`Det | `Distr]
+
+(* -------------------------------------------------------------------- *)
+(* FIXME: MOVE ME                                                       *)
+let eop_dunit (ty : ty) =
+  e_op EcCoreLib.CI_Distr.p_dunit [ty] (tfun ty (tdistr ty))
+
+let e_dunit (e : expr) =
+  e_app (eop_dunit e.e_ty) [e] (tdistr e.e_ty)
+
+(* -------------------------------------------------------------------- *)
+let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
+  EcPV.PV.iter
+    (fun pv _ -> if not (is_loc pv) then raise SemNotSupported)
+    (fun _ -> raise SemNotSupported)
+    (EcPV.i_read env.env i);
+
+  let wr =
+    let do1 (pv, ty) =
+      match pv with
+      | PVglob _ -> raise SemNotSupported
+      | PVloc  x -> (x, ty) in
+
+    let wr, mods = EcPV.PV.elements (EcPV.i_write env.env i) in
+
+    if not (List.is_empty mods) then
+      raise SemNotSupported;
+    List.map do1 wr
+  in
+
+  let env', ids =
+    List.fold_left_map
+      (fun env (x, _) -> Env.fresh env x)
+      env wr in
+
+  let ids = List.combine wr ids in
+
+  match i.i_node with
+  | Sasgn (lv, e) ->
+     let e = translate_e env e in
+     let lv = translate_lv env' lv in
+     let mode, body = cont env' in
+     (mode, (e_let lv e body))
+
+  | Srnd (lv, d) -> begin
+     let d = translate_e env d in
+     let lv = translate_lv env' lv in
+     let mode, body = cont env' in
+
+     let tya = oget (as_tdistr (EcEnv.Ty.hnorm d.e_ty env.env)) in
+     let tyb = body.e_ty in
+
+     let aout =
+       let d    = form_of_expr mhr d in
+       let body = form_of_expr mhr body in
+       let body =
+         let arg  = EcIdent.create "arg" in
+         let body = f_let lv (f_local arg tya) body in
+         f_lambda [(arg, GTty tya)] body in
+
+       match mode with
+       | `Det   -> f_dmap tya tyb d body
+       | `Distr -> f_dlet_simpl tya tyb d body
+
+     in (`Distr, expr_of_form mhr aout)
+    end
+
+  | Sif (e, bt, bf) ->
+     let cont (fenv : senv) : mode * expr =
+       let do1 ((x, ty), _) =
+         e_local (Msym.find x fenv.subst) ty in
+       let vars = List.map do1 ids in
+       (`Det, e_tuple vars) in
+
+     let e  = translate_e env e in
+     let bt = translate_s env cont bt in
+     let bf = translate_s env cont bf in
+
+     let mode, (bt, bf) =
+       match bt, bf with
+       | (`Det, bt), (`Det, bf) ->
+          (`Det, (bt, bf))
+
+       | (`Distr, bt), (`Distr, bf) ->
+          (`Distr, (bt, bf))
+
+       | (`Det, bt), (`Distr, bf) ->
+          (`Distr, (e_dunit bt, bf))
+
+       | (`Distr, bt), (`Det, bf) ->
+          (`Distr, (bt, e_dunit bf)) in
+
+     let lv =
+       let ids =
+         let do1 ((x, ty), _) =
+           (Msym.find x env'.subst, ty) in
+         List.map do1 ids in
+
+       match ids with
+       | [] ->
+          LSymbol (EcIdent.create "_", tunit)
+       | [x, ty] ->
+          LSymbol (x, ty)
+       | ids ->
+          LTuple ids in
+
+     let cmode, c = (cont env') in
+
+     (mode, e_let lv (e_if e bt bf) c) (* FIXME *)
+
+  | Scall (Some lv, ({ x_top = { m_top = `Concrete (p, _) }; x_sub = f } as xp), args)  ->
+      let fd   = oget (EcEnv.Fun.by_xpath_opt xp env.env) in
+      let args = translate_e env (e_tuple args) in
+      let op   = EcPath.pqname (oget (EcPath.prefix p)) f in
+      let op   = e_op op [] (tfun fd.f_sig.fs_arg fd.f_sig.fs_ret) in
+      let op   = e_app op [args] fd.f_sig.fs_ret in
+      let lv   = translate_lv env' lv  in
+
+      let cmode, c = cont env' in
+
+      (cmode, e_let lv op c)
+
+  | Swhile    _
+  | Smatch    _
+  | Sassert   _
+  | Sabstract _
+  | Scall     _ ->
+     raise SemNotSupported;
+
+(* -------------------------------------------------------------------- *)
+and translate_s (env : senv) (cont : senv -> mode * expr) (s : stmt) =
+  match translate_forloop env cont s with
+  | Some e ->
+     e
+  | None ->
+     match s.s_node with
+     | [] ->
+        cont env
+     | i :: s ->
+        translate_i env (fun env -> translate_s env cont (stmt s)) i
+
+(* -------------------------------------------------------------------- *)
+and translate_forloop (env : senv) (cont : senv -> mode * expr) (s : stmt) =
+  let module ET = EcReduction.EqTest in
+
+  match s.s_node with
+  | { i_node = Sasgn (LvVar (PVloc x, xty), e) } :: { i_node = Swhile (c, body) } :: s_tail ->
+     if not (ET.for_type env.env xty tint) then
+       raise SemNotSupported;
+
+     if not (ET.for_expr env.env e (e_int EcBigInt.zero)) then
+       raise SemNotSupported;
+
+     let inc, body =
+       let inc, body =
+         match List.rev body.s_node with
+         | inc :: body -> inc, List.rev body
+         | _ -> raise SemNotSupported in
+
+       match inc.i_node with
+       | Sasgn (LvVar (PVloc y, _), ic) ->
+          if x <> y then
+            raise SemNotSupported
+          else begin
+            match ic.e_node with
+            | Eapp ({ e_node = Eop (op, []) }, [{ e_node = Evar (PVloc y') }; { e_node = Eint inc }])
+                 when    y = y'
+                      && EcBigInt.lt EcBigInt.zero inc
+                      && EcPath.p_equal op EcCoreLib.CI_Int.p_int_add
+              -> inc, body
+            | _ -> raise SemNotSupported
+          end;
+       | _ -> raise SemNotSupported in
+
+     let body =
+       if BI.gt inc BI.one then begin
+         let mx =
+           e_app
+             (e_op EcCoreLib.CI_Int.p_int_mul [] (toarrow [tint; tint] tint))
+             [e_int inc; e_var (pv_loc x) tint] tint in
+         let subst = EcPV.Mpv.add env.env (pv_loc x) mx EcPV.Mpv.empty in
+         EcPV.Mpv.issubst env.env subst body
+       end else body in
+
+     let bd =
+       match c.e_node with
+       | Eapp ({ e_node = Eop (op, []) }, [{ e_node = Evar (PVloc y) }; bd])
+            when    x = y
+                 && EcPath.p_equal op EcCoreLib.CI_Int.p_int_lt -> bd
+       | _ -> raise SemNotSupported in
+
+     let wr = EcPV.s_write env.env (EcModules.stmt body) in
+
+     if EcPV.PV.mem_pv env.env (pv_loc x) wr then
+       raise SemNotSupported;
+
+     if not (EcPV.PV.indep env.env (EcPV.e_read env.env bd) wr) then
+       raise SemNotSupported;
+
+     EcPV.PV.iter
+       (fun pv _ -> if not (is_loc pv) then raise SemNotSupported)
+       (fun _ -> raise SemNotSupported)
+       (EcPV.is_read env.env body);
+
+     let wr =
+       let do1 (pv, ty) =
+         match pv with
+         | PVglob _ -> raise SemNotSupported
+         | PVloc  z -> (z, ty) in
+
+       let wr, mods = EcPV.PV.elements (EcPV.is_write env.env body) in
+
+       if not (List.is_empty mods) then
+         raise SemNotSupported;
+       List.map do1 wr
+     in
+
+     let wr = List.filter (fun (z, _) -> z <> x) wr in
+
+     let mode, body, _ =
+       let env', ids =
+         List.fold_left_map
+           (fun env (x, _) -> Env.fresh env x)
+           env wr in
+
+       let ids = List.combine wr ids in
+
+       let env', x = Env.fresh env' x in
+
+       let cont_body (fenv : senv) : mode * expr =
+         let do1 ((x, ty), _) =
+           e_local (Msym.find x fenv.subst) ty in
+         let vars = List.map do1 ids in
+         (`Det, e_tuple vars) in
+
+       let bmode, body = translate_s env' cont_body (stmt body) in
+
+       let body =
+         match ids with
+         | [] ->
+            e_lam [(EcIdent.create "_", tunit)] body
+         | [((_, ty), z)] ->
+            e_lam [(z, ty)] body
+         | ids ->
+            let arg = EcIdent.create "arg" in
+            let aty = ttuple (List.map (fun ((_, ty), _) -> ty) ids) in
+            let lv  = LTuple (List.map (fun ((_, ty), z) -> (z, ty)) ids) in
+            e_lam
+              [(arg, aty)]
+              (e_let lv (e_local arg aty) body) in
+
+       let body = e_lam [(x, tint)] body in
+
+       bmode, body, ids in
+
+     let env', ids =
+       List.fold_left_map
+         (fun env (x, _) -> Env.fresh env x)
+         env wr in
+
+     let ids = List.combine wr ids in
+     let aty = ttuple (List.map (fun ((_, ty), _) -> ty) ids) in
+
+     let env', x = Env.fresh env' x in
+
+     let lv =
+       let ids =
+         let do1 ((x, ty), _) =
+           (Msym.find x env'.subst, ty) in
+         List.map do1 ids in
+
+       match ids with
+       | [] ->
+          LSymbol (EcIdent.create "_", tunit)
+       | [x, ty] ->
+          LSymbol (x, ty)
+       | ids ->
+          LTuple ids in
+
+     let niter = form_of_expr mhr (translate_e env bd) in
+     let niter = f_proj_simpl (f_int_edivz_simpl niter (f_int inc)) 0 tint in
+     let rem   = f_proj_simpl (f_int_edivz_simpl niter (f_int inc)) 1 tint in
+     let outv  = f_int_add_simpl (f_int_mul_simpl niter (f_int inc)) rem in
+
+     let niter = expr_of_form mhr niter in
+     let outv  = expr_of_form mhr outv in
+
+     let mode, aout =
+       match mode with
+       | `Det ->
+          let args =
+            List.map
+              (fun (z, zty) ->
+                match Msym.find_opt z env.subst with
+                | None -> e_op EcCoreLib.CI_Witness.p_witness [zty] zty
+                | Some z -> e_local z zty)
+              wr in
+          let args = e_tuple args in
+          let cmode, c = translate_s env' cont (stmt s_tail) in
+          let aout = e_op EcCoreLib.CI_Int.p_iteri [aty] in
+          let aout = aout (toarrow [tint; (toarrow [tint; aty] aty); aty] aty) in
+          let aout = e_app aout [niter; body; args] aty in
+          (cmode, e_let lv aout c)
+
+       | `Distr ->
+          let args =
+            List.map
+              (fun (z, zty) ->
+                match Msym.find_opt z env.subst with
+                | None -> e_op EcCoreLib.CI_Witness.p_witness [zty] zty
+                | Some z -> e_local z zty)
+              wr in
+          let args = e_tuple args in
+          let cmode, c = translate_s env' cont (stmt s_tail) in
+          let aout = e_op EcCoreLib.CI_Distr.p_dfold [aty] in
+          let aout = aout (toarrow [toarrow [tint; aty] (tdistr aty); aty; tint] (tdistr aty)) in
+          let aout = e_app aout [body; args; niter] (tdistr aty) in
+
+          let arg = EcIdent.create "arg" in
+
+          let ctor =
+            match cmode with
+            | `Det   -> f_dmap
+            | `Distr -> f_dlet_simpl in
+
+          let aout =
+            ctor
+              aty c.e_ty
+              (form_of_expr mhr aout)
+              (f_lambda
+                 [(arg, GTty aty)]
+                 (f_let lv (f_local arg aty) (form_of_expr mhr c))) in
+          (`Distr, expr_of_form mhr aout)
+
+     in Some (mode, e_let (LSymbol (x, tint)) outv aout)
+
+  | _ ->
+     None
+
+(* -------------------------------------------------------------------- *)
+and translate_e (env : senv) (e : expr) =
+  match e.e_node with
+  | Evar (PVloc x) ->
+     e_local (oget (Msym.find_opt x env.subst)) e.e_ty
+
+  | Evar (PVglob _) ->
+     raise SemNotSupported
+
+  | _ ->
+     e_map (fun x -> x) (translate_e env) e
+
+(* -------------------------------------------------------------------- *)
+and translate_lv (env : senv) (lv : lvalue) : lpattern =
+  match lv with
+  | LvVar (pv, ty) ->
+     LSymbol (translate_pv env pv, ty)
+
+  | LvTuple pvs ->
+     let do1 (pv, ty) =
+       (translate_pv env pv, ty)
+     in LTuple (List.map do1 pvs)
+
+(* -------------------------------------------------------------------- *)
+and translate_pv (env : senv) (pv : prog_var) =
+  match pv with
+  | PVglob _ ->
+     raise SemNotSupported
+  | PVloc x ->
+      oget (Msym.find_opt x env.subst)

--- a/src/ecProcSem.mli
+++ b/src/ecProcSem.mli
@@ -1,0 +1,24 @@
+(* -------------------------------------------------------------------- *)
+open EcIdent
+open EcSymbols
+open EcTypes
+open EcModules
+
+(* -------------------------------------------------------------------- *)
+type senv
+
+(* -------------------------------------------------------------------- *)
+module Env : sig
+  val empty : EcEnv.env -> senv
+  val fresh : senv -> symbol -> senv * ident
+end
+
+(* -------------------------------------------------------------------- *)
+exception SemNotSupported
+
+(* -------------------------------------------------------------------- *)
+type mode = [`Det | `Distr]
+
+(* -------------------------------------------------------------------- *)
+val translate_e : senv -> expr -> expr
+val translate_s : senv -> (senv -> mode * expr) -> stmt -> mode * expr

--- a/src/ecScope.mli
+++ b/src/ecScope.mli
@@ -89,6 +89,8 @@ end
 (* -------------------------------------------------------------------- *)
 module Op : sig
   val add : scope -> poperator located -> EcDecl.operator * string list * scope
+
+  val add_opsem : scope -> pprocop located -> scope
 end
 
 (* -------------------------------------------------------------------- *)

--- a/theories/datatypes/Int.ec
+++ b/theories/datatypes/Int.ec
@@ -247,6 +247,12 @@ theory IterOp.
   axiom iteriS ['a] n opr (x : 'a):
     0 <= n => iteri (n+1) opr x = opr n (iteri n opr x).
 
+  lemma iteriS_rw ['a] (n : int) (opr : int -> 'a -> 'a) (x : 'a) :
+    0 < n => iteri n opr x = opr (n - 1) (iteri (n - 1) opr x).
+  proof.
+  by move=> gt0_n; rewrite {1}[n](_ : n = n - 1 + 1) // iteriS //#.
+  qed.
+
   lemma eq_iteri (f1 f2 : int -> 'a -> 'a) k a:
        (forall i a, 0 <= i < k => f1 i a = f2 i a)
     => iteri k f1 a = iteri k f2 a.


### PR DESCRIPTION
computes the output distribution of a stateless proc.

The command is in beta-mode. It misses:

 - a support for a larger set of instructions,
 - better error messages,
 - a registry of generated proc ops, and
 - a hoare/phoare statement that links the operator to the procedure.