### PR TITLE
[ci]: remove ML-KEM

### DIFF
--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -21,17 +21,6 @@
 
   ,
 
-  { "name"       : "ml-kem"
-  , "repository" : "https://github.com/formosa-crypto/formosa-mlkem"
-  , "branch"     : "master"
-  , "subdir"     : "."
-  , "config"     : "config/tests.config"
-  , "scenario"   : "mlkem"
-  , "options"    : "-pragmas Proofs:weak"
-  }
-
-  ,
-
   { "name"       : "cryptobox"
   , "repository" : "https://gitlab.com/fdupress/ec-cryptobox"
   , "branch"     : "next"


### PR DESCRIPTION
ML-KEM is hard-failing on Github Actions for an obscure reason.

Moreover, ML-KEM checking time, even in weak-check mode, is uterly long to check.

While it is investigate & ML-KEM proofs are updated using the map-reduce tactics, I am removing it from the CI.

It will be reintegrated ASAP.