### PR TITLE
runtest: allows to specify provers from the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [ [ 'jasmin-eclib', 'jasmin-lang/jasmin', 'eclib', 'tests.config', 'jasmin' ] ]
+        target: [ [ 'jasmin-eclib', 'jasmin-lang/jasmin', 'eclib', 'tests.config', 'jasmin', '-p Z3@4.8 -p Alt-Ergo@2.4' ] ]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -109,7 +109,7 @@ jobs:
         opam config exec -- easycrypt why3config
     - name: Compile project
       working-directory: project/${{ matrix.target[2] }}
-      run: opam config exec -- ec-runtest ${{ matrix.target[3] }} ${{ matrix.target[4] }}
+      run: opam config exec -- ec-runtest ${{ matrix.target[5] }} ${{ matrix.target[3] }} ${{ matrix.target[4] }}
     - uses: actions/upload-artifact@v3
       name: Upload report.log
       if: always()

--- a/scripts/testing/runtest
+++ b/scripts/testing/runtest
@@ -115,6 +115,13 @@ def _options():
         help    = 'add timing statistics')
 
     parser.add_option(
+        '-p', '--provers',
+        action  = 'append',
+        metavar = 'PROVERS',
+        default = None,
+        help    = 'Add a prover to the set of activated provers')
+
+    parser.add_option(
         '', '--report',
         action  = 'store',
         default = None,
@@ -138,6 +145,7 @@ def _options():
     options.timeout  = cmdopt.timeout
     options.timing   = cmdopt.timing
     options.jobs     = cmdopt.jobs
+    options.provers  = cmdopt.provers
     options.report   = cmdopt.report
 
     defaults = dict(
@@ -681,6 +689,9 @@ async def _run_all(options, allscripts, listener : Listener):
             command = [options.bin] + options.args + config.args
             if options.timeout:
                 command.extend(['-timeout', str(options.timeout)])
+            if options.provers:
+                for prover in options.provers:
+                    command.extend(['-p', prover])
             if options.timing:
                 tfilename = os.path.join(
                     TIMING_DIR, os.path.splitext(config.filename)[0] + '.stats')

--- a/src/ec.ml
+++ b/src/ec.ml
@@ -192,11 +192,17 @@ let main () =
           | None ->
               EcRelocate.resource ["commands"] in
         let cmd  = Filename.concat root "runtest" in
-        let args = [
-            "runtest";
-            Format.sprintf "--bin=%s" Sys.executable_name;
-            input.runo_input
-          ] @ input.runo_scenarios
+        let args =
+            [
+              "runtest";
+               Format.sprintf "--bin=%s" Sys.executable_name;
+            ]
+          @ (List.flatten
+               (List.map
+                  (fun x -> ["-p"; x])
+                  (odfl [] input.runo_provers)))
+          @ [input.runo_input]
+          @ input.runo_scenarios
         in
         Format.eprintf "Executing: %s@." (String.concat " " (cmd :: args));
         Unix.execv cmd (Array.of_list args)

--- a/src/ecOptions.ml
+++ b/src/ecOptions.ml
@@ -33,6 +33,7 @@ and cli_option = {
 and run_option = {
   runo_input     : string;
   runo_scenarios : string list;
+  runo_provers   : string list option;
 }
 
 and prv_options = {
@@ -344,7 +345,9 @@ let specs = {
 
     ("config", "Print EasyCrypt configuration", []);
 
-    ("runtest", "Run a test-suite", []);
+    ("runtest", "Run a test-suite", [
+      `Spec ("p", `String, "Add a prover to the set of provers");
+    ]);
 
     ("why3config", "Configure why3", []);
   ];
@@ -496,6 +499,13 @@ let cmp_options_of_values ini values input =
     cmpo_noeco   = get_flag "no-eco" values;
     cmpo_script  = get_flag "script" values; }
 
+let runtest_options_of_values values (input, scenarios) =
+  { runo_input     = input;
+    runo_scenarios = scenarios;
+    runo_provers   =
+      match get_strings "p" values with
+      | [] -> None | provers -> Some provers }
+
 (* -------------------------------------------------------------------- *)
 let parse getini argv =
   let (command, values, anons) = parse specs argv in
@@ -532,9 +542,9 @@ let parse getini argv =
 
     | "runtest" -> begin
         match anons with
-        | runo_input :: runo_scenarios ->
+        | input :: scenarios ->
            let ini = getini None in
-           let cmd = `Runtest { runo_input; runo_scenarios; } in
+           let cmd = `Runtest (runtest_options_of_values values (input, scenarios)) in
 
            (cmd, ini)
 

--- a/src/ecOptions.mli
+++ b/src/ecOptions.mli
@@ -29,6 +29,7 @@ and cli_option = {
 and run_option = {
   runo_input     : string;
   runo_scenarios : string list;
+  runo_provers   : string list option;
 }
 
 and prv_options = {


### PR DESCRIPTION
This allows to temporarily fix the Jasmin CI.