### PR TITLE
Warn and fail early on Invalid results from SMT

### DIFF
--- a/src/ecProvers.ml
+++ b/src/ecProvers.ml
@@ -461,7 +461,7 @@ let execute_task ?(notify : notify option) (pi : prover_infos) task =
                         Format.fprintf fmt "success: %s%!" prover;
                       Buffer.contents buf)))
                     end;
-                    incr status
+                    if (0 <= !status) then incr status
 
 
                 | CP.Invalid ->

--- a/src/ecProvers.ml
+++ b/src/ecProvers.ml
@@ -464,7 +464,13 @@ let execute_task ?(notify : notify option) (pi : prover_infos) task =
                     incr status
 
 
-                | CP.Invalid -> status := (-1)
+                | CP.Invalid ->
+                    status := (-1);
+                    notify |> oiter (fun notify -> notify `Warning (lazy (
+                      let buf = Buffer.create 0 in
+                      let fmt = Format.formatter_of_buffer buf in
+                      Format.fprintf fmt "prover %s disproved this goal." prover;
+                    Buffer.contents buf)));
                 | (CP.Failure _ | CP.HighFailure) as answer->
                   notify |> oiter (fun notify -> notify `Warning (lazy (
                     let buf = Buffer.create 0 in


### PR DESCRIPTION
This partially addresses #366 by emitting a warning on receiving `Invalid` results from an SMT solver, and allowing early failure when this happens.

The latter behaviour seems to have been intended, but subject to a race (which could potentially cause infinite looping) if two SMT solvers finished in the same iteration of the waiting loop and the first to be processed returned `Invalid` while the second returned `Valid`.