### PR TITLE
[external ci] add xsalsa security

### DIFF
--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -40,4 +40,15 @@
   , "scenario"   : "cryptobox"
   , "options"    : "-pragmas Proofs:weak"
   }
+
+  ,
+
+  { "name"       : "xsalsa20"
+  , "repository" : "https://gitlab.com/fdupress/ec-xsalsa"
+  , "branch"     : "master"
+  , "subdir"     : "."
+  , "config"     : "config/tests.config"
+  , "scenario"   : "xsalsa"
+  , "options"    : "-pragmas Proofs:weak"
+  }
 ]


### PR DESCRIPTION
Add the XSalsa20 security proof (and general proof for PRF cascades) to the external CI.