### PR TITLE
Extend external CI to support non-github repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: easycrypt
-    - uses: actions/checkout@v3
-      with:
-        path: project/${{ matrix.target.name }}
-        repository: ${{ matrix.target.repository }}
+    - name: Checkout External Project
+      run: |
+        git clone -b ${{ matrix.target.branch }} \
+          ${{ matrix.target.repository }} \
+          project/${{ matrix.target.name }}
     - name: Update OPAM & EasyCrypt dependencies
       run: |
         opam update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,25 @@ jobs:
         path: report.log
         if-no-files-found: ignore
 
+  fetch-external-matrix:
+    name: Fetch EasyCrypt External Projects Matrix
+    needs: [pre_job, compile-opam]
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: 'easycrypt'
+    - id: set-matrix
+      run: |
+        JSON=$(jq -c . < easycrypt/.github/workflows/external.json)
+        echo "::set-output name=matrix::${JSON}"
+
   external:
     name: Check EasyCrypt External Projects
-    needs: [pre_job, compile-opam]
+    needs: [fetch-external-matrix]
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-20.04
     container:
@@ -105,15 +121,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ [ 'jasmin-eclib', 'jasmin-lang/jasmin', 'eclib', 'tests.config', 'jasmin' ] ]
+        target: ${{fromJson(needs.fetch-external-matrix.outputs.matrix)}}
     steps:
     - uses: actions/checkout@v3
       with:
-        path: 'easycrypt'
+        path: easycrypt
     - uses: actions/checkout@v3
       with:
-        path: 'project'
-        repository: ${{ matrix.target[1] }}
+        path: project/${{ matrix.target.name }}
+        repository: ${{ matrix.target.repository }}
     - name: Update OPAM & EasyCrypt dependencies
       run: |
         opam update
@@ -126,13 +142,17 @@ jobs:
         rm -f ~/.why3.conf ~/.config/easycrypt/why3.conf
         opam exec -- easycrypt why3config
     - name: Compile project
-      working-directory: project/${{ matrix.target[2] }}
-      run: opam exec -- easycrypt runtest ${{ matrix.target[3] }} ${{ matrix.target[4] }}
+      working-directory: project/${{ matrix.target.name }}/${{ matrix.target.subdir }}
+      run: |
+        opam exec -- easycrypt runtest  \
+          ${{ matrix.target.options  }} \
+          ${{ matrix.target.config   }} \
+          ${{ matrix.target.scenario }}
     - uses: actions/upload-artifact@v3
       name: Upload report.log
       if: always()
       with:
-        name: report.log (${{ matrix.target[0] }})
+        name: report.log (${{ matrix.target.name }})
         path: report.log
         if-no-files-found: ignore
 

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -1,6 +1,7 @@
 [
   { "name"       : "jasmin-eclib"
-  , "repository" : "jasmin-lang/jasmin"
+  , "repository" : "https://github.com/jasmin-lang/jasmin"
+  , "branch"     : "main"
   , "subdir"     : "eclib"
   , "config"     : "tests.config"
   , "scenario"   : "jasmin"

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -7,4 +7,15 @@
   , "scenario"   : "jasmin"
   , "options"    : ""
   }
+
+  ,
+
+  { "name"       : "sha3"
+  , "repository" : "https://gitlab.com/easycrypt/sha3"
+  , "branch"     : "next"
+  , "subdir"     : "."
+  , "config"     : "config/tests.config"
+  , "scenario"   : "sponge"
+  , "options"    : "-pragmas Proofs:weak"
+  }
 ]

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -1,0 +1,9 @@
+[
+  { "name"       : "jasmin-eclib"
+  , "repository" : "jasmin-lang/jasmin"
+  , "subdir"     : "eclib"
+  , "config"     : "tests.config"
+  , "scenario"   : "jasmin"
+  , "options"    : ""
+  }
+]


### PR DESCRIPTION
This adds support for external proof repos hosted off github to the existing (simple) external CI infrastructure, and uses SHA3 as a CI test.

The immediate ambition is to add all external proofs that should check with `main` (XSalsa, CryptoBox, XMSS, ...) to checks for PRs onto `main` (not for arbitrary commits; the restriction still needs added). This will then enable the developers of feature branches (`deploy-expected-cost`, `deploy-qrom`) to activate external CI for the external proofs they support.