### PR TITLE
Docker: bump OCaml to 5.1.0

### DIFF
--- a/scripts/docker/base-box/Dockerfile
+++ b/scripts/docker/base-box/Dockerfile
@@ -27,4 +27,4 @@ WORKDIR /home/$user
 ENV OPAMYES=true OPAMVERBOSE=0 OPAMJOBS=4
 
 RUN \
-	opam init --disable-sandboxing
+	opam init --disable-sandboxing --switch=ocaml-base-compiler.5.1.0


### PR DESCRIPTION
This PR should not be accepted before we carefully checked that we do not have any penalty in using OCaml 5.x.

The published Docker image is currently based on this PR.