### PR TITLE
internal: allow eta reduction when checking the unfolding of an operator

### DIFF
--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -613,7 +613,7 @@ let process_delta ~und_delta ?target (s, o, p) tc =
         EcEnv.notify env `Warning "unused unfold: /%s" x
     end;
 
-    t_change ~ri ?target:idtg redform tc
+    t_change ~ri:{ ri with eta = true; beta = true; } ?target:idtg redform tc
 
   | _ ->
 


### PR DESCRIPTION
If not, unfolding an high-order operator will produce a formula that is not convertible to the original one.

fix #590 