### PR TITLE
Compile in `dev` mode by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ default: build
 
 build:
 	rm -f src/ec.exe ec.native
-	dune build -p easycrypt
+	dune build
 	ln -sf src/ec.exe ec.native
 ifeq ($(UNAME_P)-$(UNAME_S),arm-Darwin)
 	-codesign -f -s - src/ec.exe

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -541,7 +541,7 @@ type opprec = int * fixity
 (* -------------------------------------------------------------------- *)
 (* precondition: fst inner_left <= fst inner *)
 let maybe_paren_gen (onm, (outer, side)) (inm, inner, inner_left) pp =
-  let noparens ((pi : int), fi) (pil, fil) (po, fo) side =
+  let noparens ((pi : int), fi) (pil, _fil) (po, fo) side =
     pil > po ||  (* pi > po is too strong *)
       match fi, side with
       | `Postfix     , `Left     -> true
@@ -571,7 +571,7 @@ let maybe_paren_nosc outer inner pp =
 (* when a construct is bracketed with words, e.g., `match ... end`,
    only introduce explicit parentheses in an application *)
 let maybe_paren_bracketed_with_words (_, (_, side)) pp =
-  let parens outer =
+  let parens _outer =
     (match side with
      | `ILeft | `IRight -> true
      | _                -> false)
@@ -1348,7 +1348,7 @@ let lower_left (ppe : PPEnv.t) (t_ty : form -> EcTypes.ty) (f : form)
     | Fquant _ -> Some (fst e_bin_prio_lambda)
     | Fif _    -> Some (fst e_bin_prio_if)
     | Flet _   -> Some (fst e_bin_prio_letin)
-    | Fapp ({f_node = Fop (op, _)}, [f1; f2])
+    | Fapp ({f_node = Fop (op, _)}, [_; f2])
         when EcPath.basename op = EcCoreLib.s_cons ->
         if fst e_bin_prio_rop4 < fst opprec
         then None

--- a/src/phl/ecPhlConseq.ml
+++ b/src/phl/ecPhlConseq.ml
@@ -600,7 +600,7 @@ let t_concave_incr =
        (t_solve ~bases:["concave_incr"] ~mode:EcMatching.fmrigid ~canfail:true ~depth:20))
 
 (* -------------------------------------------------------------------- *)
-let t_ehoare_conseq_nm_end hyps =
+let t_ehoare_conseq_nm_end =
   [ t_concave_incr;
     t_id;
     t_id;
@@ -630,11 +630,11 @@ let t_ehoareF_conseq_nm pre post tc =
     let x = EcIdent.create "x" in
     f_lambda [x,GTty txreal] (f_interp_ehoare_form cond (f_local x txreal)) in
 
-  (t_ehoareF_concave fc pre post @+ t_ehoare_conseq_nm_end hyps) tc
+  (t_ehoareF_concave fc pre post @+ t_ehoare_conseq_nm_end) tc
 
 (* -------------------------------------------------------------------- *)
 let t_ehoareS_conseq_nm pre post tc =
-  let (env, hyps, _) = FApi.tc1_eflat tc in
+  let env = FApi.tc1_env tc in
   let hs = tc1_as_ehoareS tc in
   let s = hs.ehs_s in
   let m = fst hs.ehs_m in
@@ -646,7 +646,7 @@ let t_ehoareS_conseq_nm pre post tc =
     let x = EcIdent.create "x" in
     f_lambda [x,GTty txreal] (f_interp_ehoare_form cond (f_local x txreal)) in
 
-  (t_ehoareS_concave fc pre post @+ t_ehoare_conseq_nm_end hyps) tc
+  (t_ehoareS_concave fc pre post @+ t_ehoare_conseq_nm_end) tc
 
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
Until now, `make` was building EasyCrypt in release mode.

The set of warning flags in release mode is weaker then in development mode. Switching to dev mode caused the apparition of some warnings. This commit fixes them.