### PR TITLE
[pretty-printing]: pretty-print in the theory environment of the targ…

### DIFF
--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -184,6 +184,11 @@ type preenv = {
   env_modlcs   : Sid.t;                 (* declared modules *)
   env_item     : theory_item list;      (* in reverse order *)
   env_norm     : env_norm ref;
+  (* Map theory paths to their env before just before theory was closed. *)
+  (* The environment should be incuded for all theories, including       *)
+  (* abstract ones. The purpose of this map is to simplify the code      *)
+  (* related to pretty-printing.                                         *)
+  env_thenvs   : preenv Mp.t;
 }
 
 and escope = {
@@ -302,7 +307,8 @@ let empty gstate =
     env_ntbase   = Mop.empty;
     env_modlcs   = Sid.empty;
     env_item     = [];
-    env_norm     = ref empty_norm_cache; }
+    env_norm     = ref empty_norm_cache;
+    env_thenvs   = Mp.empty; }
 
 (* -------------------------------------------------------------------- *)
 let copy (env : env) =
@@ -2884,6 +2890,14 @@ module Theory = struct
   type t    = ctheory
   type mode = [`All | thmode]
 
+  type compiled = env Mp.t
+
+  type compiled_theory = {
+    name     : symbol;
+    ctheory  : t;
+    compiled : compiled;
+  }
+
   (* ------------------------------------------------------------------ *)
   let enter name env =
     enter `Theory name env
@@ -2918,6 +2932,13 @@ module Theory = struct
 
   let lookup_path ?mode name env =
     fst (lookup ?mode name env)
+
+  (* ------------------------------------------------------------------ *)
+  let env_of_theory (p : EcPath.path) (env : env) =
+    if EcPath.isprefix p env.env_scope.ec_path then
+      env
+    else
+      Option.get (Mp.find_opt p env.env_thenvs)
 
   (* ------------------------------------------------------------------ *)
   let rec bind_instance_th path inst cth =
@@ -3035,26 +3056,41 @@ module Theory = struct
     in bind_base_th for1
 
   (* ------------------------------------------------------------------ *)
-  let bind ?(import = import0) name ({ cth_items = items; cth_mode = mode } as cth) env =
-    let env = MC.bind_theory name cth env in
-    let env = { env with env_item = mkitem import (Th_theory (name, cth)) :: env.env_item } in
+  let bind
+    ?(import = import0)
+     (cth  : compiled_theory)
+     (env : env)
+  =
+    let { cth_items = items; cth_mode = mode; } = cth.ctheory in
+    let env = MC.bind_theory cth.name cth.ctheory env in
+    let env = {
+      env with
+        env_item = mkitem import (Th_theory (cth.name, cth.ctheory)) :: env.env_item }
+    in
 
-    match import, mode with
-    | _, `Concrete ->
-        let thname      = EcPath.pqname (root env) name in
-        let env_tci     = bind_instance_th thname env.env_tci items in
-        let env_tc      = bind_tc_th thname env.env_tc items in
-        let env_rwbase  = bind_br_th thname env.env_rwbase items in
-        let env_atbase  = bind_at_th thname env.env_atbase items in
-        let env_ntbase  = bind_nt_th thname env.env_ntbase items in
-        let env_redbase = bind_rd_th thname env.env_redbase items in
-        let env =
-          { env with env_tci; env_tc; env_rwbase; env_atbase; env_ntbase; env_redbase; }
-        in
-        add_restr_th thname env items
+    let env =
+      match import, mode with
+      | _, `Concrete ->
+          let thname      = EcPath.pqname (root env) cth.name in
+          let env_tci     = bind_instance_th thname env.env_tci items in
+          let env_tc      = bind_tc_th thname env.env_tc items in
+          let env_rwbase  = bind_br_th thname env.env_rwbase items in
+          let env_atbase  = bind_at_th thname env.env_atbase items in
+          let env_ntbase  = bind_nt_th thname env.env_ntbase items in
+          let env_redbase = bind_rd_th thname env.env_redbase items in
+          let env =
+            { env with
+                env_tci   ; env_tc     ; env_rwbase;
+                env_atbase; env_ntbase; env_redbase; }
+          in
+          add_restr_th thname env items
 
-    | _, _ ->
-        env
+      | _, _ ->
+          env
+    in
+
+    { env with
+        env_thenvs = Mp.set_union env.env_thenvs cth.compiled }
 
   (* ------------------------------------------------------------------ *)
   let rebind name th env =
@@ -3175,7 +3211,15 @@ module Theory = struct
       in (cleared, omap (fun item_r -> { item with ti_item = item_r; }) item_r)
 
   (* ------------------------------------------------------------------ *)
-  let close ?(clears = []) ?(pempty = `No) loca mode env =
+  type clear_mode = [`Full | `ClearOnly | `No]
+
+  let close
+    ?(clears : path list = [])
+    ?(pempty : clear_mode = `No)
+     (loca   : is_local)
+     (mode   : thmode)
+     (env    : env)
+  =
     let items = List.rev env.env_item in
     let items =
       if   List.is_empty clears
@@ -3189,35 +3233,47 @@ module Theory = struct
     in
 
     items |> omap (fun items ->
-                 { cth_items = items;
-                   cth_source = None;
-                   cth_loca   = loca;
-                   cth_mode   = mode;
-               })
+      let ctheory =
+        { cth_items  = items
+        ; cth_source = None
+        ; cth_loca   = loca
+        ; cth_mode   = mode
+        } in
+
+      let root = env.env_scope.ec_path in
+      let name = EcPath.basename root in
+
+      let compiled =
+        Mp.filter
+          (fun path _ -> EcPath.isprefix path root)
+          env.env_thenvs in
+      let compiled = Mp.add env.env_scope.ec_path env compiled in
+
+      { name; ctheory; compiled; }
+    )
 
   (* ------------------------------------------------------------------ *)
-  let require x cth env =
-    let rootnm  = EcCoreLib.p_top in
-    let thpath  = EcPath.pqname rootnm x in
+  let require (compiled : compiled_theory) (env : env) =
+    let cth    = compiled.ctheory in
+    let rootnm = EcCoreLib.p_top in
+    let thpath = EcPath.pqname rootnm compiled.name in
 
     let env =
       match cth.cth_mode with
       | `Concrete ->
           let (_, thmc), submcs =
-            MC.mc_of_theory_r rootnm (x, cth)
-          in MC.bind_submc env rootnm ((x, thmc), submcs)
+            MC.mc_of_theory_r rootnm (compiled.name, cth)
+          in MC.bind_submc env rootnm ((compiled.name, thmc), submcs)
 
       | `Abstract -> env
     in
 
-    let th = cth in
-
     let topmc = Mip.find (IPPath rootnm) env.env_comps in
-    let topmc = MC._up_theory false topmc x (IPPath thpath, th) in
+    let topmc = MC._up_theory false topmc compiled.name (IPPath thpath, cth) in
     let topmc = MC._up_mc false topmc (IPPath thpath) in
 
     let current = env.env_current in
-    let current = MC._up_theory true current x (IPPath thpath, th) in
+    let current = MC._up_theory true current compiled.name (IPPath thpath, cth) in
     let current = MC._up_mc true current (IPPath thpath) in
 
     let comps = env.env_comps in
@@ -3226,7 +3282,9 @@ module Theory = struct
     let env = { env with env_current = current; env_comps = comps; } in
 
     match cth.cth_mode with
-    | `Abstract -> env
+    | `Abstract ->
+      { env with
+        env_thenvs  = Mp.set_union env.env_thenvs compiled.compiled; }
 
     | `Concrete ->
       { env with
@@ -3235,7 +3293,8 @@ module Theory = struct
           env_rwbase  = bind_br_th thpath env.env_rwbase cth.cth_items;
           env_atbase  = bind_at_th thpath env.env_atbase cth.cth_items;
           env_ntbase  = bind_nt_th thpath env.env_ntbase cth.cth_items;
-          env_redbase = bind_rd_th thpath env.env_redbase cth.cth_items; }
+          env_redbase = bind_rd_th thpath env.env_redbase cth.cth_items;
+          env_thenvs  = Mp.set_union env.env_thenvs compiled.compiled; }
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -262,17 +262,27 @@ module Theory : sig
   type t    = ctheory
   type mode = [`All | thmode]
 
+  type compiled
+
+  type compiled_theory = private {
+    name     : symbol;
+    ctheory  : t;
+    compiled : compiled;
+  }
+
   val by_path     : ?mode:mode -> path -> env -> t
   val by_path_opt : ?mode:mode -> path -> env -> t option
   val lookup      : ?mode:mode -> qsymbol -> env -> path * t
   val lookup_opt  : ?mode:mode -> qsymbol -> env -> (path * t) option
   val lookup_path : ?mode:mode -> qsymbol -> env -> path
 
+  val env_of_theory : path -> env -> env
+
   val add  : path -> env -> env
-  val bind : ?import:import -> symbol -> ctheory -> env -> env
+  val bind : ?import:import -> compiled_theory -> env -> env
 
  (* FIXME: section ? ctheory -> theory *)
-  val require : symbol -> ctheory -> env -> env
+  val require : compiled_theory -> env -> env
   val import  : path -> env -> env
   val export  : path -> is_local -> env -> env
 
@@ -283,7 +293,7 @@ module Theory : sig
     -> ?pempty:[`Full | `ClearOnly | `No]
     -> EcTypes.is_local
     -> EcTheory.thmode
-    -> env -> ctheory option
+    -> env -> compiled_theory option
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -48,6 +48,10 @@ module PPEnv = struct
       ppe_fb     = Sp.empty;
       ppe_width  = max 20 width; }
 
+  let enter_theory (ppe : t) (p : EcPath.path) =
+    let ppe_env = EcEnv.Theory.env_of_theory p ppe.ppe_env in
+    { ppe with ppe_env }
+
   let enter_by_memid ppe id =
     match EcEnv.Memory.byid id ppe.ppe_env with
     | None   -> ppe
@@ -2029,6 +2033,7 @@ let pp_sform ppe fmt f =
 
 (* -------------------------------------------------------------------- *)
 let pp_typedecl (ppe : PPEnv.t) fmt (x, tyd) =
+  let ppe = PPEnv.enter_theory ppe (Option.get (EcPath.prefix x)) in
   let ppe = PPEnv.add_locals ppe (List.map fst tyd.tyd_params) in
   let name = P.basename x in
 
@@ -2283,6 +2288,8 @@ let pp_opdecl_nt (ppe : PPEnv.t) fmt (basename, ts, _ty, nt) =
 
 (* -------------------------------------------------------------------- *)
 let pp_opdecl ?(long = false) (ppe : PPEnv.t) fmt (x, op) =
+  let ppe = PPEnv.enter_theory ppe (Option.get (EcPath.prefix x)) in
+
   let pp_name fmt x =
     if long then
       let qs = PPEnv.op_symb ppe x None in
@@ -2314,7 +2321,6 @@ let pp_added_op (ppe : PPEnv.t) fmt op =
 (* -------------------------------------------------------------------- *)
 let pp_opname (ppe : PPEnv.t) fmt (p : EcPath.path) =
   pp_opname fmt (PPEnv.op_symb ppe p None)
-
 
 (* -------------------------------------------------------------------- *)
 let string_of_axkind = function
@@ -3222,6 +3228,7 @@ let pp_top_modexp ppe fmt (p, me) =
   pp_modexp_lc ppe fmt (mp, (me.tme_expr, Some me.tme_loca))
 
 let rec pp_theory ppe (fmt : Format.formatter) (path, cth) =
+  let ppe = PPEnv.enter_theory ppe path in
   let basename = EcPath.basename path in
   let pp_clone fmt thsrc =
     thsrc |> oiter (fun EcTheory.{ ths_base } ->

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -325,7 +325,7 @@ type prelude = {
   pr_required : required;
 }
 
-type thloaded = EcSection.checked_ctheory
+type thloaded = EcEnv.Theory.compiled_theory
 
 type scope = {
   sc_name     : (symbol * EcTheory.thmode);
@@ -2001,10 +2001,10 @@ module Theory = struct
   exception TopScope
 
   (* ------------------------------------------------------------------ *)
-  let bind (scope : scope) (x, cth) =
+  let bind (scope : scope) (cth : thloaded) =
     assert (scope.sc_pr_uc = None);
     { scope with
-        sc_env = EcSection.add_th ~import:EcTheory.import0 x cth scope.sc_env }
+        sc_env = EcSection.add_th ~import:EcTheory.import0 cth scope.sc_env }
 
   (* ------------------------------------------------------------------ *)
   let required (scope : scope) (name : required_info) =
@@ -2038,7 +2038,7 @@ module Theory = struct
       match Msym.find_opt id.rqd_name scope.sc_loaded with
       | Some (rth, ids) ->
           let scope = List.fold_right require_loaded ids scope in
-          let env   = EcSection.require id.rqd_name rth scope.sc_env in
+          let env   = EcSection.require rth scope.sc_env in
             { scope with
                 sc_env      = env;
                 sc_required = id :: scope.sc_required; }
@@ -2088,7 +2088,7 @@ module Theory = struct
     let cth = exit_r ~pempty (add_clears clears scope) in
     let ((cth, required), (name, _), scope) = cth in
     let scope = List.fold_right require_loaded required scope in
-    let scope = ofold (fun cth scope -> bind scope (name, cth)) scope cth in
+    let scope = ofold (fun cth scope -> bind scope cth) scope cth in
     (name, scope)
 
   (* ------------------------------------------------------------------ *)

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -460,7 +460,6 @@ let on_instance cb ty tci =
     cb (`Typeclass p)
 
 (* -------------------------------------------------------------------- *)
-
 type sc_name =
   | Th of symbol * is_local * thmode
   | Sc of symbol option
@@ -478,6 +477,7 @@ type scenv = {
 
 and sc_item =
   | SC_th_item  of EcTheory.theory_item
+  | SC_th       of EcEnv.Theory.compiled_theory
   | SC_decl_mod of EcIdent.t * mty_mr
 
 and sc_items =
@@ -524,13 +524,12 @@ type to_clear =
     lc_axioms    : Sp.t;
     lc_baserw    : Sp.t; }
 
-type to_gen = {
-    tg_env    : EcEnv.env;
+type to_gen =
+  { tg_env     : scenv;
     tg_params  : (EcIdent.t * Sp.t) list;
-    tg_binds  : bind list;
-    tg_subst : EcSubst.subst;
-    tg_clear : to_clear;
-  }
+    tg_binds   : bind list;
+    tg_subst   : EcSubst.subst;
+    tg_clear   : to_clear; }
 
 and bind =
   | Binding of binding
@@ -994,89 +993,6 @@ let generalize_auto to_gen (n,s,ps,lc) =
     if ps = [] then to_gen, None
     else to_gen, Some (Th_auto (n,s,ps,lc))
 
-let rec generalize_th_item to_gen prefix th_item =
-  let togen, item =
-    match th_item.ti_item with
-    | Th_type tydecl     -> generalize_tydecl to_gen prefix tydecl
-    | Th_operator opdecl -> generalize_opdecl to_gen prefix opdecl
-    | Th_axiom  ax       -> generalize_axiom  to_gen prefix ax
-    | Th_modtype ms      -> generalize_modtype to_gen ms
-    | Th_module me       -> generalize_module  to_gen me
-    | Th_theory cth      -> generalize_ctheory to_gen prefix cth
-    | Th_export (p,lc)   -> generalize_export to_gen (p,lc)
-    | Th_instance (ty,i,lc) -> generalize_instance to_gen (ty,i,lc)
-    | Th_typeclass _     -> assert false
-    | Th_baserw (s,lc)   -> generalize_baserw to_gen prefix (s,lc)
-    | Th_addrw (p,ps,lc) -> generalize_addrw to_gen (p, ps, lc)
-    | Th_reduction rl    -> generalize_reduction to_gen rl
-    | Th_auto hints      -> generalize_auto to_gen hints
-
-  in
-
-  let item =
-    Option.map
-      (fun item -> { ti_import = th_item.ti_import; ti_item = item; })
-      item
-
-  in togen, item
-
-and generalize_ctheory to_gen prefix (name, cth) =
-  let path = pqname prefix name in
-  if cth.cth_mode = `Abstract && cth.cth_loca = `Local then
-    add_clear to_gen (`Th path), None
-  else
-    let to_gen, cth_items =
-      generalize_ctheory_struct to_gen path cth.cth_items in
-    if cth_items = [] then
-      add_clear to_gen (`Th path), None
-    else
-      let cth_source =
-        match cth.cth_source with
-        | Some s when to_clear to_gen (`Th s.ths_base) -> None
-        | x -> x in
-
-      let cth = { cth with cth_items; cth_loca = `Global; cth_source } in
-      to_gen, Some (Th_theory (name, cth))
-
-and generalize_ctheory_struct to_gen prefix cth_struct =
-  match cth_struct with
-  | [] -> to_gen, []
-  | item::items ->
-    let to_gen, item = generalize_th_item to_gen prefix item in
-    let to_gen, items =
-      generalize_ctheory_struct to_gen prefix items in
-    match item with
-    | None -> to_gen, items
-    | Some item -> to_gen, item :: items
-
-let generalize_lc_item to_gen prefix item =
-  match item with
-  | SC_decl_mod (id, modty) ->
-    let to_gen = add_declared_mod to_gen id modty in
-    to_gen, None
-  | SC_th_item th_item ->
-    generalize_th_item to_gen prefix th_item
-
-let rec generalize_lc_items to_gen prefix items =
-  match items with
-  | [] -> []
-  | item::items ->
-    let to_gen, item = generalize_lc_item to_gen prefix item in
-    let items = generalize_lc_items to_gen prefix items in
-    match item with
-    | None -> items
-    | Some item -> item :: items
-
-let generalize_lc_items scenv =
-  let to_gen = {
-      tg_env    = scenv.sc_env;
-      tg_params = [];
-      tg_binds  = [];
-      tg_subst  = EcSubst.empty;
-      tg_clear  = empty_locals;
-    } in
-  generalize_lc_items to_gen (EcEnv.root scenv.sc_env) (List.rev scenv.sc_items)
-
 (* --------------------------------------------------------------- *)
 let get_locality scenv = scenv.sc_loca
 
@@ -1365,9 +1281,6 @@ let check_instance scenv ty tci lc =
         on_instance (cb scenv from cd) ty tci
 
 (* -----------------------------------------------------------*)
-type checked_ctheory = ctheory
-
-(* -----------------------------------------------------------*)
 let enter_theory (name:symbol) (lc:is_local) (mode:thmode) scenv : scenv =
   if not scenv.sc_insec && lc = `Local then
      hierror "can not start a local theory outside of a section";
@@ -1400,22 +1313,121 @@ let add_item_ (item : theory_item) (scenv:scenv) =
     | Th_modtype (s, ms) -> EcEnv.ModTy.bind s ms env
     | Th_module       me -> EcEnv.Mod.bind me.tme_expr.me_name me env
     | Th_typeclass(s,tc) -> EcEnv.TypeClass.bind s tc env
-    | Th_theory (s, cth) -> EcEnv.Theory.bind s cth env
     | Th_export  (p, lc) -> EcEnv.Theory.export p lc env
     | Th_instance (tys,i,lc) -> EcEnv.TypeClass.add_instance tys i lc env
     | Th_baserw   (s,lc) -> EcEnv.BaseRw.add s lc env
     | Th_addrw (p,ps,lc) -> EcEnv.BaseRw.addto p ps lc env
     | Th_auto (level, base, ps, lc) -> EcEnv.Auto.add ~level ?base ps lc env
     | Th_reduction r     -> EcEnv.Reduction.add r env
+    | _                  -> assert false
   in
   { scenv with
     sc_env = env;
     sc_items = SC_th_item item :: scenv.sc_items}
 
-let add_th ~import (name : symbol) (cth : checked_ctheory) scenv =
-  let item = mkitem import (EcTheory.Th_theory (name, cth)) in
-  add_item_ item scenv
+let add_th ~import (cth : EcEnv.Theory.compiled_theory) scenv =
+  let env = EcEnv.Theory.bind ~import cth scenv.sc_env in
+  { scenv with sc_env = env; sc_items = SC_th cth :: scenv.sc_items; }
 
+(* -----------------------------------------------------------*)
+let rec generalize_th_item (to_gen : to_gen) (prefix : path) (th_item : theory_item) =
+  let to_gen, item =
+    match th_item.ti_item with
+    | Th_type tydecl     -> generalize_tydecl to_gen prefix tydecl
+    | Th_operator opdecl -> generalize_opdecl to_gen prefix opdecl
+    | Th_axiom  ax       -> generalize_axiom  to_gen prefix ax
+    | Th_modtype ms      -> generalize_modtype to_gen ms
+    | Th_module me       -> generalize_module  to_gen me
+    | Th_theory th       -> (generalize_ctheory to_gen prefix th, None)
+    | Th_export (p,lc)   -> generalize_export to_gen (p,lc)
+    | Th_instance (ty,i,lc) -> generalize_instance to_gen (ty,i,lc)
+    | Th_typeclass _     -> assert false
+    | Th_baserw (s,lc)   -> generalize_baserw to_gen prefix (s,lc)
+    | Th_addrw (p,ps,lc) -> generalize_addrw to_gen (p, ps, lc)
+    | Th_reduction rl    -> generalize_reduction to_gen rl
+    | Th_auto hints      -> generalize_auto to_gen hints
+
+  in
+
+  let scenv =
+    item |> Option.fold ~none:to_gen.tg_env ~some:(fun item ->
+      let item = { ti_import = th_item.ti_import; ti_item = item; } in
+      add_item_ item to_gen.tg_env
+    )
+  in
+
+  { to_gen with tg_env = scenv }
+
+and generalize_ctheory
+  (genenv      : to_gen)
+  (prefix      : path)
+  ((name, cth) : symbol * ctheory)
+: to_gen
+=
+  let path = pqname prefix name in
+
+  if cth.cth_mode = `Abstract && cth.cth_loca = `Local then
+    add_clear genenv (`Th path)
+  else
+    let compiled =
+      let genenv =
+        let scenv =
+          enter_theory
+            name `Global cth.cth_mode
+            genenv.tg_env
+        in
+        { genenv with tg_env = scenv }
+      in
+
+      let genenv =
+        List.fold_left (fun genenv item ->
+          generalize_th_item genenv path item
+        ) genenv cth.cth_items in
+
+      let _, compiled, _ = exit_theory genenv.tg_env in
+
+      compiled
+    in        
+
+    match compiled with
+    | None ->
+      genenv
+    | Some compiled when List.is_empty compiled.ctheory.cth_items ->
+      genenv
+    | Some compiled ->
+      let scenv = add_th ~import:import0 compiled genenv.tg_env in
+      { genenv with tg_env = scenv; }
+
+and generalize_lc_item (genenv : to_gen) (prefix : path) (item : sc_item) =
+  match item with
+  | SC_decl_mod (id, modty) ->
+    add_declared_mod genenv id modty
+  | SC_th_item th_item ->
+    generalize_th_item genenv prefix th_item
+  | SC_th cth ->
+    generalize_ctheory genenv prefix (cth.name, cth.ctheory)
+
+and generalize_lc_items (genenv : to_gen) (prefix : path) (items : sc_item list) =
+  List.fold_left
+    (fun genenv item ->
+      generalize_lc_item genenv prefix item)
+    genenv items
+
+let genenv_of_scenv (scenv : scenv) : to_gen =
+  { tg_env    = Option.get (scenv.sc_top)
+  ; tg_params = []
+  ; tg_binds  = []
+  ; tg_subst  = EcSubst.empty
+  ; tg_clear  = empty_locals } 
+
+let generalize_lc_items scenv  =
+  let togen =
+    generalize_lc_items
+      (genenv_of_scenv scenv)
+      (EcEnv.root scenv.sc_env)
+      (List.rev scenv.sc_items)
+  in togen.tg_env
+  
 (* -----------------------------------------------------------*)
 let import p scenv =
   { scenv with sc_env = EcEnv.Theory.import p scenv.sc_env }
@@ -1424,10 +1436,10 @@ let import_vars m scenv =
   { scenv with
     sc_env = EcEnv.Mod.import_vars scenv.sc_env m }
 
-let require x cth scenv =
+let require (cth : EcEnv.Theory.compiled_theory) (scenv : scenv) =
   (* FIXME section *)
   if scenv.sc_insec then hierror "cannot use `require' in sections";
-  { scenv with sc_env = EcEnv.Theory.require x cth scenv.sc_env }
+  { scenv with sc_env = EcEnv.Theory.require cth scenv.sc_env }
 
 let astop scenv =
   if scenv.sc_insec then hierror "can not require inside a section";
@@ -1505,14 +1517,14 @@ let enter_section (name : symbol option) (scenv : scenv) =
     sc_abstr = false;
     sc_items = []; }
 
-let exit_section (name : symbol option) (scenv:scenv) =
+let exit_section (name : symbol option) (scenv : scenv) =
   match scenv.sc_name with
-  | Top  -> hierror "no section to close"
-  | Th _ -> hierror "cannot close a section containing pending theories"
+  | Top  ->
+    hierror "no section to close"
+  | Th _ ->
+    hierror "cannot close a section containing pending theories"
   | Sc sname ->
     let get = odfl "<empty>" in
     if sname <> name then
       hierror "expecting [%s], not [%s]" (get sname) (get name);
-    let items = generalize_lc_items scenv in
-    let scenv = oget scenv.sc_top in
-    add_items items scenv
+    generalize_lc_items scenv

--- a/src/ecSection.mli
+++ b/src/ecSection.mli
@@ -7,11 +7,6 @@ open EcTheory
 exception SectionError of string
 
 (* -------------------------------------------------------------------- *)
-type sc_item =
-  | SC_th_item  of theory_item
-  | SC_decl_mod of EcIdent.t * mty_mr
-
-(* -------------------------------------------------------------------- *)
 type scenv
 
 val env : scenv -> env
@@ -24,19 +19,18 @@ val add_decl_mod : EcIdent.t -> mty_mr -> scenv -> scenv
 val enter_section : EcSymbols.symbol option -> scenv -> scenv
 val exit_section  : EcSymbols.symbol option -> scenv -> scenv
 
-type checked_ctheory = private ctheory
-
 val enter_theory : EcSymbols.symbol -> EcTypes.is_local -> thmode -> scenv -> scenv
+
 val exit_theory  :
   ?clears:EcPath.path list ->
   ?pempty:[ `ClearOnly | `Full | `No ] ->
-  scenv -> EcSymbols.symbol * checked_ctheory option * scenv
+  scenv -> EcSymbols.symbol * EcEnv.Theory.compiled_theory option * scenv
 
 val import : EcPath.path -> scenv -> scenv
 
 val import_vars : EcPath.mpath -> scenv -> scenv
 
-val add_th  : import:import -> EcSymbols.symbol -> checked_ctheory -> scenv -> scenv
-val require : EcSymbols.symbol -> checked_ctheory -> scenv -> scenv
+val add_th  : import:import -> EcEnv.Theory.compiled_theory -> scenv -> scenv
+val require : EcEnv.Theory.compiled_theory -> scenv -> scenv
 
 val astop : scenv -> scenv


### PR DESCRIPTION
…et object

The theory environment is the environment obtained just before the theory is closed. This environment is now saved when a theory is closed (regardless of the theory being abstract or not).

This fixes two bugs:

  - hard failures when printing an abstract theory
  - long-object names