### PR TITLE
[internal]: fix filtering as saved theory-related environments

### DIFF
--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -2901,7 +2901,7 @@ module Theory = struct
 
   (* ------------------------------------------------------------------ *)
   let env_of_theory (p : EcPath.path) (env : env) =
-    if EcPath.isprefix p env.env_scope.ec_path then
+    if EcPath.isprefix ~prefix:p ~path:env.env_scope.ec_path then
       env
     else
       Option.get (Mp.find_opt p env.env_thenvs)
@@ -3211,7 +3211,7 @@ module Theory = struct
 
       let compiled =
         Mp.filter
-          (fun path _ -> EcPath.isprefix path root)
+          (fun path _ -> EcPath.isprefix ~prefix:root ~path)
           env.env_thenvs in
       let compiled = Mp.add env.env_scope.ec_path env compiled in
 

--- a/src/ecPath.ml
+++ b/src/ecPath.ml
@@ -132,18 +132,19 @@ let prefix p =
   | Psymbol _ -> None
   | Pqname (p, _) -> Some p
 
-let rec getprefix_r acc p q =
-  match p_equal p q with
-  | true  -> Some acc
-  | false ->
-      match q.p_node with
-      | Psymbol _     -> None
-      | Pqname (q, x) -> getprefix_r (x::acc) p q
+let remprefix ~(prefix : path) =
+  let rec doit (acc : symbol list) (path : path) =
+    if p_equal prefix path then
+      Some acc
+    else
+      match path.p_node with
+      | Psymbol _ -> None
+      | Pqname (path, x) -> doit (x :: acc) path in
 
-let getprefix p q = getprefix_r [] p q
+  fun ~(path : path) -> doit [] path
 
-let isprefix p q =
-  match getprefix p q with
+let isprefix ~(prefix : path) ~(path : path) =
+  match remprefix ~prefix ~path with
   | None   -> false
   | Some _ -> true
 

--- a/src/ecPath.mli
+++ b/src/ecPath.mli
@@ -31,8 +31,8 @@ val fromqsymbol : qsymbol -> path
 val basename    : path -> symbol
 val extend      : path -> symbol list -> path
 val prefix      : path -> path option
-val getprefix   : path -> path -> symbol list option
-val isprefix    : path -> path -> bool
+val remprefix   : prefix:path -> path:path -> symbol list option
+val isprefix    : prefix:path -> path:path -> bool
 val rootname    : path -> symbol
 val tolist      : path -> symbol list
 val p_size      : path -> int

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -890,7 +890,7 @@ and replay_instance
   let module E = struct exception InvInstPath end in
 
   let forpath (p : EcPath.path) =
-    match EcPath.getprefix opath p |> omap List.rev with
+    match EcPath.remprefix ~prefix:opath ~path:p |> omap List.rev with
     | None | Some [] -> None
     | Some (x::px) ->
         let q = EcPath.fromqsymbol (List.rev px, x) in

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -369,7 +369,7 @@ let gen_select_op
     EcPath.p_equal opsc (oget (EcPath.prefix p))
 
   and by_current ((p, _), _, _, _) =
-    EcPath.isprefix (oget (EcPath.prefix p)) (EcEnv.root env)
+    EcPath.isprefix ~prefix:(oget (EcPath.prefix p)) ~path:(EcEnv.root env)
 
   and by_tc ((p, _), _, _, _) =
     match oget (EcEnv.Op.by_path_opt p env) with


### PR DESCRIPTION
The bug takes its root in a poorly document API (EcPath.isprefix).

The function now takes named arguments to make things clearer.

fix #570 