### PR TITLE
internal: stable ordering of globals components

### DIFF
--- a/examples/ChaChaPoly/chacha_poly.ec
+++ b/examples/ChaChaPoly/chacha_poly.ec
@@ -2520,9 +2520,9 @@ section PROOFS.
        (iota_ 0 qdec).
   proof.
     pose E := 
-      fun (_:unit) (g:glob UFCMA_l) (_:unit) => size g.`1 <= qdec /\ exists tt, tt \in g.`1 /\ tt.`1 = tt.`2.
+      fun (_:unit) (g:glob UFCMA_l) (_:unit) => size g.`6 <= qdec /\ exists tt, tt \in g.`6 /\ tt.`1 = tt.`2.
     pose phi :=
-      fun (_:unit) (g:glob UFCMA_l) (_:unit) => find (fun (tt:tag * tag) => tt.`1 = tt.`2) g.`1.
+      fun (_:unit) (g:glob UFCMA_l) (_:unit) => find (fun (tt:tag * tag) => tt.`1 = tt.`2) g.`6.
     have -> := LP.list_partitioning UFCMA_l () E phi (iota_ 0 qdec) &m (iota_uniq 0 qdec).
     have -> /= : Pr[UFCMA_l.f() @ &m : E tt (glob UFCMA_l) res /\ ! (phi tt (glob UFCMA_l) res \in iota_ 0 qdec)] = 0%r.
     + byphoare => //. 

--- a/examples/cramer-shoup/cramer_shoup.ec
+++ b/examples/cramer-shoup/cramer_shoup.ec
@@ -492,7 +492,7 @@ section Security_Aux.
            Pr[Ad1.Main(G1).main() @ &m : res \/ G1.bad].
     + byequiv DDH1_G1 => //;1: smt ().
     (* print glob G1. *)
-    have /= := Ad1.pr_abs G1 _ _ &m (fun (b:bool) (x : glob G1) => b \/ x.`14).
+    have /= := Ad1.pr_abs G1 _ _ &m (fun (b:bool) (x : glob G1) => b \/ x.`2).
     + proc;auto => />; by rewrite dt_r_ll ?dt_ll.
     + proc;auto;call (guess_ll (<:G1.O) G1_dec_ll);auto.
       by call (choose_ll (<:G1.O) G1_dec_ll);auto; rewrite dk_ll  dt_ll DBool.dbool_ll.

--- a/examples/plug-and-pray/Plug_and_Pray_example.ec
+++ b/examples/plug-and-pray/Plug_and_Pray_example.ec
@@ -72,10 +72,10 @@ lemma Bound_aux &m (A <: Adv {-G0}):
   (1%r/q%r) * Pr[ G0(A).main() @ &m : G0.b ]
   = Pr[ Guess(G0(A)).main() @ &m :  G0.b /\ res.`1 = G0.k ].
 proof.
-pose phi:= fun (g : (glob G0(A))) (_ : unit)=> g.`1.
-pose psi:= fun (g : (glob G0(A))) (_ : unit)=> if 0 <= g.`2 < q then g.`2 else 0.
+pose phi:= fun (g : (glob G0(A))) (_ : unit)=> g.`2.
+pose psi:= fun (g : (glob G0(A))) (_ : unit)=> if 0 <= g.`3 < q then g.`3 else 0.
 have:= PBound (G0(A)) phi psi tt &m _.
-+ by move=> @/psi gG o /=; rewrite mem_range; case: (0 <= gG.`2 < q)=> //= _; exact/gt0_q.
++ by move=> @/psi gG o /=; rewrite mem_range; case: (0 <= gG.`3 < q)=> //= _; exact/gt0_q.
 have ->: card = q by rewrite undup_id 1:range_uniq size_range #smt:(gt0_q).
 have -> //=: Pr[Guess(G0(A)).main() @ &m: phi (glob G0(A)) res.`2 /\ res.`1 = psi (glob G0(A)) res.`2]
              = Pr[Guess(G0(A)).main() @ &m: G0.b /\ res.`1 = G0.k].

--- a/src/ecCommands.ml
+++ b/src/ecCommands.ml
@@ -205,24 +205,25 @@ module HiPrinting = struct
     let ppe = EcPrinting.PPEnv.ofenv env in
     let (p, _) = EcTyping.trans_msymbol env pm in
     let us = EcEnv.NormMp.mod_use env p in
+    let (globs, pv) = EcEnv.NormMp.flatten_use us in
 
     Format.fprintf fmt "Globals [# = %d]:@."
       (Sid.cardinal us.EcEnv.us_gl);
-    Sid.iter (fun id ->
+    List.iter (fun id ->
       Format.fprintf fmt "  %s@." (EcIdent.name id))
-      us.EcEnv.us_gl;
+      globs;
 
     Format.fprintf fmt "@.";
 
     Format.fprintf fmt "Prog. variables [# = %d]:@."
       (Mx.cardinal us.EcEnv.us_pv);
-    List.iter (fun (xp,_) ->
+    List.iter (fun (xp, _) ->
       let pv = EcTypes.pv_glob xp in
       let ty = EcEnv.Var.by_xpath xp env in
       Format.fprintf fmt "  @[%a : %a@]@."
         (EcPrinting.pp_pv ppe) pv
         (EcPrinting.pp_type ppe) ty)
-      (List.rev (Mx.bindings us.EcEnv.us_pv))
+      pv
 
 
   let pr_goal fmt scope n =

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -2385,14 +2385,23 @@ module NormMp = struct
       if   x_equal p xp then pv
       else EcTypes.pv_glob p
 
+  let flatten_use (us : use) =
+    let globs = Sid.elements us.us_gl in
+    let globs = List.sort EcIdent.id_ntr_compare globs in
+
+    let pv = Mx.bindings us.us_pv in
+    let pv = List.sort (fun (xp1, _) (xp2, _) -> x_ntr_compare xp1 xp2) pv in
+
+    (globs, pv)
+
   let globals env m mp =
     let us = mod_use env mp in
-    let l =
-      Sid.fold (fun id l -> f_glob id m :: l) us.us_gl [] in
-    let l =
-      Mx.fold
-        (fun xp ty l -> f_pvar (EcTypes.pv_glob xp) ty m :: l) us.us_pv l in
-    f_tuple l
+
+    let globs, pv = flatten_use us in
+    let globs = List.map (fun id -> f_glob id m) globs in
+    let pv = List.map (fun (xp, ty) -> f_pvar (pv_glob xp) ty m) pv in
+
+    f_tuple (globs @ pv)
 
   let norm_glob env m mp = globals env m mp
 

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -245,6 +245,8 @@ module NormMp : sig
   val use_mem_xp    : xpath -> use use_restr -> bool
   val use_mem_gl    : mpath -> use use_restr -> bool
 
+  val flatten_use : use -> EcIdent.t list * (xpath * ty) list
+
   val norm_glob     : env -> EcMemory.memory -> mpath -> form
   val norm_tglob    : env -> mpath -> EcTypes.ty
 

--- a/theories/crypto/RndExcept.eca
+++ b/theories/crypto/RndExcept.eca
@@ -306,7 +306,7 @@ abstract theory AdversaryN.
      `| Pr[Main(R(SampleE), CountA(A)).main() @ &m : E res Count.c (glob A) ] -
         Pr[Main(R(Sample), CountA(A)).main() @ &m : E res Count.c (glob A) ] | <= q%r * p%r / n%r .
   proof.
-    apply (ler_trans _ _ _ (pr_A_upto (CountA(A)) _ (fun r (x: int *  glob A) => E r x.`1 x.`2) &m)).
+    apply (ler_trans _ _ _ (pr_A_upto (CountA(A)) _ (fun r (x: glob A * int) => E r x.`2 x.`1) &m)).
     + move=> O O_ll;proc.
       call (A_ll (Count(O)) _); 2 : by auto.
       by proc;sp;if => //;wp;call O_ll.

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -450,17 +450,17 @@ byequiv (_: !b{2} /\ ={glob A} ==> res{1} = !res{2}) => //.
 proc; inline *.
 pose inv (gPKE1 : glob MRPKE_lor) (gPKE2 : glob MRPKE_lor) (gODH2 : glob ODH_Orcl)
          (skeys2:(Pk * group, K) fmap) :=
-  !gODH2.`5 /\
+  !gODH2.`1 /\
   gPKE1.`1=gPKE2.`1 /\ gPKE1.`2=gPKE2.`2 /\ gPKE1.`3=gPKE2.`3 /\ gPKE1.`4=gPKE2.`4 /\
-  gPKE1.`6=gPKE2.`6  /\  fdom gPKE2.`5 = fdom gODH2.`4 /\ fdom skeys2 = gODH2.`3 /\
-  gODH2.`1 <= gPKE1.`2 /\
-  gODH2.`2 = gPKE2.`3 /\ gODH2.`4 = gPKE1.`5 /\
-  (forall pk sk, gPKE1.`5.[pk] = Some sk => pk = g ^ sk) /\
-  (forall pk gx k, skeys2.[(pk,gx)] = Some k => pk \in gPKE2.`5 && exists (x : exp), gx = g ^ x && k = hash(pk ^ x)) /\
-  (forall pk sk, gPKE1.`5.[pk] = Some sk => pk = g ^ sk) /\
+  gPKE1.`5=gPKE2.`5  /\  fdom gPKE2.`6 = fdom gODH2.`4 /\ fdom skeys2 = gODH2.`5 /\
+  gODH2.`3 <= gPKE1.`4 /\
+  gODH2.`2 = gPKE2.`3 /\ gODH2.`4 = gPKE1.`6 /\
+  (forall pk sk, gPKE1.`6.[pk] = Some sk => pk = g ^ sk) /\
+  (forall pk gx k, skeys2.[(pk,gx)] = Some k => pk \in gPKE2.`6 && exists (x : exp), gx = g ^ x && k = hash(pk ^ x)) /\
+  (forall pk sk, gPKE1.`6.[pk] = Some sk => pk = g ^ sk) /\
   (forall pk tag cph,
-    ((pk, tag, cph) \in gPKE1.`4)%List => pk \in gPKE1.`5 && (pk, cph.`1) \in skeys2)  /\
-  (forall pk sk gx k, gPKE1.`5.[pk] = Some sk => skeys2.[(pk, gx)] = Some k => k = hash(gx ^ sk)).
+    ((pk, tag, cph) \in gPKE1.`5)%List => pk \in gPKE1.`6 && (pk, cph.`1) \in skeys2)  /\
+  (forall pk sk gx k, gPKE1.`6.[pk] = Some sk => skeys2.[(pk, gx)] = Some k => k = hash(gx ^ sk)).
 wp; call (_: inv (glob MRPKE_lor){1} (glob MRPKE_lor){2} (glob ODH_Orcl){2} Adv1_Procs.skeys{2}); last first.
  wp; rnd; wp; skip; rewrite /inv /=; clear inv => />; smt (fdom0 emptyE).
 + proc; inline*.
@@ -632,11 +632,11 @@ byequiv (_: b{2} /\ ={glob A} ==> res{1} = res{2}) => //.
 proc; inline *.
 pose inv (gPKE1:glob MRPKErnd_lor) (gPKE2:glob MRPKE_lor) (gODH2:glob ODH_Orcl)
          (skeys2:(Pk*group,K) fmap) :=
-  gODH2.`5 /\ gPKE1.`2=gPKE2.`1 /\ gPKE1.`3=gPKE2.`2 /\ gPKE1.`4=gPKE2.`3 /\ gPKE1.`5=gPKE2.`4 /\
-  gPKE1.`7=gPKE2.`6 /\ fdom gPKE2.`5 = fdom gODH2.`4 /\ gODH2.`1 <= gPKE1.`3 /\
-  gODH2.`2 = gPKE2.`3 /\ gODH2.`4 = gPKE1.`6 /\ gPKE1.`1 = skeys2 /\ gODH2.`3 = fdom skeys2 /\
-  (forall pk cph tag, ((pk,cph,tag) \in gPKE1.`5)%List => pk \in gPKE1.`6) /\
-  (forall pk tag (ctxt : CTxt), (pk, tag, ctxt) \in gPKE1.`5 => (pk,ctxt.`1) \in skeys2).
+  gODH2.`1 /\ gPKE1.`2=gPKE2.`1 /\ gPKE1.`3=gPKE2.`2 /\ gPKE1.`5=gPKE2.`4 /\ gPKE1.`4=gPKE2.`3 /\
+  gPKE1.`6=gPKE2.`5 /\ fdom gPKE2.`6 = fdom gODH2.`4 /\ gODH2.`3 <= gPKE1.`5 /\
+  gODH2.`2 = gPKE2.`3 /\ gODH2.`4 = gPKE1.`7 /\ gPKE1.`1 = skeys2 /\ gODH2.`5 = fdom skeys2 /\
+  (forall pk cph tag, ((pk,cph,tag) \in gPKE1.`6)%List => pk \in gPKE1.`7) /\
+  (forall pk tag (ctxt : CTxt), (pk, tag, ctxt) \in gPKE1.`6 => (pk,ctxt.`1) \in skeys2).
 wp; call (_: inv (glob MRPKErnd_lor){1} (glob MRPKE_lor){2} (glob ODH_Orcl){2} Adv1_Procs.skeys{2});
  last by wp; rnd; wp; skip => /> *; smt(fdom0).
 + proc;inline*.
@@ -809,59 +809,24 @@ byequiv; first proc; inline *.
 seq 5 1 : (#pre /\ b{1} = MRPKE_lor.b{1} /\ b0{1} = b{1} /\
            MRPKE_lor.b{1} = AEADmul_Oracles.b{2});
            first by wp;rnd;skip.
-(* print glob MRPKErnd_lor.
-Prog. variables [# = 7]:
-1  MRPKErnd_lor.skeys : (Pk * group, K) fmap
-2  MRPKE_lor.count_dec : int
-3  MRPKE_lor.count_lor : int
-4  MRPKE_lor.count_gen : int
-5  MRPKE_lor.lorlist : (Pk * Tag * CTxt) list
-6  MRPKE_lor.pklist : (Pk, Sk) fmap
-7  MRPKE_lor.b : bool *)
-(* print glob Adv2_Procs.
-Prog. variables [# = 7]:
-1  Adv2_Procs.kindex : (Pk * Pk, int) fmap
-2  MRPKErnd_lor.skeys : (Pk * group, K) fmap
-3  MRPKE_lor.count_dec : int
-4  MRPKE_lor.count_lor : int
-5  MRPKE_lor.count_gen : int
-6  MRPKE_lor.lorlist : (Pk * Tag * CTxt) list
-7  MRPKE_lor.pklist : (Pk, Sk) fmap *)
-(* print glob AEADmul_Oracles.
-Prog. variables [# = 6]:
-1  AEADmul_Oracles.deccount : int
-2  AEADmul_Oracles.lorcount : int
-3  AEADmul_Oracles.lorlist : (int * AData * Cph) list
-4  AEADmul_Oracles.n_keys : int
-5  AEADmul_Oracles.keys : K list
-6  AEADmul_Oracles.b : bool *)
-(*
-Prog. variables [# = 6]:
-1-5  AEADmul_Oracles.keys : K list
-2-4  AEADmul_Oracles.n_keys : int
-3-1  AEADmul_Oracles.deccount : int
-4-2  AEADmul_Oracles.lorcount : int
-5-3  AEADmul_Oracles.lorlist : (int * AData * Cph) list
-6-6  AEADmul_Oracles.b : bool
-*)
 pose inv (gPKE1:glob MRPKErnd_lor) (gAdv2:glob Adv2_Procs) (gAEAD2:glob AEADmul_Oracles) :=
-         gPKE1.`7 = gAEAD2.`6 /\ gPKE1.`2 = gAdv2.`3 /\ gPKE1.`3 = gAdv2.`4 /\
-         gPKE1.`4 = gAdv2.`5 /\ gPKE1.`5 = gAdv2.`6 /\ gPKE1.`6 = gAdv2.`7 /\
-         fdom gPKE1.`1 = fdom gAdv2.`2 /\ gAEAD2.`1 <= gAdv2.`3 /\ gAEAD2.`2 <= gAdv2.`4 /\
-         fdom gAdv2.`1 = fdom gAdv2.`2 /\ size gAEAD2.`5 = gAEAD2.`4 /\
+         gPKE1.`2 = gAEAD2.`1 /\ gPKE1.`3 = gAdv2.`3 /\ gPKE1.`4 = gAdv2.`4 /\
+         gPKE1.`5 = gAdv2.`5 /\ gPKE1.`6 = gAdv2.`6 /\ gPKE1.`7 = gAdv2.`7 /\
+         fdom gPKE1.`1 = fdom gAdv2.`2 /\ gAEAD2.`2 <= gAdv2.`3 /\ gAEAD2.`4 <= gAdv2.`5 /\
+         fdom gAdv2.`1 = fdom gAdv2.`2 /\ size gAEAD2.`3 = gAEAD2.`6 /\
          (forall i tag cph,
-             (i, tag, cph) \in gAEAD2.`3 =>
-             0 <= i < gAEAD2.`4) /\
+             (i, tag, cph) \in gAEAD2.`5 =>
+             0 <= i < gAEAD2.`6) /\
          (forall pk eph i,
              gAdv2.`1.[(pk,eph)] = Some i =>
-             0 <= i < gAEAD2.`4) /\
+             0 <= i < gAEAD2.`6) /\
          (forall pk eph i tag c,
              gAdv2.`1.[(pk,eph)] = Some i =>
-             (i, tag, c) \in gAEAD2.`3 =>
+             (i, tag, c) \in gAEAD2.`5 =>
              (pk, tag, (eph,c)) \in gAdv2.`6) /\
          (forall pk eph i,
              gAdv2.`1.[(pk,eph)] = Some i =>
-             gPKE1.`1.[(pk,eph)] = Some (nth witness gAEAD2.`5 i)).
+             gPKE1.`1.[(pk,eph)] = Some (nth witness gAEAD2.`3 i)).
 wp; call (_: inv (glob MRPKErnd_lor){1} (glob Adv2_Procs){2} (glob AEADmul_Oracles){2});
 last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
 + proc;inline *.

--- a/theories/crypto/assumptions/PKSMK.ec
+++ b/theories/crypto/assumptions/PKSMK.ec
@@ -505,8 +505,8 @@ abstract theory UF1_UF.
           res.`1 = odflt 0 Aux.forged].
     proof.
       pose phi (g:glob UF(Aux)) (_:bool) := 
-        (exists i, 0 <= i < q_gen /\ g.`1 = Some i).
-      pose psi (g:glob UF(Aux)) (_:bool) := odflt 0 g.`1.
+        (exists i, 0 <= i < q_gen /\ g.`7 = Some i).
+      pose psi (g:glob UF(Aux)) (_:bool) := odflt 0 g.`7.
       have Hpsi: forall g o, phi g o => psi g o \in range 0 q_gen.
       + by move=> g ? [i [h heq]];rewrite /psi heq /= mem_range.
       have := PBound (UF(Aux)) phi psi () &m Hpsi.  

--- a/theories/encryption/Hybrid.ec
+++ b/theories/encryption/Hybrid.ec
@@ -430,7 +430,7 @@ section.
     by move=> x Hx; rewrite dinter1E /=; smt(supp_dinter).
   pose ev :=
     fun (_j:int) (g:glob HybGameFixed(L(Ob))) (r:outputA),
-      let (l,l0,ga,ge) = g in p ga ge l r /\ l <= q.
+      let (ga,ge,l,l0) = g in p ga ge l r /\ l <= q.
   have := M.Mean_uni (HybGameFixed(L(Ob))) &m ev (1%r/q%r) _ _ => //; simplify ev => ->.
   have := M.Mean_uni (HybGameFixed(R(Ob))) &m ev (1%r/q%r) _ _ => //; simplify ev => ->.
   have supp_range: perm_eq (to_seq (support [0..max 0 (q - 1)])) (range 0 q).

--- a/theories/encryption/Indist.ec
+++ b/theories/encryption/Indist.ec
@@ -300,7 +300,7 @@ lemma INDb_INDLR &m (p:glob A -> glob O -> int -> bool):
   = (  Pr[INDL(O,A).main() @ &m : res /\ p (glob A) (glob O) Count.c]
      - Pr[INDR(O,A).main() @ &m : res /\ p (glob A) (glob O) Count.c]) / 2%r.
 proof.
-have //= H:= Sample_bool WA &m (fun (g:glob WA), let (b,c,ga,go) = g in p ga go c).
+have //= H:= Sample_bool WA &m (fun (g:glob WA), let (ga,go,b,c) = g in p ga go c).
 have ->:   Pr[INDb(O, A).main() @ &m : res /\ p (glob A) (glob O) Count.c]
          = Pr[MB.M.Rand(WA).main() @ &m : fst res = snd res /\ p (glob A) (glob O) Count.c].
 + byequiv (: ={glob A,glob O}


### PR DESCRIPTION
Before, the globals compoenents were sorted by the hash-consing
tags, leading to a 1. unpredictable ordering & 2. unstable
ordering (especially in case of undos/redos)

Globs components are now sorted by fullnames.