### PR TITLE
Allows selecting a prover by its version number.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ECARGS    ?=
 ECTOUT    ?= 10
 ECJOBS    ?= 0
 ECEXTRA   ?= --report=report.log
-ECPROVERS ?= Alt-Ergo Z3 CVC4
+ECPROVERS ?= Alt-Ergo@2.4 Z3@4.8 CVC4@1.8
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/testing/runtest
 CHECK     += --bin=./ec.native --bin-args="$(ECARGS)"

--- a/src/ec.ml
+++ b/src/ec.ml
@@ -72,7 +72,7 @@ let print_config config =
       let fullname =
         Printf.sprintf "%s@%s"
           prover.EcProvers.pr_name
-          prover.EcProvers.pr_version in
+          (EcProvers.Version.to_string prover.EcProvers.pr_version) in
 
       match prover.EcProvers.pr_evicted with
       | None -> fullname

--- a/src/ecProvers.mli
+++ b/src/ecProvers.mli
@@ -16,13 +16,20 @@ module Hints : sig
 end
 
 (* -------------------------------------------------------------------- *)
+module Version : sig
+  type version
+
+  val to_string : version -> string
+end
+
+(* -------------------------------------------------------------------- *)
 type prover_eviction = [
   | `Inconsistent
 ]
 
 type prover = {
   pr_name    : string;
-  pr_version : string;
+  pr_version : Version.version;
   pr_evicted : (prover_eviction * bool) option;
 }
 
@@ -51,6 +58,7 @@ val known : evicted:bool -> prover list
 (* -------------------------------------------------------------------- *)
 type parsed_pname = {
   prn_name     : string;
+  prn_version  : Version.version option;
   prn_ovrevict : bool;
 }
 


### PR DESCRIPTION
Syntax is name@version. The selected prover is the prover with name `name` and with the lowest version that is greater (or equal) than `version`.

For example, if Z3 4.8.0, Z3 4.8.2 & Z3 4.12.2 are installed, Z3@4.8 selects Z3 4.8.0.