### PR TITLE
stage the SmtMap -> FMap renaming

### DIFF
--- a/theories/datatypes/FMap.ec
+++ b/theories/datatypes/FMap.ec
@@ -1,0 +1,1 @@
+require export SmtMap.


### PR DESCRIPTION
This is to stage the renaming in #605 across a release.

- Pre-release: add `FMap` as an alias for `SmtMap`.
- Post-release: deprecate `SmtMap` by merging #605.