### PR TITLE
Propagate subtype changes to Word

### DIFF
--- a/examples/MEE-CBC/FunctionalSpec.ec
+++ b/examples/MEE-CBC/FunctionalSpec.ec
@@ -12,7 +12,10 @@ clone import BitWord as Octet with
   op n <- 8
 rename "word" as "octet"
 rename "Word" as "Octet"
-proof gt0_n by done.
+proof *.
+realize gt0_n by trivial.
+realize getE by rewrite /"_.[_]".
+realize setE by rewrite /"_.[_<-_]".
 
 op o2int (o : octet) : int = bs2int (ofoctet o).
 op int2o (i : int) : octet = mkoctet (int2bs 8 i).
@@ -35,8 +38,11 @@ clone import Word as Block with
   op   n             <- 16
 rename "word" as "block"
 rename "Word" as "Block"
-proof Alphabet.enum_spec, ge0_n by done.
+proof *.
 realize Alphabet.enum_spec by exact/Octet.enum_spec.
+realize ge0_n by trivial.
+realize getE by rewrite /"_.[_]".
+realize setE by rewrite /"_.[_<-_]".
 
 abbrev dblock = DBlock.dunifin.
 
@@ -127,8 +133,11 @@ clone import Word as Tag with
   op   n             <- 32
 rename "word" as "tag"
 rename "Word" as "Tag"
-proof Alphabet.enum_spec, ge0_n by done.
+proof *.
 realize Alphabet.enum_spec by exact/Octet.enum_spec.
+realize ge0_n by trivial.
+realize getE by rewrite /"_.[_]".
+realize setE by rewrite /"_.[_<-_]".
 
 (** Messages are just octet lists **)
 type msg = octet list.
@@ -490,6 +499,7 @@ proof.
                       (size (pad _p (hmac_sha256 _mk _p)))
                       (nth witness (iv :: mee_enc AES hmac_sha256 _ek _mk iv _p)
                                    (size (pad _p (hmac_sha256 _mk _p)))).
+        smt().
       split=> //=.
       split; 1:by rewrite /mee_enc /= size_cbc_enc addzC.
       by rewrite take_size.

--- a/theories/datatypes/Word.eca
+++ b/theories/datatypes/Word.eca
@@ -1,35 +1,44 @@
 (* -------------------------------------------------------------------- *)
 require import AllCore List Distr StdOrder.
 require import FinType.
-require (*--*) Tuple.
+require (*--*) Subtype Tuple.
 (*---*) import IntOrder RealOrder.
 
 (* -------------------------------------------------------------------- *)
 clone import FinType as Alphabet.
 
 op n : {int | 0 <= n} as ge0_n.
-
-type word.
-
-op mkword : t list -> word.
-op ofword : word -> t list.
-op dchar  : t.
-
+op dchar : t.
 op wordw : t list = mkseq (fun _ => dchar) n.
 
-(* -------------------------------------------------------------------- *)
 lemma nosmt size_wordw: size wordw = n.
 proof. by rewrite size_mkseq ler_maxr ?ge0_n. qed.
 
-axiom nosmt mkwordK : cancel ofword mkword.
+clone include Subtype
+  with type T   <- t list,
+       op P   <- fun w => size w = n
+proof *.
+realize inhabited by exists wordw; exact size_wordw.
 
-axiom nosmt ofwordK :
+type word = sT.
+(* default value chosen for backward compatibility *)
+op mkword x = odflt (insubd wordw) (insub x).
+op ofword = val.
+
+(* -------------------------------------------------------------------- *)
+
+lemma nosmt mkwordK : cancel ofword mkword.
+proof. smt(valK). qed.
+
+lemma nosmt ofwordK :
   forall (s : t list), size s = n =>
     ofword (mkword s) = s.
+proof. smt(insubT). qed.
 
-axiom nosmt mkword_out :
+lemma nosmt mkword_out :
   forall (s : t list), size s <> n =>
     ofword (mkword s) = wordw.
+proof. smt(insubN insubdK size_wordw). qed.
 
 lemma nosmt size_word : forall w, size (ofword w) = n.
 proof.


### PR DESCRIPTION
Previous `Word` implementation generates unprovable subtype-like axioms on `clone` and `proof*`. Directly including `Subtype` removes these proof obligations.