### PR TITLE
[smt]: proper selection of SMT variant

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -1691,9 +1691,8 @@ section PROOFS.
         swap 13 9; wp; conseq (_: true) => />; 1: smt(); islossless.
         while true (size p2).
         + move=> z; wp; conseq (_: true) => //=; 2: by islossless.
-          move => &hr; elim (p2{hr}) => //. 
-          clear &hr.
-          smt (size_drop size_eq0 gt0_block_size).
+          move => &hr; elim (p2{hr}) => //= => {&hr}.
+          smt (size_drop size_ge0 size_eq0 gt0_block_size).
         by auto; smt (size_ge0 size_eq0 dpoly_out_ll). 
       + by proc; inline *; sp 1 1; if; auto => /> *; smt(get_setE mem_set).
       + by move=> &2 _; islossless.

--- a/src/ec.ml
+++ b/src/ec.ml
@@ -70,11 +70,15 @@ let print_config config =
 
   (* Print list of known provers *)
   begin
-    let string_of_prover prover =
+    let string_of_prover (prover : EcProvers.prover) =
       let fullname =
-        Printf.sprintf "%s@%s"
-          prover.EcProvers.pr_name
-          (EcProvers.Version.to_string prover.EcProvers.pr_version) in
+        Format.asprintf "%s%t@%s"
+          prover.pr_name
+          (fun fmt ->
+            if not (String.is_empty prover.pr_alt) then
+              Format.fprintf fmt "[%s]" prover.pr_alt)
+          (EcProvers.Version.to_string prover.pr_version)
+      in
 
       match prover.EcProvers.pr_evicted with
       | None -> fullname

--- a/src/ecProvers.mli
+++ b/src/ecProvers.mli
@@ -30,6 +30,7 @@ type prover_eviction = [
 type prover = {
   pr_name    : string;
   pr_version : Version.version;
+  pr_alt     : string;
   pr_evicted : (prover_eviction * bool) option;
 }
 
@@ -58,6 +59,7 @@ val known : evicted:bool -> prover list
 (* -------------------------------------------------------------------- *)
 type parsed_pname = {
   prn_name     : string;
+  prn_alt      : string;
   prn_version  : Version.version option;
   prn_ovrevict : bool;
 }

--- a/theories/distributions/DInterval.ec
+++ b/theories/distributions/DInterval.ec
@@ -69,7 +69,8 @@ have uniq_s: uniq s; first apply: uniq_flatten_map.
   by move => x y _ _ /=; apply/addrI.
 - move=> x y /mem_range rg_x /mem_range rg_y /hasP /=.
   case=> j [/mapP[/= k [/mem_range rg_k]] ->>].
-  by case/mapP=> l [/mem_range rg_l] {rg_x} {rg_y} /#.
+  case/mapP=> l [/mem_range rg_l] {rg_x} {rg_y}.
+  smt(IntDiv.euclideU).
 - by apply: range_uniq.
 have mem_s: forall x, (x \in s) <=> (x \in range 0 p).
 - move=> x; rewrite mem_range; split.


### PR DESCRIPTION
Why3 can define several variants (e.g. counterexamples, noBV).

Currently, EasyCrypt select the first variant that comes in the prover list. From now on, the default variant (= empty name) is selected by default. It is also possible to provide the desired in the prover name (syntax = "prover[variant]", e.g. "Z3[noBV]").

This is compatible with the version selection (e.g. "Z3[noBV]@4.8")