### PR TITLE
Added minimal external API

### DIFF
--- a/src/ecCommands.mli
+++ b/src/ecCommands.mli
@@ -5,6 +5,9 @@ open EcLocation
 exception Restart
 
 (* -------------------------------------------------------------------- *)
+type loader
+
+val loader   : loader
 val addidir  : ?namespace:EcLoader.namespace -> ?recursive:bool -> string -> unit
 val loadpath : unit -> (EcLoader.namespace option * string) list
 
@@ -21,6 +24,8 @@ type checkmode = {
   cm_iterate  : bool;
 }
 
+val initial : checkmode:checkmode -> boot:bool -> EcScope.scope
+
 val initialize  :
      restart:bool
   -> undo:bool
@@ -30,6 +35,13 @@ val initialize  :
 
 val current     : unit -> EcScope.scope
 val addnotifier : notifier -> unit
+
+(* -------------------------------------------------------------------- *)
+val process_internal :
+     loader
+  -> EcScope.scope
+  -> EcParsetree.global_action located
+  -> EcScope.scope
 
 (* -------------------------------------------------------------------- *)
 val process : ?timed:bool -> ?break:bool ->

--- a/src/ecScope.mli
+++ b/src/ecScope.mli
@@ -68,6 +68,11 @@ val attop  : scope -> bool
 val goal   : scope -> proof_auc option
 val xgoal  : scope -> proof_uc option
 
+(* Creates a scope that is identical to the supplied one except
+ * that the environment and required theories are reset to the ones
+ * from the prelude. *)
+val for_loading : scope -> scope
+
 type topmode = [`InProof | `InActiveProof | `InTop]
 
 val check_state : topmode -> string -> scope -> unit
@@ -134,6 +139,10 @@ module Theory : sig
   open EcTheory
 
   exception TopScope
+
+  (* [update_with_required dst src] updates [dst] with the required
+   * theories of [src] *)
+  val update_with_required : dst:scope -> src:scope -> scope
 
   (* [enter scope mode name] start a theory in scope [scope] with
    * name [name] and mode (abstract/concrete) [mode]. *)
@@ -210,6 +219,12 @@ module Prover : sig
   val set_default : scope -> smt_options -> scope
   val full_check  : scope -> scope
   val check_proof : scope -> bool -> scope
+
+  val pprover_infos_to_prover_infos :
+       EcEnv.env
+    -> EcProvers.prover_infos
+    -> pprover_infos
+    -> EcProvers.prover_infos
 end
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
Added minimal external API, faciliating the development of tools using EasyCrypt as a library. The changes are limited to ecScope.{ml,mli} and ecCommands.{ml,mli} are are labeled "external API" as otherwise they might be removed as dead code. (Based on the API developed at part of the UC DSL implementation, but names have been made generic.)