### PR TITLE
Additonal lemmas on fset (oflist) equality and a lemma on perm_eq/undup

### DIFF
--- a/theories/datatypes/FSet.ec
+++ b/theories/datatypes/FSet.ec
@@ -47,6 +47,18 @@ rewrite -(perm_eq_mem _ _ (oflistK s2)).
 by rewrite !mem_undup (perm_eq_mem _ _ peq_s1s2).
 qed.
 
+lemma oflist_perm_eq_undup (s1 s2 : 'a list):
+  perm_eq (undup s1) (undup s2) => oflist s1 = oflist s2.
+proof.
+move=> peq_s1s2; apply/fset_eq /uniq_perm_eq; 1,2: exact/uniq_elems.
+move=> x; rewrite -(perm_eq_mem _ _ (oflistK s1)).
+by rewrite -(perm_eq_mem _ _ (oflistK s2)) (perm_eq_mem _ _ peq_s1s2).
+qed.
+
+lemma perm_eq_oflistP (s1 s2 : 'a list):
+  oflist s1 = oflist s2 <=> perm_eq (undup s1) (undup s2).
+proof. by split; [apply perm_eq_oflist | apply oflist_perm_eq_undup]. qed.
+
 (* -------------------------------------------------------------------- *)
 op card ['a] (s : 'a fset) = size (elems s) axiomatized by cardE.
 

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -1545,6 +1545,13 @@ have := leq_size_perm s1 s2 uq_s1 s1_in_s2 _.
 - by rewrite eq_sz. - by case=> + _; apply.
 qed.
 
+lemma perm_eq_undup (s1 s2 : 'a list):
+  perm_eq s1 s2 => perm_eq (undup s1) (undup s2).
+proof.
+move=> peq_s1s2; rewrite uniq_perm_eq 1,2:undup_uniq => x.
+by rewrite 2!mem_undup &(perm_eq_mem).
+qed.
+
 lemma count_mem_uniq (s : 'a list):
   (forall x, count (pred1 x) s = b2i (mem s x)) => uniq s.
 proof.


### PR DESCRIPTION
These lemmas establish an equivalence between the unduped versions of two lists being permutations of each other and equality of the corresponding fsets. Combining these with the additional lemma on `perm_eq` and `undup` in `List.ec` seems to make the original `oflist_perm_eq` lemma redundant.