### PR TITLE
[nix] Rework the nix configuration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,30 @@
 
 with import <nixpkgs> {};
 
-let why3_local =
+let alt-ergo-pin =
+  alt-ergo.overrideAttrs (o : rec {
+    version = "2.4.2";
+    src = fetchFromGitHub {
+      owner = "OCamlPro";
+      repo = "alt-ergo";
+      rev = version;
+      hash = "sha256-8pJ/1UAbheQaLFs5Uubmmf5D0oFJiPxF6e2WTZgRyAc=";
+    };
+  });
+in
+
+let cvc4-pin = cvc4; in
+
+let z3-pin = z3_4_12; in
+
+let provers =
+  if withProvers then [
+    alt-ergo-pin
+    cvc4-pin
+    z3-pin
+  ] else []; in
+
+let why3-pin =
   why3.overrideAttrs (o : rec {
     version = "1.6.0";
     src = fetchurl {
@@ -11,13 +34,6 @@ let why3_local =
     };
   });
 in
-let why3 = why3_local; in
-
-let provers =
-  if withProvers then [
-    alt-ergo
-    z3
-  ] else []; in
 
 stdenv.mkDerivation {
   pname = "easycrypt";
@@ -36,11 +52,10 @@ stdenv.mkDerivation {
     menhir
     menhirLib
     yojson
-    why3
     zarith
   ]);
 
-  propagatedBuildInputs = [ why3 ]
+  propagatedBuildInputs = [ why3-pin ]
     ++ devDeps
     ++ provers;
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,40 +2,13 @@
 
 with import <nixpkgs> {};
 
-let why3_local =
-  why3.overrideAttrs (o : rec {
-    version = "1.6.0";
-    src = fetchurl {
-      url = "https://why3.gitlabpages.inria.fr/releases/${o.pname}-${version}.tar.gz";
-      sha256 = "sha256-hFvM6kHScaCtcHCc6Vezl9CR7BFbiKPoTEh7kj0ZJxw=";
-    };
-  });
+let ec = callPackage ./default.nix { inherit withProvers devDeps; };
 in
-let why3 = why3_local; in
-
-let provers =
-  if withProvers then [
-    alt-ergo
-    z3
-  ] else []; in
 
 pkgs.mkShell {
-  buildInputs = devDeps ++ [ git ] ++ (with ocamlPackages; [
-    ocaml
-    findlib
-    batteries
-    camlp-streams
-    dune_3
-    dune-build-info
-    dune-site
-    inifiles
-    menhir
-    menhirLib
-    merlin
-    yojson
-    why3
-    zarith
-  ]) ++ (with python3Packages; [
+  buildInputs = ec.buildInputs
+  ++ ec.propagatedBuildInputs
+  ++ (with python3Packages; [
     pyyaml
   ]);
 }

--- a/theories/distributions/DBool.ec
+++ b/theories/distributions/DBool.ec
@@ -82,7 +82,7 @@ lemma dmap_pred (d: 'a distr) (p: 'a -> bool) :
 proof.
 move => d_ll; apply eq_distr => x.
 rewrite dbiased1E clamp_id; first by smt(ge0_mu le1_mu).
-rewrite dmap1E /(\o) /pred1; smt(mu_not).
+by rewrite dmap1E /(\o) /pred1 -d_ll -mu_not /#.
 qed.
 
 lemma dbiased1 : dbiased 1%r = dunit true.


### PR DESCRIPTION
This reworks the nix configuration to:
1. avoid duplication of derivation information; and
2. pin provers to better support replication; (this is only partial: nixpkgs allows easy pinning of `z3` down to minor only, and `cvc4` is pinned only by virtue of no longer being maintained).

The pinning upgrades all provers to their maximum version supported by `why3` 1.6.0, stopping short of upgrading `cvc4` to `cvc5` due to clear instability in `cvc5` and its interactions with `why3` (50/50 chance of High failure). A minor refinement is needed in the case of one SMT call which fails with `z3` 4.12.2 and all other solvers, but succeeds with `z3` <= 4.12.1.

The pinning of `alt-ergo` to 2.4.2 works, but leaves paths and derivation names unchanged, so `alt-ergo-2.4.2` appears in paths as `alt-ergo-2.4.3`. Avoiding this might require vendoring a derivation for `alt-ergo`. (@vbgl , do you have a suggestion for this? `alt-ergo` is internally split into 3 separate derivations and that level of override-based surgery is beyond the effort I'm willing to put into pinning an SMT solver.)

If we decide the pins need more work, it should be fine to only keep the first commit, and at least make it easier and safer to later improve our derivations.