### PR TITLE
New tactic: "proc rewrite"

### DIFF
--- a/src/ecHiTacticals.ml
+++ b/src/ecHiTacticals.ml
@@ -228,6 +228,7 @@ and process1_phl (_ : ttenv) (t : phltactic located) (tc : tcenv1) =
     | Plossless                 -> EcPhlHiAuto.t_lossless
     | Prepl_stmt infos          -> EcPhlTrans.process_equiv_trans infos
     | Pprocchange (s, p, f)     -> EcPhlRewrite.process_change s p f
+    | Pprocrewrite (s, p, f)    -> EcPhlRewrite.process_rewrite s p f
   in
 
   try  tx tc

--- a/src/ecLowGoal.ml
+++ b/src/ecLowGoal.ml
@@ -1583,6 +1583,7 @@ let t_rewrite
     | None     -> FPosition.select_form ?keyed ?xconv hyps None left tgfp
     | Some pos -> pos in
 
+
   let tgfp =
     try  FPosition.map npos change tgfp
     with InvalidPosition -> raise InvalidGoalShape

--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -746,8 +746,10 @@ let f_match opts hyps (ue, ev) ~ptn subject =
       (ue, clue, ev)
 
 (* -------------------------------------------------------------------- *)
-type ptnpos = [`Select of int | `Sub of ptnpos] Mint.t
-type occ    = [`Inclusive | `Exclusive] * Sint.t
+type ptnpos1 = [`Select of int | `Sub of ptnpos]
+and  ptnpos  = ptnpos1 Mint.t
+
+type occ = [`Inclusive | `Exclusive] * Sint.t
 
 exception InvalidPosition
 exception InvalidOccurence
@@ -1036,6 +1038,19 @@ module FPosition = struct
 
     in
       as_seq1 (doit p [f])
+
+  (* ------------------------------------------------------------------ *)
+  let reroot (root : int list) (p : ptnpos) =
+    if Mint.is_empty p then
+      Mint.empty
+    else begin
+      assert (Mint.mem 0 p && Mint.cardinal p = 1);
+      Mint.singleton 0 (
+        List.fold_right
+          (fun i (p : ptnpos1) -> (`Sub (Mint.singleton i p) :> ptnpos1))
+          root (Mint.find 0 p)
+      )
+    end
 
   (* ------------------------------------------------------------------ *)
   let topattern ?x (p : ptnpos) (f : form) =

--- a/src/ecMatching.mli
+++ b/src/ecMatching.mli
@@ -167,6 +167,8 @@ module FPosition : sig
 
   val is_empty : ptnpos -> bool
 
+  val reroot : int list -> ptnpos -> ptnpos
+
   val tostring : ptnpos -> string
 
   val select : ?o:occ -> (Sid.t -> form -> select) -> form -> ptnpos

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3233,8 +3233,11 @@ phltactic:
 | LOSSLESS
     { Plossless }
 
-| PROC CHANGE side=side? pos=codepos COLON f=sform
+| PROC CHANGE side=side? pos=codepos COLON f=sexpr
     { Pprocchange (side, pos, f) }
+
+| PROC REWRITE side=side? pos=codepos f=pterm
+    { Pprocrewrite (side, pos, f) }
 
 bdhoare_split:
 | b1=sform b2=sform b3=sform?

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -749,7 +749,8 @@ type phltactic =
   | Prw_equiv      of rw_eqv_info
   | Psymmetry
   | Pbdhoare_split of bdh_split
-  | Pprocchange    of side option * codepos * pformula
+  | Pprocchange    of side option * codepos * pexpr
+  | Pprocrewrite   of side option * codepos * ppterm
 
     (* Eager *)
   | Peager_seq       of (eager_info * codepos1 pair * pformula)

--- a/src/phl/ecPhlRewrite.ml
+++ b/src/phl/ecPhlRewrite.ml
@@ -2,42 +2,136 @@
 open EcParsetree
 open EcAst
 open EcCoreGoal
+open EcEnv
 open EcModules
 open EcFol
 
 (* -------------------------------------------------------------------- *)
-let process_change
+let get_expression_of_instruction (i : instr) =
+  match i.i_node with
+  | Sasgn (lv, e) -> Some (e, (fun e -> i_asgn (lv, e)))
+  | Srnd  (lv, e) -> Some (e, (fun e -> i_rnd  (lv, e)))
+  | _             -> None
+
+(* -------------------------------------------------------------------- *)
+let t_change
     (side : side option)
     (pos  : codepos)
-    (form : pformula)
+    (expr : expr -> LDecl.hyps * memenv -> 'a * expr)
     (tc   : tcenv1)
 =
-  let concl = FApi.tc1_goal tc in
+  let hyps, concl = FApi.tc1_flat tc in
 
-  let change i =
-    let (e, mk) =
-      match i.i_node with
-      | Sasgn (lv, e) -> (e, (fun e -> i_asgn (lv, e)))
-      | Srnd  (lv, e) -> (e, (fun e -> i_rnd  (lv, e)))
-      | _             -> assert false in
+  let change (i : instr) =
+    let e, mk =
+      EcUtils.ofdfl
+        (fun () ->
+           tc_error !!tc
+             "targeted instruction should be \
+             an assignment or random sampling")
+        (get_expression_of_instruction i)
+    in
 
-    let m, e' = EcProofTyping.tc1_process_Xhl_form ?side tc e.e_ty form in
+    let m, _ = EcFol.destr_programS side concl in
+    let data, e' = expr e (hyps, m) in
     let mid = EcMemory.memory m in
-    let e' = expr_of_form mid e' in
 
     let f  = form_of_expr mid e in
     let f' = form_of_expr mid e' in
 
-    ([f_forall_mems [m] (f_eq f f')], [mk e'])
+    (data, [f_forall_mems [m] (f_eq f f')]), [mk e']
   in
 
   let kinds = [`Hoare `Stmt; `EHoare `Stmt; `PHoare `Stmt; `Equiv `Stmt] in
 
   if not (EcLowPhlGoal.is_program_logic concl kinds) then
-    assert false;
+    tc_error !!tc
+      "conclusion should be a program logic \
+      (hoare | ehoare | phoare | equiv)";
 
   let s = EcLowPhlGoal.tc1_get_stmt side tc in
-  let goals, s = EcMatching.Zipper.map pos change s in
+  let (data, goals), s = EcMatching.Zipper.map pos change s in
   let concl = EcLowPhlGoal.hl_set_stmt side concl s in
 
-  FApi.xmutate1 tc `ProcChange (goals @ [concl])
+  data, FApi.xmutate1 tc `ProcChange (goals @ [concl])
+
+(* -------------------------------------------------------------------- *)
+let process_change
+    (side : side option)
+    (pos  : codepos)
+    (form : pexpr)
+    (tc   : tcenv1)
+=
+  let expr (e : expr) ((hyps, m) : LDecl.hyps * memenv) =
+    let hyps = LDecl.push_active m hyps in
+    let e =
+      EcProofTyping.pf_process_exp
+        !!tc hyps `InProc (Some e.e_ty) form
+    in (), e
+  in
+
+  let (), tc = t_change side pos expr tc in tc
+
+(* -------------------------------------------------------------------- *)
+let process_rewrite
+    (side : side option)
+    (pos  : codepos)
+    (pt   : ppterm)
+    (tc   : tcenv1)
+=
+  let hyps = FApi.tc1_hyps tc in
+  let ptenv = EcProofTerm.ptenv_of_penv hyps !!tc in
+  let pt = EcProofTerm.process_full_pterm ptenv pt in
+
+  let pts = EcHiGoal.LowRewrite.find_rewrite_patterns `LtoR pt in
+
+  let change (e : expr) ((hyps, m) : LDecl.hyps * memenv) =
+    let e = form_of_expr (fst m) e in
+
+    let try1 (pt, mode, (f1, f2)) =
+      try
+        let subf, occmode =
+          EcProofTerm.pf_find_occurence_lazy
+            pt.EcProofTerm.ptev_env ~ptn:f1 e
+        in
+
+        assert (EcProofTerm.can_concretize pt.ptev_env);
+
+        let f2 = EcProofTerm.concretize_form pt.ptev_env f2 in
+        let pt, _ = EcProofTerm.concretize pt in
+
+        let cpos =
+          EcMatching.FPosition.select_form
+            ~xconv:`AlphaEq ~keyed:occmode.k_keyed
+            hyps None subf e in
+
+        let e = EcMatching.FPosition.map cpos (fun _ -> f2) e in
+
+        Some ((pt, mode, cpos), e)
+
+      with EcProofTerm.FindOccFailure _ ->
+        None
+
+    in
+
+    let data, e =
+      EcUtils.ofdfl
+        (fun () -> tc_error !!tc "cannot find a pattern to rewrite")
+        (List.find_map try1 pts) in
+
+    (m, data), expr_of_form mhr e
+  in
+
+  let (m, (pt, mode, cpos)), tc = t_change side pos change tc in
+
+  let cpos = EcMatching.FPosition.reroot [1] cpos in
+
+  let discharge (tc : tcenv1) =
+    let tc = EcLowGoal.t_intros_i_1 [fst m] tc in
+    FApi.t_seq
+      (EcLowGoal.t_rewrite ~mode pt (`LtoR, Some cpos))
+      EcLowGoal.t_reflex
+      tc
+  in
+
+  FApi.t_first discharge tc

--- a/src/phl/ecPhlRewrite.mli
+++ b/src/phl/ecPhlRewrite.mli
@@ -3,4 +3,5 @@ open EcParsetree
 open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
-val process_change : side option -> codepos -> pformula -> backward
+val process_change : side option -> codepos -> pexpr -> backward
+val process_rewrite : side option -> codepos -> ppterm -> backward

--- a/tests/procrewrite.ec
+++ b/tests/procrewrite.ec
@@ -1,0 +1,19 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore.
+
+(* -------------------------------------------------------------------- *)
+module M = {
+  proc f(a : int, b : int) : int = {
+    var c : int <- a * (a + b);
+    return c;
+  }
+}.
+
+(* -------------------------------------------------------------------- *)
+lemma L a0 b0 : hoare[M.f : arg = (a0, b0) ==> res = (b0 + a0) * a0].
+proof.
+proc.
+proc rewrite 1 addzC.
+proc rewrite 1 mulzC.
+auto=> />.
+qed.


### PR DESCRIPTION
This tactic allows to rewrite an expression in a statement.
    
The syntax is:

```
proc rewrite <side?> <codepos> <proof-term>
````
    
This tactic relies on "proc change" and does not modify the TCB.
    
Test plan:
    
 - unit test (tests/procrewrite.ec)