### PR TITLE
Renaming the easycrypt lib (making it easyier for external imports)

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -6,8 +6,8 @@
 (include_subdirs unqualified)
 
 (library 
- (name core)
- (public_name easycrypt.core)
+ (name ecLib)
+ (public_name easycrypt.ecLib)
  (modules :standard \ ec)
  (libraries batteries camlp-streams dune-build-info inifiles why3 yojson zarith)
 )
@@ -17,7 +17,7 @@
  (name ec)
  (modules ec)
  (promote (until-clean))
- (libraries batteries camlp-streams dune-build-info inifiles why3 yojson zarith core))
+ (libraries batteries camlp-streams dune-build-info inifiles why3 yojson zarith ecLib))
 
 (ocamllex ecLexer)
 

--- a/src/ec.ml
+++ b/src/ec.ml
@@ -1,5 +1,5 @@
 (* -------------------------------------------------------------------- *)
-open Core
+open EcLib
 open EcUtils
 open EcOptions
 


### PR DESCRIPTION
The title pretty much says it all ! The previous name was just not very clever and prone to conflicts ! 