### PR TITLE
Fix logical variable shadowing program variables

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -881,6 +881,9 @@ pside_:
 pside:
 | x=brace(pside_) { x }
 
+pside_force:
+| brace(b=boption(NOT) m=loc(pside_) { (b, m) }) { $1 }
+
 (* -------------------------------------------------------------------- *)
 (* Patterns                                                             *)
 
@@ -1211,7 +1214,7 @@ sform_u(P):
    { let e1 = List.reduce1 (fun _ -> lmap (fun x -> PFtuple x) e1) (unloc e1) in
      pfset (EcLocation.make $startpos $endpos) ti se e1 e2 }
 
-| x=sform_r(P) s=loc(pside)
+| x=sform_r(P) s=pside_force
    { PFside (x, s) }
 
 | op=loc(numop) ti=tvars_app?

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -181,7 +181,7 @@ and pformula_r =
   | PFident   of pqsymbol * ptyannot option
   | PFref     of psymbol * pffilter list
   | PFmem     of psymbol
-  | PFside    of pformula * symbol located
+  | PFside    of pformula * (bool * symbol located)
   | PFapp     of pformula * pformula list
   | PFif      of pformula * pformula * pformula
   | PFmatch   of pformula * (ppattern * pformula) list


### PR DESCRIPTION
Currently, when resolving an identifier, EasyCrypt tries to resolve it as a logical variable first, and then as a program variable (in the active memory), even when a memory specifier is given.

This commit adds a new memory specifier that changes the resolution order: when using it, we first try to resolve the identifier as a program variable (in the given memory), and then as a logical variable if no program variable matching that name is found.

The syntax is `form{!memory}`.

The pretty-printer has been updated accordingly.

Fix #122, fix #196 