### PR TITLE
cleanup: remove the `dump` command

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3535,27 +3535,6 @@ tactics_or_prf:
 | PROOF        { `Proof    }
 
 (* -------------------------------------------------------------------- *)
-tcd_toptactic:
-| t=toptactic {
-    let l1 = $startpos(t) in
-    let l2 = $endpos(t) in
-
-    if l1.L.pos_fname <> l2.L.pos_fname then
-      parse_error
-        (EcLocation.make $startpos $endpos)
-        (Some "<dump> command cannot span multiple files");
-    ((l1.L.pos_fname, (l1.L.pos_cnum, l2.L.pos_cnum)), t)
-  }
-
-tactic_dump:
-| DUMP aout=STRING wd=word? t=paren(tcd_toptactic)
-  {  let infos = {
-      tcd_source = fst t;
-      tcd_width  = wd;
-      tcd_output = aout;
-    } in (infos, snd t) }
-
-(* -------------------------------------------------------------------- *)
 (* Theory cloning                                                       *)
 
 theory_clone:
@@ -3847,7 +3826,6 @@ global_action:
 | reduction        { Greduction   $1 }
 | axiom            { Gaxiom       $1 }
 | tactics_or_prf   { Gtactics     $1 }
-| tactic_dump      { Gtcdump      $1 }
 | x=loc(realize)   { Grealize     x  }
 | gprover_info     { Gprover_info $1 }
 | addrw            { Gaddrw       $1 }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1200,13 +1200,6 @@ type proofmode = {
 }
 
 (* -------------------------------------------------------------------- *)
-type tcdump = {
-  tcd_source : string * (int * int);
-  tcd_width  : int option;
-  tcd_output : string;
-}
-
-(* -------------------------------------------------------------------- *)
 type save = [ `Qed | `Admit | `Abort ]
 
 (* -------------------------------------------------------------------- *)
@@ -1261,7 +1254,6 @@ type global_action =
   | GsctClose    of osymbol_r
   | Grealize     of prealize located
   | Gtactics     of [`Proof | `Actual of ptactic list]
-  | Gtcdump      of (tcdump * ptactic list)
   | Gprover_info of pprover_infos
   | Gsave        of save located
   | Gpragma      of psymbol


### PR DESCRIPTION
The `dump` allowed to prettify EasyCrypt files. It was unmaintained and is not used by any known project.