### PR TITLE
Allow patterns in cut-rewrite.

### DIFF
--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -812,6 +812,25 @@ let process_rewrite1_r ttenv ?target ri tc =
               process_rewrite1_core ~mode ?target (theside, prw, o) pt tc
           end
 
+        | { fp_head = FPCut (Some f); fp_args = []; }
+        ->
+          let ps = ref Mid.empty in
+
+          let f =
+            EcTyping.trans_pattern
+              (LDecl.toenv ptenv.pte_hy) ps ptenv.pte_ue
+              f
+          in
+
+          !ps |> Mid.iter (fun x _ ->
+            ptenv.pte_ev := MEV.add x `Form !(ptenv.pte_ev)
+          );
+
+          let pt = PTApply { pt_head = PTCut f; pt_args = []; } in
+          let pt = { ptev_env = ptenv; ptev_pt = pt; ptev_ax = f; } in
+
+          process_rewrite1_core ~mode ?target (theside, prw, o) pt tc
+
         | _ ->
           let pt = PT.process_full_pterm ~implicits ptenv pt in
           process_rewrite1_core ~mode ?target (theside, prw, o) pt tc

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -2430,7 +2430,7 @@ gpoterm(F):
    { mk_pterm (fst hd) (snd hd) args }
 
 %inline pterm:
-| pt=gpoterm(form) { pt }
+| pt=gpoterm(form_h) { pt }
 
 (* ------------------------------------------------------------------ *)
 pcutdef1:

--- a/tests/rw_explicit_eq_with_pattern.ec
+++ b/tests/rw_explicit_eq_with_pattern.ec
@@ -1,0 +1,26 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore.
+
+(* -------------------------------------------------------------------- *)
+lemma L1 (c d x : int) : x + (x + c) = x.
+proof.
+rewrite (_ : x + _ = d).
+- suff: x + (x + c) = d by exact. admit.
+- suff: d = x by exact. admit.
+qed.
+
+(* -------------------------------------------------------------------- *)
+lemma L2 (c d x : int) : x + (x + c) = x.
+proof.
+rewrite [_ + c](_ : x + _ = d).
+- suff: x + c = d by exact. admit.
+- suff: x + d = x by exact. admit.
+qed.
+
+(* -------------------------------------------------------------------- *)
+lemma L3 (c d x : int) : x + (x + c) = x.
+proof.
+rewrite [_ + c](_ : _ + c = d).
+- suff: x + c = d by exact. admit.
+- suff: x + d = x by exact. admit.
+qed.


### PR DESCRIPTION
It is now possible to use pattern variables in cut-rewrite:

```
rewrite (_ : pattern = term)
```

See tests/rw_explicit_eq_with_pattern.ec for examples.