### PR TITLE
Support project-local ini files

### DIFF
--- a/src/ec.ml
+++ b/src/ec.ml
@@ -27,6 +27,7 @@ let psep = match Sys.os_type with "Win32" -> ";" | _ -> ":"
 
 (* -------------------------------------------------------------------- *)
 let confname    = "easycrypt.conf"
+let projname    = "easycrypt.project"
 let why3dflconf = Filename.concat XDG.home "why3.conf"
 
 (* -------------------------------------------------------------------- *)
@@ -121,17 +122,64 @@ let main () =
             if Sys.file_exists conffile then Some conffile else None) in
       List.Exceptionless.hd (Option.to_list localini @ xdgini) in
 
-    let ini =
-      Option.bind conffile (fun ini ->
-        try  Some (EcOptions.read_ini_file ini)
-        with
-        | Sys_error _ -> None
-        | EcOptions.InvalidIniFile (lineno, file) ->
-            Format.eprintf "%s:%l: cannot read INI file@." file lineno;
-            exit 1
-      )
+    let projfile (path : string option) =
+      let rec find (path : string) : string option =
+        let projfile = Filename.concat path projname in
+        if Sys.file_exists projfile then
+          Some projfile
+        else
+          if Filename.dirname path = path then
+            None
+          else
+            find (Filename.dirname path)
+      in
 
-    in (conffile, EcOptions.parse_cmdline ?ini Sys.argv) in
+      let root =
+        match path with
+        | Some path ->
+           Filename.dirname path
+        | None ->
+           Unix.getcwd () in
+
+      let root =
+        if   Filename.is_relative root
+        then Filename.concat (Unix.getcwd ()) root
+        else root in
+
+      find root in
+
+    let read_ini_file ini =
+      try  Some (EcOptions.read_ini_file ini)
+      with
+      | Sys_error _ -> None
+      | EcOptions.InvalidIniFile (lineno, file) ->
+          Format.eprintf "%s:%l: cannot read INI file@." file lineno;
+          exit 1
+    in
+
+    let getini (path : string option) =
+      let inisys =
+        Option.bind conffile (fun conffile ->
+          Option.map
+            (fun ini -> { inic_ini = ini; inic_root = None; })
+            (read_ini_file conffile)
+        )
+      in
+
+      let iniproj =
+        Option.bind (projfile path) (fun conffile ->
+          Option.map
+            (fun ini -> {
+               inic_ini  = ini;
+               inic_root = Some (Filename.dirname conffile);
+            })
+            (read_ini_file conffile)
+        )
+      in
+
+      List.filter_map identity [iniproj; inisys] in
+
+    (conffile, EcOptions.parse_cmdline ~ini:getini Sys.argv) in
 
   (* Execution of eager commands *)
   begin
@@ -479,4 +527,6 @@ let main () =
     raise e
 
 (* -------------------------------------------------------------------- *)
-let () = main ()
+let () =
+  Format.eprintf "%s" (Unix.getcwd ());
+  main ()

--- a/src/ecOptions.mli
+++ b/src/ecOptions.mli
@@ -66,8 +66,17 @@ type ini_options = {
   ini_rdirs    : (string option * string) list;
 }
 
+type ini_context = {
+  inic_ini  : ini_options;
+  inic_root : string option;
+}
+
 (* -------------------------------------------------------------------- *)
 exception InvalidIniFile of (int * string)
 
 val read_ini_file : string -> ini_options
-val parse_cmdline : ?ini:ini_options -> string array -> options
+
+val parse_cmdline :
+     ?ini:(string option -> ini_context list)
+  -> string array
+  -> options


### PR DESCRIPTION
EasyCrypt now reads project-local files for getting its configuration settings. This configuration file takes precedence over the system-level configuration file.

The project-local configuration file is named 'easycrypt.project'.  It is identical to the system-level configuration file.

When compiling a file, the configuration file is searched upward from the target file directory. When ran in interactive mode, the configuration file is searched upward from the current working directory.

Note that when ProofGeneral starts EasyCrypt, the working directory is set to the directory of the focused file.