### PR TITLE
Remove dead code relating to substitution

### DIFF
--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -2113,19 +2113,6 @@ module Fsubst = struct
     f_subst (uni_subst uidmap)
 
   (* ------------------------------------------------------------------ *)
-  let subst_locals s =
-    Hf.memo_rec 107 (fun aux f ->
-      match f.f_node with
-      | Flocal id ->
-          (try Mid.find id s with Not_found -> f)
-      | _ ->
-        (* TODO: (Adrien) is thit ok? *)
-        f_map (fun ty -> ty) aux f)
-
-  let subst_local id f1 f2 =
-    subst_locals (Mid.singleton id f1) f2
-
-  (* ------------------------------------------------------------------ *)
   let init_subst_tvar ?es_loc s =
     let sty = { ty_subst_id with ts_v = Mid.find_opt^~ s } in
     { f_subst_id with

--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -510,8 +510,6 @@ module Fsubst : sig
   val add_binding  : f_subst -> binding  -> f_subst * binding
   val add_bindings : f_subst -> bindings -> f_subst * bindings
 
-  val subst_locals : form Mid.t -> form -> form
-
   val subst_lpattern : f_subst -> lpattern -> f_subst * lpattern
   val subst_xpath    : f_subst -> xpath -> xpath
   val subst_stmt     : f_subst -> stmt  -> stmt

--- a/src/ecFol.ml
+++ b/src/ecFol.ml
@@ -502,6 +502,55 @@ and f_real_inv_simpl f =
        | _ -> destr_error "destr_rint/inv"
      with DestrError _ -> f_app fop_real_inv [f] treal
 
+(* -------------------------------------------------------------------- *)
+let rec f_let_simpl lp f1 f2 =
+  match lp with
+  | LSymbol (id, _) -> begin
+      match Mid.find_opt id (f_fv f2) with
+      | None   -> f2
+      | Some i ->
+          if   i = 1 || can_subst f1
+          then
+            let s = Fsubst.f_bind_local Fsubst.f_subst_id id f1 in
+            Fsubst.f_subst s f2
+          else
+            f_let lp f1 f2
+    end
+
+  | LTuple ids -> begin
+      match f1.f_node with
+      | Ftuple fs ->
+          let (d, s) =
+            List.fold_left2 (fun (d, s) (id, ty) f1 ->
+              match Mid.find_opt id (f_fv f2) with
+              | None   -> (d, s)
+              | Some i ->
+                  if   i = 1 || can_subst f1
+                  then (d, Fsubst.f_bind_local s id f1)
+                  else (((id, ty), f1) :: d, s))
+              ([], Fsubst.f_subst_id) ids fs
+          in
+            List.fold_left
+              (fun f2 (id, f1) -> f_let (LSymbol id) f1 f2)
+              (Fsubst.f_subst s f2) d
+      | _ ->
+        let x = EcIdent.create "tpl" in
+        let ty = ttuple (List.map snd ids) in
+        let lpx = LSymbol(x,ty) in
+        let fx = f_local x ty in
+        let tu = f_tuple (List.mapi (fun i (_,ty') -> f_proj fx i ty') ids) in
+        f_let_simpl lpx f1 (f_let_simpl lp tu f2)
+    end
+
+  | LRecord (_, ids) ->
+      let check (id, _) =
+        id |> omap (fun id -> not (Mid.mem id (f_fv f2))) |> odfl true
+      in if List.for_all check ids then f2 else f_let lp f1 f2
+
+let f_lets_simpl =
+  (* FIXME : optimize this *)
+  List.fold_right (fun (lp,f1) f2 -> f_let_simpl lp f1 f2)
+
 let rec f_app_simpl f args ty =
   f_betared (f_app f args ty)
 

--- a/src/ecFol.mli
+++ b/src/ecFol.mli
@@ -89,8 +89,6 @@ val f_betared : form -> form
 
 val f_proj_simpl : form -> int -> EcTypes.ty -> form
 val f_if_simpl   : form -> form -> form -> form
-val f_let_simpl  : EcTypes.lpattern -> form -> form -> form
-val f_lets_simpl : (EcTypes.lpattern * form) list -> form -> form
 
 val f_forall_simpl : bindings -> form -> form
 val f_exists_simpl : bindings -> form -> form

--- a/src/ecFol.mli
+++ b/src/ecFol.mli
@@ -89,6 +89,8 @@ val f_betared : form -> form
 
 val f_proj_simpl : form -> int -> EcTypes.ty -> form
 val f_if_simpl   : form -> form -> form -> form
+val f_let_simpl  : EcTypes.lpattern -> form -> form -> form
+val f_lets_simpl : (EcTypes.lpattern * form) list -> form -> form
 
 val f_forall_simpl : bindings -> form -> form
 val f_exists_simpl : bindings -> form -> form


### PR DESCRIPTION
Instead, the f_subst mechanism should be used. (And this is in fact done for simplification of let formulas in EcReduction.)