### PR TITLE
In substitutions, lazyly refresh the codomain of the univar map

### DIFF
--- a/src/ecTypes.ml
+++ b/src/ecTypes.ml
@@ -214,8 +214,15 @@ let rec ty_subst s =
             | Some ty -> ty_subst s ty
           end
         end
-      | Tunivar id    -> Muid.find_def ty id s.ts_u
-      | Tvar id       -> Mid.find_def ty id s.ts_v
+      | Tunivar id -> begin
+          match Muid.find_opt id s.ts_u with
+          | None ->
+            ty
+          | Some ty ->
+            ty_subst s ty
+        end
+
+      | Tvar id -> Mid.find_def ty id s.ts_v
       | _ -> ty_map (ty_subst s) ty
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
This map is allowed to do name capture and is hence sensitive to bound variables renaming.