### PR TITLE
[runtest]: new CLI argument --bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ ECEXTRA   ?= --report=report.log
 ECPROVERS ?= Alt-Ergo Z3 CVC4
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/testing/runtest
-CHECK     += --bin-args="$(ECARGS)" --bin-args="$(ECPROVERS:%=-p %)"
+CHECK     += --bin=./ec.native --bin-args="$(ECARGS)"
+CHECK     += --bin-args="$(ECPROVERS:%=-p %)"
 CHECK     += --timeout="$(ECTOUT)" --jobs="$(ECJOBS)"
 CHECK     += $(ECEXTRA) config/tests.config
 

--- a/config/tests.config
+++ b/config/tests.config
@@ -1,6 +1,3 @@
-[default]
-bin = ./ec.native
-
 [test-prelude]
 args   = -boot
 okdirs = theories/prelude

--- a/scripts/testing/runtest
+++ b/scripts/testing/runtest
@@ -73,6 +73,13 @@ def _options():
     parser = OptionParser()
 
     parser.add_option(
+        '', '--bin',
+        action  = 'store',
+        metavar = 'BIN',
+        default = None,
+        help    = 'EasyCrypt binary to use')
+
+    parser.add_option(
         '', '--bin-args',
         action  = 'append',
         metavar = 'ARGS',
@@ -148,8 +155,12 @@ def _options():
                     targets.append(name)
         return targets
 
-    options.bin     = config.get('default', 'bin')
-    options.args    = config.get('default', 'args').split()
+    options.bin = cmdopt.bin
+
+    if options.bin is None:
+        options.bin = config.get('default', 'bin', fallback = 'easycrypt')
+
+    options.args    = config.get('default', 'args', fallback = '').split()
     options.targets = resolve_targets(args[1:])
 
     if options.report is None:

--- a/src/ec.ml
+++ b/src/ec.ml
@@ -144,7 +144,12 @@ let main () =
           | None ->
               EcRelocate.resource ["commands"] in
         let cmd  = Filename.concat root "runtest" in
-        let args = ["runtest"; input.runo_input] @ input.runo_scenarios in
+        let args = [
+            "runtest";
+            Format.sprintf "--bin=%s" Sys.executable_name;
+            input.runo_input
+          ] @ input.runo_scenarios
+        in
         Format.eprintf "Executing: %s@." (String.concat " " (cmd :: args));
         Unix.execv cmd (Array.of_list args)
       end


### PR DESCRIPTION
This argument tells `runtest` which binary to use for EasyCrypt.

It takes precedence over what is found in the INI file (in default/bin).

Moreover, `easycrypt runtest` automatically set --bin to itself. This allows to select the correct version of EasyCrypt without having to tweak the INI file accordingly.