### PR TITLE
Add tactic `weakmem`

### DIFF
--- a/src/ecHiTacticals.ml
+++ b/src/ecHiTacticals.ml
@@ -194,6 +194,7 @@ and process1_phl (_ : ttenv) (t : phltactic located) (tc : tcenv1) =
     | Pkill info                -> EcPhlCodeTx.process_kill info
     | Palias info               -> EcPhlCodeTx.process_alias info
     | Pset info                 -> EcPhlCodeTx.process_set info
+    | Pweakmem info             -> EcPhlCodeTx.process_weakmem info
     | Prnd (side, pos, info)    -> EcPhlRnd.process_rnd side pos info
     | Prndsem (side, pos)       -> EcPhlRnd.process_rndsem side pos
     | Pconseq (opt, info)       -> EcPhlConseq.process_conseq_opt opt info

--- a/src/ecLexer.mll
+++ b/src/ecLexer.mll
@@ -156,6 +156,7 @@
     "inline"      , INLINE     ;        (* KW: tactic *)
     "interleave"  , INTERLEAVE ;        (* KW: tactic *)
     "alias"       , ALIAS      ;        (* KW: tactic *)
+    "weakmem"     , WEAKMEM    ;        (* KW: tactic *)
     "fission"     , FISSION    ;        (* KW: tactic *)
     "fusion"      , FUSION     ;        (* KW: tactic *)
     "unroll"      , UNROLL     ;        (* KW: tactic *)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -600,6 +600,7 @@
 %token UNDO
 %token UNROLL
 %token VAR
+%token WEAKMEM
 %token WHILE
 %token WHY3
 %token WITH
@@ -3234,6 +3235,9 @@ phltactic:
 
 | ALIAS s=side? o=codepos x=lident EQ e=expr
     { Pset (s, o, false, x,e) }
+
+| WEAKMEM h=lident p=param_decl
+    { Pweakmem(h, p) }
 
 | FISSION s=side? o=codepos AT d1=word COMMA d2=word
     { Pfission (s, o, (1, (d1, d2))) }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -736,6 +736,7 @@ type phltactic =
   | Prnd           of oside * semrndpos option * rnd_tac_info_f
   | Prndsem        of oside * codepos1
   | Palias         of (oside * codepos * osymbol_r)
+  | Pweakmem       of (psymbol * fun_params)
   | Pset           of (oside * codepos * bool * psymbol * pexpr)
   | Pconseq        of (pcqoptions * (conseq_ppterm option tuple3))
   | Pconseqauto    of crushmode

--- a/src/phl/ecPhlCodeTx.mli
+++ b/src/phl/ecPhlCodeTx.mli
@@ -14,3 +14,6 @@ val process_kill  : oside * codepos * int option -> backward
 val process_alias : oside * codepos * psymbol option -> backward
 val process_set   : oside * codepos * bool * psymbol * pexpr -> backward
 val process_cfold : oside * codepos * int option -> backward
+
+(* -------------------------------------------------------------------- *)
+val process_weakmem : (psymbol * fun_params) -> backward

--- a/theories/distributions/Dexcepted.ec
+++ b/theories/distributions/Dexcepted.ec
@@ -300,6 +300,7 @@ while (i = x /\ test = X) (if test x r then 1 else 0) 1 (mu (dt x) (predC (X x))
 + smt().
 + smt().
 + move=> ih. alias 2 r0 = r.
+  weakmem ih (r0:t) => {ih} ih.
   (** TRANSITIVITY FOR PHOARE!! **)
   phoare split (mu (dt x) (predI P (predC (X x))))
                (mu (dt x) (X x) * mu (dt x \ X x) P)


### PR DESCRIPTION
This tactic allows to weaken the memory of a phoare hypothesis by adding new variables to it.

This tactic is needed in the while rule for phoare, when one wants to apply the induction hypothesis & the memories are not compatible. Currently, the convertibility check does not enforce that memories are equal, but a to-come PR is going to fix that point.