### PR TITLE
Simplify/clean up memory/call restrictions.

### DIFF
--- a/src/ecAst.mli
+++ b/src/ecAst.mli
@@ -124,17 +124,17 @@ and oracle_info = {
   oi_calls : xpath list;
 }
 
+and oracle_infos = oracle_info Msym.t
+
 and mod_restr = {
   mr_xpaths : mr_xpaths;
   mr_mpaths : mr_mpaths;
-  mr_oinfos : oracle_info Msym.t;
 }
 
 and module_type = {
   mt_params : (EcIdent.t * module_type) list;
   mt_name   : EcPath.path;
   mt_args   : EcPath.mpath list;
-  mt_restr  : mod_restr;
 }
 
 (* -------------------------------------------------------------------- *)
@@ -159,9 +159,11 @@ and memenv = memory * memtype
 (* -------------------------------------------------------------------- *)
 and gty =
   | GTty    of ty
-  | GTmodty of module_type
+  | GTmodty of mty_mr
   | GTmem   of memtype
 
+and mty_mr = module_type * mod_restr  
+  
 and binding  = (EcIdent.t * gty)
 and bindings = binding list
 
@@ -361,6 +363,11 @@ val mr_fv    : mod_restr fv
 
 val mty_equal : module_type equality
 val mty_hash  : module_type hash
+val mty_fv    : module_type fv
+
+val mty_mr_equal : mty_mr equality
+val mty_mr_hash  : mty_mr hash
+val mty_mr_fv    : mty_mr fv
 
 val mr_tostring : mod_restr -> string
 

--- a/src/ecBaseLogic.ml
+++ b/src/ecBaseLogic.ml
@@ -1,4 +1,5 @@
 (* -------------------------------------------------------------------- *)
+open EcAst
 open EcTypes
 open EcCoreFol
 
@@ -6,7 +7,7 @@ open EcCoreFol
 type local_kind =
 | LD_var    of ty * form option
 | LD_mem    of EcMemory.memtype
-| LD_modty  of EcModules.module_type
+| LD_modty  of mty_mr
 | LD_hyp    of form
 | LD_abs_st of EcModules.abs_uses
 

--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -74,7 +74,7 @@ let gty_fv = EcAst.gty_fv
 let gtty (ty : EcTypes.ty) =
   GTty ty
 
-let gtmodty (mt : module_type) =
+let gtmodty (mt : mty_mr) =
   GTmodty mt
 
 let gtmem (mt : EcMemory.memtype) =

--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcBigInt
 open EcPath
+open EcAst
 open EcMaps
 open EcIdent
 open EcTypes
@@ -41,12 +42,12 @@ type mod_restr = EcAst.mod_restr
 
 (* -------------------------------------------------------------------- *)
 val gtty    : EcTypes.ty -> gty
-val gtmodty : module_type -> gty
+val gtmodty : mty_mr -> gty
 val gtmem   : EcMemory.memtype -> gty
 
 (* -------------------------------------------------------------------- *)
 val as_gtty  : gty -> EcTypes.ty
-val as_modty : gty -> module_type
+val as_modty : gty -> mty_mr
 val as_mem   : gty -> EcMemory.memtype
 
 (* -------------------------------------------------------------------- *)
@@ -86,7 +87,7 @@ val form_forall: (form -> bool) -> form -> bool
 (* -------------------------------------------------------------------- *)
 val gty_as_ty  : gty -> EcTypes.ty
 val gty_as_mem : gty -> EcMemory.memtype
-val gty_as_mod : gty -> module_type
+val gty_as_mod : gty -> mty_mr
 val kind_of_gty: gty -> [`Form | `Mem | `Mod]
 
 (* soft-constructors - common leaves *)

--- a/src/ecCoreModules.ml
+++ b/src/ecCoreModules.ml
@@ -316,8 +316,8 @@ type mod_restr = EcAst.mod_restr
 let mr_equal = EcAst.mr_equal
 let mr_hash  = EcAst.mr_hash
 
-let mr_is_empty mr =
-  Msym.for_all (fun _ oi -> [] = PreOI.allowed oi) mr.mr_oinfos
+let ois_is_empty (ois : oracle_infos) =
+  Msym.for_all (fun _ oi -> [] = PreOI.allowed oi) ois
 
 let mr_xpaths_fv (m : mr_xpaths) : int Mid.t =
   EcPath.Sx.fold
@@ -359,7 +359,7 @@ type module_sig_body = module_sig_body_item list
 type module_sig = {
   mis_params : (EcIdent.t * module_type) list;
   mis_body   : module_sig_body;
-  mis_restr  : mod_restr;
+  mis_oinfos : oracle_infos;
 }
 
 type top_module_sig = {
@@ -447,20 +447,17 @@ type abs_uses = {
 
 type module_expr = {
   me_name     : symbol;
+  me_params   : (EcIdent.t * module_type) list;
   me_body     : module_body;
   me_comps    : module_comps;
   me_sig_body : module_sig_body;
-  me_params   : (EcIdent.t * module_type) list;
+  me_oinfos   : oracle_infos;
 }
 
-(* Invariant:
-   In an abstract module [ME_Decl mt], [mt] must not be a functor, i.e. it must
-   be fully applied. Therefore, we must have:
-   [List.length mp.mt_params = List.length mp.mt_args]  *)
 and module_body =
   | ME_Alias       of int * EcPath.mpath
   | ME_Structure   of module_structure       (* Concrete modules. *)
-  | ME_Decl        of module_type         (* Abstract modules. *)
+  | ME_Decl        of mty_mr                 (* Abstract modules. *)
 
 and module_structure = {
   ms_body      : module_item list;

--- a/src/ecCoreModules.mli
+++ b/src/ecCoreModules.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcSymbols
 open EcPath
+open EcAst
 open EcTypes
 
 (* -------------------------------------------------------------------- *)
@@ -133,7 +134,7 @@ val mr_equal :
 
 val mr_hash : mod_restr -> int
 
-val mr_is_empty : mod_restr -> bool
+val ois_is_empty : oracle_infos -> bool
 
 val mr_xpaths_fv : mr_xpaths -> int EcIdent.Mid.t
 val mr_mpaths_fv : mr_mpaths -> int EcIdent.Mid.t
@@ -149,7 +150,7 @@ type module_sig_body = module_sig_body_item list
 type module_sig = {
   mis_params : (EcIdent.t * module_type) list;
   mis_body   : module_sig_body;
-  mis_restr  : mod_restr;
+  mis_oinfos : oracle_infos;
 }
 
 type top_module_sig = {
@@ -206,10 +207,11 @@ type abs_uses = {
 
 type module_expr = {
   me_name     : symbol;
+  me_params   : (EcIdent.t * module_type) list;
   me_body     : module_body;
   me_comps    : module_comps;
   me_sig_body : module_sig_body;
-  me_params   : (EcIdent.t * module_type) list;
+  me_oinfos   : oracle_infos;
 }
 
 (* Invariant:
@@ -219,10 +221,10 @@ type module_expr = {
 and module_body =
   | ME_Alias       of int * EcPath.mpath
   | ME_Structure   of module_structure       (* Concrete modules. *)
-  | ME_Decl        of module_type         (* Abstract modules. *)
+  | ME_Decl        of mty_mr                 (* Abstract modules. *)
 
 and module_structure = {
-  ms_body      : module_item list;
+  ms_body : module_item list;
 }
 
 and module_item =

--- a/src/ecCorePrinting.ml
+++ b/src/ecCorePrinting.ml
@@ -68,8 +68,6 @@ module type PrinterAPI = sig
   val pp_added_op    : PPEnv.t -> operator pp
   val pp_axiom       : ?long:bool -> PPEnv.t -> (path * axiom     ) pp
   val pp_theory      : PPEnv.t -> (path * ctheory                 ) pp
-  val pp_restr_s     :            (bool                           ) pp
-  val pp_restr       : PPEnv.t -> (mod_restr                      ) pp
   val pp_modtype1    : PPEnv.t -> (module_type                    ) pp
   val pp_modtype     : PPEnv.t -> (module_type                    ) pp
   val pp_modexp      : PPEnv.t -> (mpath * module_expr            ) pp
@@ -109,12 +107,6 @@ module type PrinterAPI = sig
     val pr_db  : Format.formatter -> EcEnv.env -> db -> unit
     val pr_any : Format.formatter -> EcEnv.env -> qsymbol -> unit
   end
-
-  (* ------------------------------------------------------------------ *)
-  val pp_use : PPEnv.t -> Format.formatter -> EcEnv.use -> unit
-  val pp_use_restr :
-    EcEnv.env -> print_abstract:bool ->
-    Format.formatter -> EcEnv.use EcModules.use_restr -> unit
 end
 
 (* ==================================================================== *)

--- a/src/ecCoreSubst.mli
+++ b/src/ecCoreSubst.mli
@@ -94,16 +94,17 @@ module Fsubst : sig
   val add_binding  : binding subst_binder
   val add_bindings : bindings subst_binder
 
-  val lp_subst  : lpattern    subst_binder
-  val mp_subst  : mpath       substitute
-  val x_subst   : xpath       substitute
-  val pv_subst  : prog_var    substitute
-  val s_subst   : stmt        substitute
-  val e_subst   : expr        substitute
-  val me_subst  : memenv      substitute
-  val m_subst   : EcIdent.t   substitute
-  val mr_subst  : mod_restr   substitute
-  val mty_subst : module_type substitute
-  val oi_subst  : PreOI.t     substitute
-  val gty_subst : gty         substitute
+  val lp_subst     : lpattern    subst_binder
+  val mp_subst     : mpath       substitute
+  val x_subst      : xpath       substitute
+  val pv_subst     : prog_var    substitute
+  val s_subst      : stmt        substitute
+  val e_subst      : expr        substitute
+  val me_subst     : memenv      substitute
+  val m_subst      : EcIdent.t   substitute
+  val mr_subst     : mod_restr   substitute
+  val mty_subst    : module_type substitute
+  val mty_mr_subst : mty_mr substitute
+  val oi_subst     : PreOI.t     substitute
+  val gty_subst    : gty         substitute
 end

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcPath
 open EcSymbols
+open EcAst
 open EcTypes
 open EcMemory
 open EcDecl
@@ -186,9 +187,11 @@ module Mod : sig
   val bind  : ?import:import -> symbol -> t -> env -> env
   val enter : symbol -> (EcIdent.t * module_type) list -> env -> env
 
-  val bind_local    : EcIdent.t -> module_type -> env -> env
-  val bind_locals   : (EcIdent.t * module_type) list -> env -> env
-  val declare_local : EcIdent.t -> module_type -> env -> env
+  val bind_local    : EcIdent.t -> mty_mr -> env -> env
+  val bind_locals   : (EcIdent.t * mty_mr) list -> env -> env
+  val bind_param    : EcIdent.t -> module_type -> env -> env
+  val bind_params   : (EcIdent.t * module_type) list -> env -> env
+  val declare_local : EcIdent.t -> mty_mr -> env -> env
   val is_declared   : EcIdent.t -> env -> bool
 
   val add_restr_to_locals : Sx.t use_restr -> Sm.t use_restr -> env -> env
@@ -216,10 +219,7 @@ module ModTy : sig
   val add  : path -> env -> env
   val bind : ?import:import -> symbol -> t -> env -> env
 
-  val mod_type_equiv :
-    (form -> form -> bool) -> env -> module_type -> module_type -> bool
-  val has_mod_type : env -> module_type list -> module_type -> bool
-  val sig_of_mt :  env -> module_type -> module_sig
+  val sig_of_mt : env -> module_type -> module_sig
 end
 
 (* -------------------------------------------------------------------- *)
@@ -240,8 +240,6 @@ module NormMp : sig
   val fun_use       : env -> xpath -> use
   val restr_use     : env -> mod_restr -> use use_restr
   val get_restr_use : env -> mpath -> use use_restr
-  val get_restr_me  : env -> module_expr -> mpath -> mod_restr
-  val get_restr     : env -> mpath -> mod_restr
 
   val sig_of_mp     : env -> mpath -> module_sig
 
@@ -255,6 +253,8 @@ module NormMp : sig
   val is_abstract_fun : xpath -> env -> bool
   val x_equal         : env -> xpath -> xpath -> bool
   val pv_equal        : env -> EcTypes.prog_var -> EcTypes.prog_var -> bool
+
+  val mod_type_equiv : env -> mty_mr -> mty_mr -> bool
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -717,11 +717,7 @@ let f_match_core opts hyps (ue, ev) f1 f2 =
             in (env, subst)
 
         | GTmodty p1, GTmodty p2 ->
-          let f_equiv f1 f2 =
-            try doit env (subst, mxs) f1 f2; true
-            with MatchFailure -> false in
-
-            if not (ModTy.mod_type_equiv f_equiv env p1 p2) then
+            if not (NormMp.mod_type_equiv env p1 p2) then
               raise MatchFailure;
 
             let subst =

--- a/src/ecModules.ml
+++ b/src/ecModules.ml
@@ -16,35 +16,31 @@ module OI = PreOI
 let mr_empty = {
   mr_xpaths = ur_empty EcPath.Sx.empty;
   mr_mpaths = ur_empty EcPath.Sm.empty;
-  mr_oinfos = Msym.empty;
 }
 
 let mr_full = {
   mr_xpaths = ur_full EcPath.Sx.empty;
   mr_mpaths = ur_full EcPath.Sm.empty;
-  mr_oinfos = Msym.empty;
 }
 
 let mr_add_restr mr (rx : Sx.t use_restr) (rm : Sm.t use_restr) =
   { mr_xpaths = ur_union Sx.union Sx.inter mr.mr_xpaths rx;
-    mr_mpaths = ur_union Sm.union Sm.inter mr.mr_mpaths rm;
-    mr_oinfos = mr.mr_oinfos; }
+    mr_mpaths = ur_union Sm.union Sm.inter mr.mr_mpaths rm; }
 
-let change_oinfo restr f oi =
-  { restr with mr_oinfos = Msym.add f oi restr.mr_oinfos }
+let change_oinfo (ois : oracle_infos) (f : symbol) (oi : oracle_info) =
+  Msym.add f oi ois
 
-let add_oinfo restr f oi = change_oinfo restr f oi
+let oicalls_filter (ois : oracle_infos) (f : symbol) (filter : xpath -> bool) =
+  match Msym.find f ois with
+  | oi -> change_oinfo ois f (OI.filter filter oi)
+  | exception Not_found -> ois
 
-let oicalls_filter restr f filter =
-  match Msym.find f restr.mr_oinfos with
-  | oi -> change_oinfo restr f (OI.filter filter oi)
-  | exception Not_found -> restr
-
-let change_oicalls restr f ocalls =
-  let oi = match Msym.find f restr.mr_oinfos with
+let change_oicalls (ois : oracle_infos) (f : symbol) (ocalls : xpath list) =
+  let oi =
+    match Msym.find f ois with
     | oi -> OI.filter (fun x -> List.mem x ocalls) oi
-    | exception Not_found -> OI.mk ocalls in
-  add_oinfo restr f oi
+    | exception Not_found -> OI.mk ocalls
+  in change_oinfo ois f oi
 
 (* -------------------------------------------------------------------- *)
 let mty_hash  = EcCoreFol.mty_hash

--- a/src/ecModules.mli
+++ b/src/ecModules.mli
@@ -1,4 +1,5 @@
 (* -------------------------------------------------------------------- *)
+open EcAst
 open EcPath
 
 (* -------------------------------------------------------------------- *)
@@ -31,13 +32,8 @@ val mr_empty : mod_restr
 val mr_full  : mod_restr
 
 val mr_add_restr :
-  mod_restr -> EcPath.Sx.t use_restr -> EcPath.Sm.t use_restr -> mod_restr
+  mod_restr -> Sx.t use_restr -> Sm.t use_restr -> mod_restr
 
-val add_oinfo :
-  mod_restr -> string -> OI.t -> mod_restr
+val change_oicalls : oracle_infos -> string -> xpath list -> oracle_infos
 
-val change_oicalls :
-  mod_restr -> string -> xpath list -> mod_restr
-
-val oicalls_filter :
-  mod_restr -> EcSymbols.Msym.key -> (EcPath.xpath -> bool) -> mod_restr
+val oicalls_filter : oracle_infos -> string -> (xpath -> bool) -> oracle_infos

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1642,19 +1642,10 @@ oracle_restr:
 (* -------------------------------------------------------------------- *)
 (* Module restrictions *)
 
-mod_restr_el:
-  | f=lident COLON orcls=option(oracle_restr)
-    { { pmre_name = f; pmre_orcls = orcls; } }
-
 mod_restr:
   | LBRACE mr=mem_restr RBRACE
-    { { pmr_mem = mr; pmr_procs = [] } }
-  | LBRACKET l=rlist1(mod_restr_el,COMMA) RBRACKET
-    { { pmr_mem = []; pmr_procs = l } }
-  | LBRACE mr=mem_restr RBRACE LBRACKET l=rlist1(mod_restr_el,COMMA) RBRACKET
-    { { pmr_mem = mr;	pmr_procs = l } }
-  | LBRACKET l=rlist1(mod_restr_el,COMMA) RBRACKET LBRACE mr=mem_restr RBRACE
-    { { pmr_mem = mr;	pmr_procs = l } }
+    { { pmr_mem = mr } }
+
 
 (* -------------------------------------------------------------------- *)
 (* Modules interfaces                                                   *)
@@ -1670,11 +1661,11 @@ mod_restr:
     { { pmty_pq = x; pmty_mem = Some mr; } }
 
 sig_def:
-| pi_locality=loc(locality) MODULE TYPE pi_name=uident args=sig_params* mr=mod_restr? EQ i=sig_body
+| pi_locality=loc(locality) MODULE TYPE pi_name=uident args=sig_params* EQ i=sig_body
     { let pi_sig =
         Pmty_struct { pmsig_params = List.flatten args;
                       pmsig_body   = i;
-			                pmsig_restr  = mr; } in
+			               } in
       { pi_name; pi_sig; pi_locality = locality_as_local pi_locality; } }
 
 sig_body:

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -260,7 +260,6 @@ and pmod_restr_el = {
 
 and pmod_restr = {
   pmr_mem   : pmod_restr_mem;
-	pmr_procs : pmod_restr_el list;
  }
 
 (* -------------------------------------------------------------------- *)
@@ -270,7 +269,6 @@ and pmodule_sig =
 and pmodule_sig_struct = {
   pmsig_params : (psymbol * pmodule_type) list;
   pmsig_body   : pmodule_sig_struct_body;
-  pmsig_restr  : pmod_restr option;
 }
 
 and pmodule_sig_struct_body = pmodule_sig_item list

--- a/src/ecProofTerm.ml
+++ b/src/ecProofTerm.ml
@@ -791,7 +791,7 @@ and apply_pterm_to_local ?loc pt id =
   | LD_var (ty, _) ->
       apply_pterm_to_arg_r ?loc pt (PVAFormula (f_local id ty))
 
-  | LD_modty mty ->
+  | LD_modty (mty, _) ->
       let env  = LDecl.toenv pt.ptev_env.pte_hy in
       let msig = EcEnv.ModTy.sig_of_mt env mty in
       apply_pterm_to_arg_r ?loc pt (PVAModule (EcPath.mident id, msig))

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -99,8 +99,8 @@ val is_conv    : ?ri:reduction_info -> LDecl.hyps -> form -> form -> bool
 val check_conv : ?ri:reduction_info -> LDecl.hyps -> form -> form -> unit
 
 val check_bindings :
-  exn -> EcDecl.ty_params -> EcEnv.env -> EcSubst.subst ->
-  (EcIdent.t * EcFol.gty) list -> (EcIdent.t * EcFol.gty) list ->
+  exn -> EcEnv.env -> EcSubst.subst ->
+  bindings -> bindings ->
   EcEnv.env * EcSubst.subst
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecSection.mli
+++ b/src/ecSection.mli
@@ -1,5 +1,5 @@
 (* -------------------------------------------------------------------- *)
-open EcModules
+open EcAst
 open EcEnv
 open EcTheory
 
@@ -9,7 +9,7 @@ exception SectionError of string
 (* -------------------------------------------------------------------- *)
 type sc_item =
   | SC_th_item  of theory_item
-  | SC_decl_mod of EcIdent.t * module_type
+  | SC_decl_mod of EcIdent.t * mty_mr
 
 (* -------------------------------------------------------------------- *)
 type scenv
@@ -19,7 +19,7 @@ val env : scenv -> env
 val initial : env -> scenv
 
 val add_item     : theory_item -> scenv -> scenv
-val add_decl_mod : EcIdent.t -> module_type -> scenv -> scenv
+val add_decl_mod : EcIdent.t -> mty_mr -> scenv -> scenv
 
 val enter_section : EcSymbols.symbol option -> scenv -> scenv
 val exit_section  : EcSymbols.symbol option -> scenv -> scenv

--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -639,6 +639,10 @@ and subst_oracle_info (s : subst) (oi : OI.t) =
   OI.mk (List.map (subst_xpath s) (PreOI.allowed oi))
 
 (* -------------------------------------------------------------------- *)
+and subst_oracle_infos (s : subst) (ois : oracle_infos) =
+  EcSymbols.Msym.map (fun oi -> subst_oracle_info s oi) ois
+
+    (* -------------------------------------------------------------------- *)
 and subst_mod_restr (s : subst) (mr : mod_restr) =
   let rx = ur_app (fun set -> EcPath.Sx.fold (fun x r ->
       EcPath.Sx.add (subst_xpath s x) r
@@ -646,9 +650,7 @@ and subst_mod_restr (s : subst) (mr : mod_restr) =
   let r = ur_app (fun set -> EcPath.Sm.fold (fun x r ->
       EcPath.Sm.add (subst_mpath s x) r
     ) set EcPath.Sm.empty) mr.mr_mpaths in
-  let ois = EcSymbols.Msym.map (fun oi ->
-      subst_oracle_info s oi) mr.mr_oinfos in
-  { mr_xpaths = rx; mr_mpaths = r; mr_oinfos = ois }
+  { mr_xpaths = rx; mr_mpaths = r; }
 
 (* -------------------------------------------------------------------- *)
 and subst_modsig_body_item (s : subst) (item : module_sig_body_item) =
@@ -686,8 +688,7 @@ and subst_modsig ?params (s : subst) (comps : module_sig) =
   let comps =
     { mis_params = newparams;
       mis_body   = subst_modsig_body sbody comps.mis_body;
-      mis_restr  = subst_mod_restr sbody comps.mis_restr;
-    }
+      mis_oinfos = subst_oracle_infos sbody comps.mis_oinfos; }
   in
     (sbody, comps)
 
@@ -700,8 +701,12 @@ and subst_modtype (s : subst) (modty : module_type) =
 
   { mt_params = List.map (snd_map (subst_modtype s)) modty.mt_params;
     mt_name   = mt_name;
-    mt_args   = List.map (subst_mpath s) modty.mt_args;
-    mt_restr = subst_mod_restr s modty.mt_restr; }
+    mt_args   = List.map (subst_mpath s) modty.mt_args; }
+
+
+(* -------------------------------------------------------------------- *)
+and subst_mty_mr (s : subst) ((mty, mr) : mty_mr) =
+  subst_modtype s mty, subst_mod_restr s mr
 
 (* -------------------------------------------------------------------- *)
 and subst_gty (s : subst) (ty : gty) =
@@ -710,7 +715,7 @@ and subst_gty (s : subst) (ty : gty) =
      GTty (subst_ty s ty)
 
   | GTmodty mty ->
-     GTmodty (subst_modtype s mty)
+     GTmodty (subst_mty_mr s mty)
 
   | GTmem m ->
      GTmem (EcMemory.mt_subst (subst_ty s) m)
@@ -789,7 +794,7 @@ and subst_module_body (s : subst) (body : module_body) =
   | ME_Structure bstruct ->
       ME_Structure (subst_module_struct s bstruct)
 
-  | ME_Decl p -> ME_Decl (subst_modtype s p)
+  | ME_Decl p -> ME_Decl (subst_mty_mr s p)
 
 (* -------------------------------------------------------------------- *)
 and subst_module_comps (s : subst) (comps : module_comps) =
@@ -810,7 +815,8 @@ and subst_module (s : subst) (m : module_expr) =
   let me_body = subst_module_body sbody m.me_body in
   let me_comps = subst_module_comps sbody m.me_comps in
   let me_sig_body = subst_modsig_body sbody m.me_sig_body in
-  { me_name = m.me_name; me_body; me_comps; me_params; me_sig_body }
+  let me_oinfos = subst_oracle_infos sbody m.me_oinfos in
+  { me_name = m.me_name; me_params; me_body; me_comps; me_sig_body; me_oinfos; }
 
 (* -------------------------------------------------------------------- *)
 let subst_modsig ?params (s : subst) (comps : module_sig) =

--- a/src/ecSubst.mli
+++ b/src/ecSubst.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcIdent
 open EcPath
+open EcAst
 open EcModules
 open EcTypes
 open EcTheory
@@ -60,6 +61,7 @@ val subst_modsig       : ?params:(ident list) -> subst -> module_sig -> module_s
 val subst_top_modsig   : subst -> top_module_sig -> top_module_sig
 val subst_modsig_body  : subst -> module_sig_body -> module_sig_body
 val subst_mod_restr    : subst -> mod_restr -> mod_restr
+val subst_oracle_infos : subst -> oracle_infos -> oracle_infos
 
 (* -------------------------------------------------------------------- *)
 val subst_gty   : subst -> gty -> gty

--- a/src/ecTheory.ml
+++ b/src/ecTheory.ml
@@ -79,10 +79,10 @@ let mkitem (import : import) (item : theory_item_r) =
   { ti_import = import; ti_item = item; }
 
 (* -------------------------------------------------------------------- *)
-let module_comps_of_module_sig_comps (comps : module_sig_body) restr =
+let module_comps_of_module_sig_comps (comps : module_sig_body) (ois : oracle_infos) =
   let onitem = function
     | Tys_function funsig ->
-      let oi = Msym.find funsig.fs_name restr.mr_oinfos in
+      let oi = Msym.find funsig.fs_name ois in
         MI_Function {
           f_name = funsig.fs_name;
           f_sig  = funsig;
@@ -92,13 +92,15 @@ let module_comps_of_module_sig_comps (comps : module_sig_body) restr =
     List.map onitem comps
 
 (* -------------------------------------------------------------------- *)
-let module_expr_of_module_sig name mp tymod =
+let module_expr_of_module_sig (name : EcIdent.t) ((mty, mr) : mty_mr) (sig_ : module_sig) =
   (* Abstract modules must be fully applied. *)
-  assert (List.length mp.mt_params = List.length mp.mt_args);
+  assert (List.length mty.mt_params = List.length mty.mt_args);
 
-  let tycomps = module_comps_of_module_sig_comps tymod.mis_body mp.mt_restr in
-    { me_name     = EcIdent.name name;
-      me_body     = ME_Decl mp;
-      me_comps    = tycomps;
-      me_sig_body = tymod.mis_body;
-      me_params   = tymod.mis_params ; }
+  let tycomps = module_comps_of_module_sig_comps sig_.mis_body sig_.mis_oinfos in
+
+  { me_name     = EcIdent.name name;
+    me_params   = sig_.mis_params ;
+    me_body     = ME_Decl (mty, mr);
+    me_comps    = tycomps;
+    me_sig_body = sig_.mis_body;
+    me_oinfos   = sig_.mis_oinfos; }

--- a/src/ecTheory.mli
+++ b/src/ecTheory.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcSymbols
 open EcPath
+open EcAst
 open EcTypes
 open EcDecl
 open EcModules
@@ -74,5 +75,4 @@ and rule_option = {
 val mkitem : import -> theory_item_r -> theory_item
 
 (* -------------------------------------------------------------------- *)
-val module_expr_of_module_sig:
-  EcIdent.t -> module_type -> module_sig -> module_expr
+val module_expr_of_module_sig : EcIdent.t -> mty_mr -> module_sig -> module_expr

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -212,7 +212,7 @@ and ind_compatible exn env pi1 pi2 =
 
 and prctor_compatible exn env s prc1 prc2 =
   error_body exn (EcSymbols.sym_equal prc1.prc_ctor prc2.prc_ctor);
-  let env, s = EcReduction.check_bindings exn [] env s prc1.prc_bds prc2.prc_bds in
+  let env, s = EcReduction.check_bindings exn env s prc1.prc_bds prc2.prc_bds in
   error_body exn (List.length prc1.prc_spec = List.length prc2.prc_spec);
   let doit f1 f2 =
     error_body exn (EcReduction.is_conv (EcEnv.LDecl.init env []) f1 (EcSubst.subst_form s f2)) in

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcSymbols
+open EcAst
 open EcEnv
 open EcDecl
 open EcPath
@@ -235,7 +236,7 @@ val trans_memtype :
 
 (* -------------------------------------------------------------------- *)
 val trans_restr_for_modty :
-  env -> module_type -> pmod_restr option -> module_type
+  env -> module_type -> pmod_restr option -> mty_mr
 
 val transmodsig  : env -> pinterface -> top_module_sig
 val transmodtype : env -> pmodule_type -> module_type * module_sig
@@ -262,7 +263,7 @@ val check_mem_restr_fun :
   env -> xpath -> mod_restr -> unit
 
 val check_modtype :
-  env -> mpath -> module_sig -> module_type -> unit
+  env -> mpath -> module_sig -> mty_mr -> unit
 
 (* -------------------------------------------------------------------- *)
 val get_ring  : (ty_params * ty) -> env -> EcDecl.ring  option

--- a/src/phl/ecPhlFun.ml
+++ b/src/phl/ecPhlFun.ml
@@ -42,16 +42,15 @@ let check_concrete pf env f =
 
 (* -------------------------------------------------------------------- *)
 let lossless_hyps env top sub =
-  let clear_to_top restr =
+  let clear_to_top =
     let mr_mpaths = { (ur_empty Sm.empty) with ur_neg = Sm.singleton top } in
-    { restr with mr_xpaths = ur_empty Sx.empty;
-                 mr_mpaths = mr_mpaths } in
+    { mr_xpaths = ur_empty Sx.empty; mr_mpaths = mr_mpaths } in
 
   let sig_ = EcEnv.NormMp.sig_of_mp env top in
   let bd =
     List.map
       (fun (id, mt) ->
-         (id, GTmodty { mt with mt_restr = clear_to_top mt.mt_restr } )
+         (id, GTmodty (mt, clear_to_top))
       ) sig_.mis_params
   in
   (* WARN: this implies that the oracle do not have access to top *)
@@ -59,7 +58,7 @@ let lossless_hyps env top sub =
   let concl = f_losslessF (EcPath.xpath (EcPath.m_apply top args) sub) in
   let calls =
     let name = sub in
-    (EcSymbols.Msym.find name sig_.mis_restr.mr_oinfos) |> OI.allowed
+    (EcSymbols.Msym.find name sig_.mis_oinfos) |> OI.allowed
   in
   let hyps = List.map f_losslessF calls in
     f_forall bd (f_imps hyps concl)


### PR DESCRIPTION
Memory restrictions can now only be decorators of modules types in top-level abstract module declarations / quantifications.

Call restrictions can now only be decorators of procedure declarations in module types.