### PR TITLE
Optimize pretty-printing of notations

### DIFF
--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -341,7 +341,7 @@ module Op : sig
 
   type notation = ty_params * EcDecl.notation
 
-  val get_notations : env -> (path * notation) list
+  val get_notations : head:path option -> env -> (path * notation) list
 
   val iter : ?name:qsymbol -> (path -> t -> unit) -> env -> unit
   val all  : ?check:(path -> t -> bool) -> ?name:qsymbol -> env -> (path * t) list

--- a/src/ecPath.ml
+++ b/src/ecPath.ml
@@ -71,6 +71,14 @@ module Sp = struct
 end
 
 (* -------------------------------------------------------------------- *)
+module Mop = Map.Make(struct
+  type t = path option
+
+  let compare (p1 : path option) (p2 : path option) =
+    ocompare p_compare p1 p2
+end)
+
+(* -------------------------------------------------------------------- *)
 let mk_path node =
   Hspath.hashcons { p_node = node; p_tag = -1; }
 

--- a/src/ecPath.mli
+++ b/src/ecPath.mli
@@ -48,6 +48,9 @@ module Sp : sig
 end
 
 (* -------------------------------------------------------------------- *)
+module Mop : Map.S with type key = path option
+
+(* -------------------------------------------------------------------- *)
 type mpath = private {
   m_top  : mpath_top;
   m_args : mpath list;

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -1618,7 +1618,13 @@ and try_pp_notations (ppe : PPEnv.t) outer fmt f =
      not nt.ont_ponly && try_notation args
   in
 
-  let nts = EcEnv.Op.get_notations ppe.PPEnv.ppe_env in
+  let head =
+    try
+      Some (fst (destr_op (fst (destr_app f))))
+    with DestrError _ -> None
+  in
+
+  let nts = EcEnv.Op.get_notations ~head ppe.PPEnv.ppe_env in
 
   List.exists try_notation nts
 


### PR DESCRIPTION
The printer now does a eager filtering of notations (only notations that share the same head symbol as the printed formula are considered)

The does not change the behavior of the pretty-printer, but greatly improves performance.