### PR TITLE
Unify the behavior of simplify & /= w.r.t. auto-unfolding.

### DIFF
--- a/src/ecCallbyValue.ml
+++ b/src/ecCallbyValue.ml
@@ -323,8 +323,7 @@ and app_red st f1 args =
     f_app f1 args.stack args.resty
 
 and reduce_user_delta st f1 p tys args =
-  let f2 =
-    f_app f1 args.stack args.resty in
+  let f2 = f_app f1 args.stack args.resty in
 
   match reduce_user_with_exn st f2 with
   | f -> f
@@ -383,8 +382,12 @@ and cbv (st : state) (s : subst) (f : form) (args : args) : form =
     let rfn = f_app fn (List.take (List.length fnargs - 1) fnargs) f.f_ty in
     cbv st s rfn args
 
-  | Fquant (Llambda, b, f1) ->
-    betared st s b f1 args
+  | Fquant (Llambda, b, f1) when not (Args.isempty args) ->
+    cbv_init st Subst.subst_id (betared st s b f1 args)
+
+  | Fquant (Llambda, _, _) ->
+    assert (Args.isempty args);
+    Subst.subst s f
 
   | Fif (f, f1, f2) ->
     if st.st_ri.iota then

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -109,7 +109,7 @@ let process_simplify_info ri (tc : tcenv1) =
   let delta_p, delta_h =
     ri.pdelta
       |> omap (List.fold_left do1 (Sp.empty, Sid.empty))
-      |> omap (fun (x, y) -> (fun p -> if Sp.mem p x then `Force else `No), (Sid.mem^~ y))
+      |> omap (fun (x, y) -> (fun p -> if Sp.mem p x then `Force else `IfApplied), (Sid.mem^~ y))
       |> odfl ((fun _ -> `IfTransparent), predT)
   in
 


### PR DESCRIPTION
Before this commit, `simplify` was not configured to unfold symbols marked for auto-unfolding.