### PR TITLE
Remove module overriding

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3869,8 +3869,11 @@ clone_override:
 | LEMMA x=qoident mode=loc(opclmode) y=qoident
   { x, PTHO_Axiom (y, unloc mode) }
 
-| MODULE x=uqident mode=loc(opclmode) y=uqident
-   { (x, PTHO_Module (y, unloc mode)) }
+| MODULE uqident loc(opclmode) uqident
+   { parse_error
+       (EcLocation.make $startpos $endpos)
+       (Some "Module overriding is no longer supported.")
+   }
 
 | MODULE TYPE x=uqident mode=loc(opclmode) y=uqident
    { (x, PTHO_ModTyp (y, unloc mode)) }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1190,7 +1190,6 @@ and theory_override =
 | PTHO_Op     of op_override
 | PTHO_Pred   of pr_override
 | PTHO_Axiom  of ax_override
-| PTHO_Module of me_override
 | PTHO_ModTyp of mt_override
 | PTHO_Theory of th_override
 

--- a/src/ecThCloning.mli
+++ b/src/ecThCloning.mli
@@ -17,13 +17,13 @@ type ovkind =
 | OVK_Abbrev
 | OVK_Theory
 | OVK_Lemma
-| OVK_ModExpr
 | OVK_ModType
 
 type clone_error =
 | CE_UnkTheory         of qsymbol
 | CE_DupOverride       of ovkind * qsymbol
 | CE_UnkOverride       of ovkind * qsymbol
+| CE_ThyOverride       of qsymbol
 | CE_UnkAbbrev         of qsymbol
 | CE_TypeArgMism       of ovkind * qsymbol
 | CE_OpIncompatible    of qsymbol * incompatible

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -703,7 +703,6 @@ end = struct
     | OVK_Abbrev    -> "abbreviation"
     | OVK_Theory    -> "theory"
     | OVK_Lemma     -> "lemma/axiom"
-    | OVK_ModExpr   -> "module"
     | OVK_ModType   -> "module type"
 
   let pp_incompatible env fmt = function
@@ -734,6 +733,10 @@ end = struct
     | CE_UnkOverride (kd, x) ->
         msg "unknown %s `%s'"
           (string_of_ovkind kd) (string_of_qsymbol x)
+
+    | CE_ThyOverride x ->
+        msg "Cannot override theory `%s`: contains module"
+          (string_of_qsymbol x)
 
     | CE_UnkAbbrev x ->
         msg "unknown abbreviation: `%s'" (string_of_qsymbol x)


### PR DESCRIPTION
As a fix for #380, disallow all ways of overriding a module when cloning a theory.
Note: this will most likely break some existing proofs.