### PR TITLE
Operators body can now be formulas

### DIFF
--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -948,6 +948,14 @@ let f_xmuli_simpl f1 f2 =
   f_xmul_simpl (f_N f1) f2
 
 (* -------------------------------------------------------------------- *)
+let f_none (ty : ty) : form =
+  f_op EcCoreLib.CI_Option.p_none [ty] (toption ty)
+
+let f_some ({ f_ty = ty } as f : form) : form =
+  let op = f_op EcCoreLib.CI_Option.p_some [ty] (tfun ty (toption ty)) in
+  f_app op [f] (toption ty)
+
+(* -------------------------------------------------------------------- *)
 let cost_map g cost =
   let calls =
     EcPath.Mx.map (fun cb ->

--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -338,6 +338,10 @@ val f_int_pow   : form -> form -> form
 val f_int_edivz : form -> form -> form
 
 (* -------------------------------------------------------------------- *)
+val f_none : ty -> form
+val f_some : form -> form
+
+(* -------------------------------------------------------------------- *)
 val f_is_inf : form -> form
 val f_is_int : form -> form
 
@@ -466,7 +470,7 @@ type f_subst = private {
   fs_freshen  : bool; (* true means realloc local *)
   fs_loc      : form Mid.t;
   fs_esloc    : expr Mid.t;
-  fs_ty      : ty_subst;
+  fs_ty       : ty_subst;
   fs_mem      : EcIdent.t Mid.t;
   fs_memtype  : EcMemory.memtype option; (* Only substituted in Fcoe *)
   fs_mempred  : mem_pr Mid.t;  (* For predicates over memories,

--- a/src/ecDecl.ml
+++ b/src/ecDecl.ml
@@ -74,7 +74,7 @@ type operator_kind =
   | OB_nott of notation
 
 and opbody =
-  | OP_Plain  of EcTypes.expr * bool  (* nosmt? *)
+  | OP_Plain  of EcCoreFol.form * bool  (* nosmt? *)
   | OP_Constr of EcPath.path * int
   | OP_Record of EcPath.path
   | OP_Proj   of EcPath.path * int * int
@@ -294,8 +294,7 @@ let operator_as_prind (op : operator) =
   | _ -> assert false
 
 (* -------------------------------------------------------------------- *)
-let axiomatized_op ?(nargs = 0) ?(nosmt = false) path (tparams, bd) lc =
-  let axbd = EcCoreFol.form_of_expr EcCoreFol.mhr bd in
+let axiomatized_op ?(nargs = 0) ?(nosmt = false) path (tparams, axbd) lc =
   let axbd, axpm =
     let bdpm = List.map fst tparams in
     let axpm = List.map EcIdent.fresh bdpm in

--- a/src/ecDecl.mli
+++ b/src/ecDecl.mli
@@ -49,7 +49,7 @@ type operator_kind =
   | OB_nott of notation
 
 and opbody =
-  | OP_Plain  of EcTypes.expr * bool (* nosmt? *)
+  | OP_Plain  of EcCoreFol.form * bool (* nosmt? *)
   | OP_Constr of EcPath.path * int
   | OP_Record of EcPath.path
   | OP_Proj   of EcPath.path * int * int
@@ -169,7 +169,7 @@ val axiomatized_op :
      ?nargs: int
   -> ?nosmt:bool
   -> EcPath.path
-  -> (ty_params * expr)
+  -> (ty_params * form)
   -> locality
   -> axiom
 

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -2887,8 +2887,7 @@ module Op = struct
     let op = oget (by_path_opt p env) in
     let f  =
       match op.op_kind with
-      | OB_oper (Some (OP_Plain (e, _))) when force || not op.op_opaque ->
-          form_of_expr EcCoreFol.mhr e
+      | OB_oper (Some (OP_Plain (f, _)))
       | OB_pred (Some (PR_Plain f)) when force || not op.op_opaque ->
           f
       | _ -> raise NotReducible

--- a/src/ecFol.ml
+++ b/src/ecFol.ml
@@ -54,7 +54,6 @@ let destr_rint f =
 
   | _ -> destr_error "destr_rint"
 
-
 (* -------------------------------------------------------------------- *)
 let fop_int_le     = f_op CI.CI_Int .p_int_le    [] (toarrow [tint ; tint ] tbool)
 let fop_int_lt     = f_op CI.CI_Int .p_int_lt    [] (toarrow [tint ; tint ] tbool)

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -615,8 +615,8 @@ let process_delta ~und_delta ?target (s, o, p) tc =
         let op = EcEnv.Op.by_path (fst p) env in
 
         match op.EcDecl.op_kind with
-        | EcDecl.OB_oper (Some (EcDecl.OP_Plain (e, _))) ->
-            (snd p, op.EcDecl.op_tparams, form_of_expr EcFol.mhr e, args, Some (fst p))
+        | EcDecl.OB_oper (Some (EcDecl.OP_Plain (f, _))) ->
+            (snd p, op.EcDecl.op_tparams, f, args, Some (fst p))
         | EcDecl.OB_pred (Some (EcDecl.PR_Plain f)) ->
             (snd p, op.EcDecl.op_tparams, f, args, Some (fst p))
         | _ ->

--- a/src/ecInductive.ml
+++ b/src/ecInductive.ml
@@ -3,6 +3,7 @@ open EcUtils
 open EcSymbols
 open EcTypes
 open EcDecl
+open EcCoreFol
 
 module EP = EcPath
 module FL = EcCoreFol
@@ -163,7 +164,7 @@ let datatype_projectors (tpath, tparams, { tydt_ctors = ctors }) =
 
   let do1 i (cname, cty) =
     let thv = EcIdent.create "the" in
-    let the = e_local thv thety in
+    let the = f_local thv thety in
     let rty = ttuple cty in
 
     let do1 j (_, cty2) =
@@ -172,17 +173,17 @@ let datatype_projectors (tpath, tparams, { tydt_ctors = ctors }) =
           (fun ty -> (EcIdent.create (symbol_of_ty ty), ty))
           cty2 in
 
-      e_lam lvars
+      f_lambda
+        (List.map (fun (x, ty) -> (x, GTty ty)) lvars)
         (if   i = j
-         then e_some (e_tuple (List.map (curry e_local) lvars))
-         else e_none rty) in
+         then f_some (f_tuple (List.map (curry f_local) lvars))
+         else f_none rty) in
 
-
-    let body = e_match the (List.mapi do1 ctors) (toption rty) in
-    let body = e_lam [thv, thety] body in
+    let body = f_match the (List.mapi do1 ctors) (toption rty) in
+    let body = f_lambda [thv, GTty thety] body in
 
     let op = Some (OP_Plain (body, false)) in
-    let op = mk_op ~opaque:false tparams body.e_ty op `Global in (* FIXME *)
+    let op = mk_op ~opaque:false tparams body.f_ty op `Global in (* FIXME *)
 
     (cname, op) in
 

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -24,7 +24,7 @@
   let opdef_of_opbody ty b =
     match b with
     | None            -> PO_abstr ty
-    | Some (`Expr e ) -> PO_concr (ty, e)
+    | Some (`Form f ) -> PO_concr (ty, f)
     | Some (`Case bs) -> PO_case  (ty, bs)
     | Some (`Reft rt) -> PO_reft  (ty, rt)
 
@@ -1972,7 +1972,7 @@ operator:
       po_locality = locality; } }
 
 opbody:
-| e=expr   { `Expr e  }
+| f=form   { `Form f  }
 | bs=opbr+ { `Case bs }
 
 opax:
@@ -3785,14 +3785,14 @@ clone_override:
 
 | OP st=nosmt x=qoident tyvars=bracket(tident*)?
     p=ptybinding1* sty=ioption(prefix(COLON, loc(type_exp)))
-    mode=loc(opclmode) e=expr
+    mode=loc(opclmode) f=form
 
    { let ov = {
        opov_nosmt  = st;
        opov_tyvars = tyvars;
        opov_args   = List.flatten p;
        opov_retty  = odfl (mk_loc mode.pl_loc PTunivar) sty;
-       opov_body   = e;
+       opov_body   = f;
      } in
 
      (x, PTHO_Op (`BySyntax ov, unloc mode)) }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -380,7 +380,7 @@ type ptyvardecls =
 
 type pop_def =
   | PO_abstr of pty
-  | PO_concr of pty * pexpr
+  | PO_concr of pty * pformula
   | PO_case  of pty * pop_branch list
   | PO_reft  of pty * (psymbol * pformula)
 
@@ -1197,7 +1197,7 @@ and op_override_def = {
   opov_tyvars : psymbol list option;
   opov_args   : ptybinding list;
   opov_retty  : pty;
-  opov_body   : pexpr;
+  opov_body   : pformula;
 }
 
 and pr_override_def = {

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -2262,21 +2262,22 @@ let pp_opdecl_op (ppe : PPEnv.t) fmt (basename, ts, ty, op) =
     | None ->
         Format.fprintf fmt ": %a" (pp_type ppe) ty
 
-    | Some (OP_Plain (e, _)) ->
+    | Some (OP_Plain (f, _)) ->
         let ((subppe, pp_vds), e, has_vds) =
           let (vds, e) =
-            match e.e_node with
-            | Equant (`ELambda, vds, e) -> (vds, e)
-            | _ -> ([], e) in
-          (pp_locbinds ppe ~fv:e.e_fv vds, e,
+            match f.f_node with
+            | Fquant (Llambda, vds, f) ->
+               (List.map (snd_map gty_as_ty) vds, f)
+            | _ -> ([], f) in
+          (pp_locbinds ppe ~fv:f.f_fv vds, e,
            match vds with [] -> false | _ -> true)
         in
           if has_vds then
             Format.fprintf fmt "%t :@ %a =@ %a" pp_vds
-              (pp_type ppe) e.e_ty (pp_expr subppe) e
+              (pp_type ppe) f.f_ty (pp_form subppe) f
           else
             Format.fprintf fmt ":@ %a =@ %a"
-              (pp_type ppe) e.e_ty (pp_expr subppe) e
+              (pp_type ppe) e.f_ty (pp_form subppe) f
     | Some (OP_Constr (indp, i)) ->
         Format.fprintf fmt
           ": %a =@ < %d-th constructor of %a >"

--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -2037,15 +2037,12 @@ let check_bindings exn tparams env s bd1 bd2 =
 
 let rec conv_oper env ob1 ob2 =
   match ob1, ob2 with
-  | OP_Plain(e1,_), OP_Plain(e2,_)  ->
-    Format.eprintf "[W]: ICI1@.";
-    conv_expr env EcSubst.empty e1 e2
-  | OP_Plain({e_node = Eop(p,tys)},_), _ ->
-    Format.eprintf "[W]: ICI2@.";
+  | OP_Plain(f1,_), OP_Plain(f2,_)  ->
+    error_body (is_conv (LDecl.init env []) f1 f2)
+  | OP_Plain({f_node = Fop(p,tys)},_), _ ->
     let ob1 = get_open_oper env p tys  in
     conv_oper env ob1 ob2
-  | _, OP_Plain({e_node = Eop(p,tys)}, _) ->
-    Format.eprintf "[W]: ICI3@.";
+  | _, OP_Plain({f_node = Fop(p,tys)}, _) ->
     let ob2 = get_open_oper env p tys in
     conv_oper env ob1 ob2
   | OP_Constr(p1,i1), OP_Constr(p2,i2) ->

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -434,7 +434,7 @@ let on_opdecl (cb : cb) (opdecl : operator) =
      match b with
      | OP_Constr _ | OP_Record _ | OP_Proj   _ -> assert false
      | OP_TC -> assert false
-     | OP_Plain  (e, _) -> on_expr cb e
+     | OP_Plain  (f, _) -> on_form cb f
      | OP_Fix    f ->
        let rec on_mpath_branches br =
          match br with
@@ -715,7 +715,7 @@ let tydecl_fv tyd =
 let op_body_fv body ty =
   let fv = ty_fv_and_tvar ty in
   match body with
-  | OP_Plain (e, _) -> EcIdent.fv_union fv (fv_and_tvar_e e)
+  | OP_Plain (f, _) -> EcIdent.fv_union fv (fv_and_tvar_f f)
   | OP_Constr _ | OP_Record _ | OP_Proj _ | OP_TC -> fv
   | OP_Fix opfix ->
     let fv =
@@ -902,8 +902,8 @@ let generalize_opdecl to_gen prefix (name, operator) =
           match body with
           | OP_Constr _ | OP_Record _ | OP_Proj _ -> assert false
           | OP_TC -> assert false (* ??? *)
-          | OP_Plain (e,nosmt) ->
-            OP_Plain (e_lam extra_a e, nosmt)
+          | OP_Plain (f,nosmt) ->
+            OP_Plain (f_lambda (List.map (fun (x, ty) -> (x, GTty ty)) extra_a) f, nosmt)
           | OP_Fix opfix ->
             let subst = EcSubst.add_opdef EcSubst.empty path tosubst in
             let nb_extra = List.length extra_a in

--- a/src/ecSmt.ml
+++ b/src/ecSmt.ml
@@ -1091,7 +1091,6 @@ and create_op ?(body = false) (genv : tenv) p =
     let decl =
       match body, op.op_kind with
       | true, OB_oper (Some (OP_Plain (body, false))) ->
-          let body = EcFol.form_of_expr EcFol.mhr body in
           let wparams, wbody = trans_body (genv, lenv) wdom wcodom body in
           WDecl.create_logic_decl [WDecl.make_ls_defn ls (wextra@wparams) wbody]
 
@@ -1449,8 +1448,8 @@ module Frequency = struct
     match EcEnv.Op.by_path_opt p env with
     | Some {op_kind = OB_pred (Some (PR_Plain f)) } ->
       r_union rs (f_ops unwanted_op f)
-    | Some {op_kind = OB_oper (Some (OP_Plain (e, false))) } ->
-      r_union rs (f_ops unwanted_op (form_of_expr mhr e))
+    | Some {op_kind = OB_oper (Some (OP_Plain (f, false))) } ->
+      r_union rs (f_ops unwanted_op f)
     | Some {op_kind = OB_oper (Some (OP_Fix ({ opf_nosmt = false } as e))) } ->
       let rec aux rs = function
         | OPB_Leaf (_, e) -> r_union rs (f_ops unwanted_op (form_of_expr mhr e))

--- a/src/ecThCloning.ml
+++ b/src/ecThCloning.ml
@@ -38,6 +38,7 @@ type clone_error =
 | CE_ModTyIncompatible of qsymbol
 | CE_ModIncompatible   of qsymbol
 | CE_InvalidRE         of string
+| CE_InlinedOpIsForm   of qsymbol
 
 exception CloneError of EcEnv.env * clone_error
 

--- a/src/ecThCloning.mli
+++ b/src/ecThCloning.mli
@@ -32,6 +32,7 @@ type clone_error =
 | CE_ModTyIncompatible of qsymbol
 | CE_ModIncompatible   of qsymbol
 | CE_InvalidRE         of string
+| CE_InlinedOpIsForm   of qsymbol
 
 exception CloneError of EcEnv.env * clone_error
 

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -752,15 +752,22 @@ end = struct
     | CE_TyIncompatible (x, err) ->
         msg "type `%s` %a"
           (string_of_qsymbol x) (pp_incompatible env) err
+
     | CE_ModTyIncompatible x ->
         msg "module type `%s` is incompatible"
           (string_of_qsymbol x)
+
     | CE_ModIncompatible x ->
         msg "module `%s` is incompatible"
           (string_of_qsymbol x)
 
     | CE_InvalidRE x ->
         msg "invalid regexp: `%s'" x
+
+    | CE_InlinedOpIsForm x ->
+        msg
+          "inlined operator's body must be an expression-like formula: `%s'"
+          (string_of_qsymbol x)
 end
 
 (* -------------------------------------------------------------------- *)

--- a/theories/algebra/Ideal.ec
+++ b/theories/algebra/Ideal.ec
@@ -238,7 +238,7 @@ qed.
 
 (* -------------------------------------------------------------------- *)
 op principal (I : t -> bool) =
-  exists a : t, forall x, (I x <=> exists b, x = b * a).
+  exists (a : t), forall x, (I x <=> exists b, x = b * a).
 
 lemma principal_ideal I : principal I => ideal I.
 proof.


### PR DESCRIPTION
When cloning a theory, inlined operator definitions must be expressions s.t. their substitution can be done in procedures bodies.