### PR TITLE
External CI: add cryptobox

### DIFF
--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -29,4 +29,15 @@
   , "scenario"   : "mlkem"
   , "options"    : "-pragmas Proofs:weak"
   }
+
+  ,
+
+  { "name"       : "cryptobox"
+  , "repository" : "https://gitlab.com/fdupress/ec-cryptobox"
+  , "branch"     : "next"
+  , "subdir"     : "."
+  , "config"     : "config/tests.config"
+  , "scenario"   : "cryptobox"
+  , "options"    : "-pragmas Proofs:weak"
+  }
 ]

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -22,7 +22,7 @@
   ,
 
   { "name"       : "ml-kem"
-  , "repository" : "https://github.com/formosa-crypto/formosa-mlkem" 
+  , "repository" : "https://github.com/formosa-crypto/formosa-mlkem"
   , "branch"     : "master"
   , "subdir"     : "."
   , "config"     : "config/tests.config"


### PR DESCRIPTION
Places the next branch of the cryptobox proof into the external CI.

This PR is meant to also try to figure out what is a good process to impose on external CI contributions.