### PR TITLE
Operator unfolding when applied to enough arguments

### DIFF
--- a/src/ecCallbyValue.ml
+++ b/src/ecCallbyValue.ml
@@ -328,10 +328,12 @@ and reduce_user_delta st f1 p tys args =
   | f -> f
   | exception NotReducible ->
     let mode = st.st_ri.delta_p p in
-    if mode <> `No && Op.reducible ~force:(mode = `Force) st.st_env p then
-      let f = Op.reduce ~force:(mode = `Force) st.st_env p tys in
+    let nargs = List.length args.stack in
+    match mode with
+    | #Op.redmode as mode when Op.reducible ~mode ~nargs st.st_env p ->
+      let f = Op.reduce ~mode ~nargs st.st_env p tys in
       cbv st Subst.subst_id f args
-    else f2
+    | _ -> f2
 
 (* -------------------------------------------------------------------- *)
 and reduce_logic st f =

--- a/src/ecDecl.ml
+++ b/src/ecDecl.ml
@@ -127,6 +127,7 @@ type operator = {
   op_loca     : locality;
   op_opaque   : bool;
   op_clinline : bool;
+  op_unfold   : int option;
 }
 
 (* -------------------------------------------------------------------- *)
@@ -239,23 +240,24 @@ let is_prind op =
   | OB_pred (Some (PR_Ind _)) -> true
   | _ -> false
 
-let gen_op ?(clinline = false) ~opaque tparams ty kind lc = {
+let gen_op ?(clinline = false) ?unfold ~opaque tparams ty kind lc = {
   op_tparams  = tparams;
   op_ty       = ty;
   op_kind     = kind;
   op_loca     = lc;
   op_opaque   = opaque;
   op_clinline = clinline;
+  op_unfold   = unfold;
 }
 
-let mk_pred ?clinline ~opaque tparams dom body lc =
+let mk_pred ?clinline ?unfold ~opaque tparams dom body lc =
   let kind = OB_pred body in
   let ty   =  (EcTypes.toarrow dom EcTypes.tbool) in
-  gen_op ?clinline ~opaque tparams ty kind lc
+  gen_op ?clinline ?unfold ~opaque tparams ty kind lc
 
-let mk_op ?clinline ~opaque tparams ty body lc =
+let mk_op ?clinline ?unfold ~opaque tparams ty body lc =
   let kind = OB_oper body in
-  gen_op ?clinline ~opaque tparams ty kind lc
+  gen_op ?clinline ?unfold ~opaque tparams ty kind lc
 
 let mk_abbrev ?(ponly = false) tparams xs (codom, body) lc =
   let kind = {

--- a/src/ecDecl.mli
+++ b/src/ecDecl.mli
@@ -102,6 +102,7 @@ type operator = {
   op_loca     : locality;
   op_opaque   : bool;
   op_clinline : bool;
+  op_unfold   : int option;
 }
 
 val op_ty     : operator -> ty
@@ -114,8 +115,8 @@ val is_fix    : operator -> bool
 val is_abbrev : operator -> bool
 val is_prind  : operator -> bool
 
-val mk_op   : ?clinline:bool -> opaque:bool -> ty_params -> ty -> opbody option -> locality -> operator
-val mk_pred : ?clinline:bool -> opaque:bool -> ty_params -> ty list -> prbody option -> locality -> operator
+val mk_op   : ?clinline:bool -> ?unfold:int -> opaque:bool -> ty_params -> ty -> opbody option -> locality -> operator
+val mk_pred : ?clinline:bool -> ?unfold:int -> opaque:bool -> ty_params -> ty list -> prbody option -> locality -> operator
 
 val mk_abbrev :
      ?ponly:bool -> ty_params -> (EcIdent.ident * ty) list

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -314,6 +314,8 @@ end
 module Op : sig
   type t = operator
 
+  type redmode = [`Force | `IfTransparent | `IfApplied]
+
   val by_path     : path -> env -> t
   val by_path_opt : path -> env -> t option
   val lookup      : qsymbol -> env -> path * t
@@ -323,8 +325,8 @@ module Op : sig
   val add  : path -> env -> env
   val bind : ?import:import -> symbol -> operator -> env -> env
 
-  val reducible : ?force:bool -> env -> path -> bool
-  val reduce    : ?force:bool -> env -> path -> ty list -> form
+  val reducible : ?mode:redmode -> ?nargs:int -> env -> path -> bool
+  val reduce    : ?mode:redmode -> ?nargs:int -> env -> path -> ty list -> form
 
   val is_projection  : env -> path -> bool
   val is_record_ctor : env -> path -> bool

--- a/src/ecLowGoal.mli
+++ b/src/ecLowGoal.mli
@@ -43,8 +43,10 @@ val t_trivial          :
   ?subtc:FApi.backward -> ?keep:bool -> ?conv:[`Alpha | `Conv] -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
+type opmode = EcReduction.deltap
+
 type simplify_t =
-  ?target:ident -> ?delta:bool -> ?logic:rlogic_info -> FApi.backward
+  ?target:ident -> ?delta:opmode -> ?logic:rlogic_info -> FApi.backward
 
 type simplify_with_info_t =
   ?target:ident -> reduction_info -> FApi.backward

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1085,6 +1085,13 @@ ptybindings_decl:
 | x=ptybinding1+
     { List.flatten x }
 
+ptybindings_opdecl:
+| x=ptybinding1+
+    { (List.flatten x, None) }
+
+| x=ptybinding1* SLASH y=ptybinding1*
+    { (List.flatten x, Some (List.flatten y)) }
+
 (* -------------------------------------------------------------------- *)
 sc_var_ty:
 | x=ident+ COLON ty=loc(type_exp)
@@ -1938,7 +1945,7 @@ op_or_const:
 
 operator:
 | locality=locality k=op_or_const st=nosmt tags=bracket(ident*)?
-    x=plist1(oident, COMMA) tyvars=tyvars_decl? args=ptybindings_decl?
+    x=plist1(oident, COMMA) tyvars=tyvars_decl? args=ptybindings_opdecl?
     sty=prefix(COLON, loc(type_exp))? b=seq(prefix(EQ, loc(opbody)), opax?)?
 
   { let gloc = EcLocation.make $startpos $endpos in
@@ -1950,14 +1957,14 @@ operator:
       po_aliases  = List.tl x;
       po_tags     = odfl [] tags;
       po_tyvars   = tyvars;
-      po_args     = odfl [] args;
+      po_args     = odfl ([], None) args;
       po_def      = opdef_of_opbody sty (omap (unloc |- fst) b);
       po_ax       = obind snd b;
       po_nosmt    = st;
       po_locality = locality; } }
 
 | locality=locality k=op_or_const st=nosmt tags=bracket(ident*)?
-    x=plist1(oident, COMMA) tyvars=tyvars_decl? args=ptybindings_decl?
+    x=plist1(oident, COMMA) tyvars=tyvars_decl? args=ptybindings_opdecl?
     COLON LBRACE sty=loc(type_exp) PIPE reft=form RBRACE AS rname=ident
 
   { { po_kind     = k;
@@ -1965,7 +1972,7 @@ operator:
       po_aliases  = List.tl x;
       po_tags     = odfl [] tags;
       po_tyvars   = tyvars;
-      po_args     = odfl [] args;
+      po_args     = odfl ([], None) args;
       po_def      = opdef_of_opbody sty (Some (`Reft (rname, reft)));
       po_ax       = None;
       po_nosmt    = st;

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -400,7 +400,7 @@ type poperator = {
   po_aliases: psymbol list;
   po_tags   : psymbol list;
   po_tyvars : ptyvardecls option;
-  po_args   : ptybindings;
+  po_args   : ptybindings * ptybindings option;
   po_def    : pop_def;
   po_ax     : osymbol_r;
   po_nosmt  : bool;

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -75,7 +75,7 @@ type reduction_info = {
   cost    : bool;              (* reduce trivial cost statements *)
 }
 
-and deltap      = [`Yes | `No | `Force]
+and deltap      = [EcEnv.Op.redmode | `No]
 and rlogic_info = [`Full | `ProductCompat] option
 
 val full_red     : reduction_info

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -949,7 +949,8 @@ let generalize_opdecl to_gen prefix (name, operator) =
             op_kind     = OB_pred (Some body);
             op_loca     = `Global;
             op_opaque   = false;
-            op_clinline = operator.op_clinline; } in
+            op_clinline = operator.op_clinline;
+            op_unfold   = operator.op_unfold; } in
         tg_subst, operator
 
       | OB_nott nott ->
@@ -964,7 +965,8 @@ let generalize_opdecl to_gen prefix (name, operator) =
             op_kind     = OB_nott nott;
             op_loca     = `Global;
             op_opaque   = false;
-            op_clinline = operator.op_clinline; }
+            op_clinline = operator.op_clinline;
+            op_unfold   = operator.op_unfold; }
     in
     let to_gen = {to_gen with tg_subst} in
     to_gen, Some (Th_operator (name, operator))

--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -1021,7 +1021,8 @@ let subst_op (s : subst) (op : operator) =
     op_kind     = kind          ;
     op_loca     = op.op_loca    ;
     op_opaque   = op.op_opaque  ;
-    op_clinline = op.op_clinline; }
+    op_clinline = op.op_clinline;
+    op_unfold   = op.op_unfold  ; }
 
 (* -------------------------------------------------------------------- *)
 let subst_ax (s : subst) (ax : axiom) =

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -586,7 +586,8 @@ and replay_prd (ove : _ ovrenv) (subst, ops, proofs, scope) (import, x, oopr) =
                 op_kind     = OB_pred (Some (PR_Plain body));
                 op_opaque   = oopr.op_opaque;
                 op_clinline = prmode <> `Alias;
-                op_loca     = refpr.op_loca; } in
+                op_loca     = refpr.op_loca;
+                op_unfold   = refpr.op_unfold; } in
             (newpr, body)
 
         | `ByPath p -> begin

--- a/src/phl/ecPhlConseq.ml
+++ b/src/phl/ecPhlConseq.ml
@@ -707,7 +707,7 @@ let t_bdHoareF_conseq_equiv f2 p q p2 q2 tc =
 
 (* -------------------------------------------------------------------- *)
 let rec t_hi_conseq notmod f1 f2 f3 tc =
-  let t_mytrivial = fun tc -> t_simplify ?target:None ~delta:false tc in
+  let t_mytrivial = fun tc -> t_simplify ?target:None ~delta:`No tc in
   let t_mytrivial = [t_mytrivial; t_split; t_fail] in
   let t_mytrivial = FApi.t_try (FApi.t_seqs t_mytrivial) in
   let t_on1       = FApi.t_on1 ~ttout:t_mytrivial in

--- a/src/phl/ecPhlSkip.ml
+++ b/src/phl/ecPhlSkip.ml
@@ -60,7 +60,7 @@ module LowInternal = struct
 
   (* ------------------------------------------------------------------ *)
   let t_bdhoare_skip_r tc =
-    let t_trivial = FApi.t_seqs [t_simplify ~delta:false; t_split; t_fail] in
+    let t_trivial = FApi.t_seqs [t_simplify ~delta:`No; t_split; t_fail] in
     let t_conseq  = EcPhlConseq.t_bdHoareS_conseq_bd FHeq f_r1 in
       FApi.t_internal
         (FApi.t_seqsub t_conseq


### PR DESCRIPTION
Operator unfolding when applied to enough arguments

When declaring an operator, it is now possible to specify which
arguments are mandatory before an operator application is
automtically unfolded during simplification.

Syntax is:

```
op name (x1 : t1) (xp : tp) / (x_p+1 : t_p+1) ... = ...
```

where the optional `/` indicated that the operator `name` will
be automatically unfolded when applied to at least `p`
arguments.
