### PR TITLE
CI: only for PR & main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: EasyCrypt compilation & check
 
-on: [push,pull_request,merge_group]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
 
 env:
   HOME: /home/charlie
@@ -8,22 +12,8 @@ env:
   OPAMJOBS: 2
 
 jobs:
-  pre_job:
-    name: Check for Duplicates Jobs
-    runs-on: ubuntu-20.04
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-    - uses: fkirc/skip-duplicate-actions@v5
-      id: skip_check
-      with:
-        concurrent_skipping: 'same_content_newer'
-        skip_after_successful_duplicate: 'false'
-
   compile-opam:
     name: EasyCrypt compilation (opam)
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/easycrypt/ec-build-box
@@ -38,8 +28,6 @@ jobs:
 
   compile-nix:
     name: EasyCrypt compilation (nix)
-    needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true'
     env:
       HOME: /home/runner
     runs-on: ubuntu-20.04
@@ -60,8 +48,7 @@ jobs:
 
   check:
     name: Check EasyCrypt Libraries
-    needs: [pre_job, compile-opam]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: compile-opam
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/easycrypt/ec-build-box
@@ -95,7 +82,6 @@ jobs:
 
   fetch-external-matrix:
     name: Fetch EasyCrypt External Projects Matrix
-    needs: [pre_job]
     runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -110,8 +96,7 @@ jobs:
 
   external:
     name: Check EasyCrypt External Projects
-    needs: [pre_job, compile-opam, fetch-external-matrix]
-    if: needs.pre_job.outputs.should_skip != 'true'
+    needs: [compile-opam, fetch-external-matrix]
     runs-on: ubuntu-20.04
     container:
       image: ghcr.io/easycrypt/ec-build-box


### PR DESCRIPTION
This allows to remove the job duplicates detection script that has its own odities and was badly working with automatic merges.

If ones want to have the CI running on its develoment branch, that person should create a draft PR.