### PR TITLE
[matching]: when crossing a binder, update the env. accordingly

### DIFF
--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -3446,16 +3446,17 @@ module LDecl = struct
     with LdeclError _ -> raise NotReducible
 
   (* ------------------------------------------------------------------ *)
-  let check_name_clash id hyps =
+  let check_name_clash ?(onlyid = false) id hyps =
     if   has_id id hyps
     then error (NameClash (`Ident id))
-    else
+    else if not onlyid then begin
       let s = EcIdent.name id in
       if s <> "_" && has_name ~dep:false s hyps then
         error (NameClash (`Symbol s))
+    end
 
-  let add_local id ld hyps =
-    check_name_clash id hyps;
+  let add_local ?onlyid id ld hyps =
+    check_name_clash ?onlyid id hyps;
     { hyps with h_local = (id, ld) :: hyps.h_local }
 
   (* ------------------------------------------------------------------ *)
@@ -3497,8 +3498,8 @@ module LDecl = struct
     | LD_abs_st us    -> AbsStmt.bind x us env
 
   (* ------------------------------------------------------------------ *)
-  let add_local x k h =
-    let le_hyps = add_local x k (tohyps h) in
+  let add_local ?onlyid x k h =
+    let le_hyps = add_local ?onlyid x k (tohyps h) in
     let le_env  = add_local_env x k h.le_env in
     { h with le_hyps; le_env; }
 

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -459,7 +459,7 @@ module LDecl : sig
   val baseenv : hyps -> env
 
   val ld_subst  : f_subst -> local_kind -> local_kind
-  val add_local : EcIdent.t -> local_kind -> hyps -> hyps
+  val add_local : ?onlyid:bool -> EcIdent.t -> local_kind -> hyps -> hyps
 
   val by_name : symbol    -> hyps -> l_local
   val by_id   : EcIdent.t -> hyps -> local_kind

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -663,7 +663,7 @@ let process_delta ~und_delta ?target (s, o, p) tc =
     if matches then begin
       let p    = concretize_form ptenv p in
       let cpos =
-        let test = fun _ fp ->
+        let test = fun _ hyps fp ->
           let fp =
             match fp.f_node with
             | Fapp (h, hargs) when List.length hargs > na ->
@@ -675,7 +675,7 @@ let process_delta ~und_delta ?target (s, o, p) tc =
             then `Accept (-1)
             else `Continue
         in
-          try  FPosition.select ?o test target
+          try  FPosition.select ?o test hyps target
           with InvalidOccurence ->
             tc_error !!tc "invalid occurences selector"
       in

--- a/src/ecMatching.mli
+++ b/src/ecMatching.mli
@@ -171,7 +171,7 @@ module FPosition : sig
 
   val tostring : ptnpos -> string
 
-  val select : ?o:occ -> (Sid.t -> form -> select) -> form -> ptnpos
+  val select : ?o:occ -> (Sid.t -> LDecl.hyps -> form -> select) -> LDecl.hyps -> form -> ptnpos
 
   val select_form : ?xconv:EcReduction.xconv -> ?keyed:bool ->
     LDecl.hyps -> occ option -> form -> form -> ptnpos

--- a/src/ecProofTerm.ml
+++ b/src/ecProofTerm.ml
@@ -341,7 +341,7 @@ let pf_find_occurence
 
   let mode = { mode with fm_conv = occmode.k_conv } in
 
-  let trymatch mode bds tp =
+  let trymatch mode bds pte_hy tp =
     if not (keycheck tp key) then `Continue else
 
     let tps =
@@ -357,7 +357,7 @@ let pf_find_occurence
       tps |> List.iter (fun tp ->
         if Mid.set_disjoint bds tp.f_fv then begin
           try
-            pf_form_match ~mode pt ~ptn tp;
+            pf_form_match ~mode { pt with pte_hy } ~ptn tp;
             raise (E.MatchFound tp)
           with EcMatching.MatchFailure -> ()
       end);
@@ -370,8 +370,8 @@ let pf_find_occurence
   try
     let _ =
       if   rooted
-      then ignore (trymatch mode Mid.empty subject)
-      else ignore (EcMatching.FPosition.select (trymatch mode) subject)
+      then ignore (trymatch mode Mid.empty pt.pte_hy subject)
+      else ignore (EcMatching.FPosition.select (trymatch mode) pt.pte_hy subject)
     in raise (FindOccFailure `MatchFailure)
   with E.MatchFound subf ->
      if full && not (can_concretize pt) then begin

--- a/src/ecSearch.ml
+++ b/src/ecSearch.ml
@@ -43,7 +43,7 @@ let match_ (env : EcEnv.env) (search : search list) f =
         let ev = EcMatching.MEV.of_idents (Mid.keys !v) `Form in
         let na = List.length (snd (EcFol.destr_app ptn)) in
 
-        let trymatch _bds tp =
+        let trymatch _bds hyps tp =
           let tp =
             match tp.f_node with
             | Fapp (h, hargs) when List.length hargs > na ->
@@ -59,7 +59,7 @@ let match_ (env : EcEnv.env) (search : search list) f =
             `Continue
 
         in try
-            ignore (EcMatching.FPosition.select trymatch f);
+            ignore (EcMatching.FPosition.select trymatch hyps f);
             false
           with E.MatchFound -> true
       end

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -2923,7 +2923,9 @@ and trans_form_or_pattern env ?mv ?ps ue pf tt =
 
                   let module E = struct exception MatchFound end in
 
-                  let test =
+                  let test hyps =
+                    let env = EcEnv.LDecl.toenv hyps in
+
                     match ppt with
                     | `Pattern ppt ->
                          let ue   = EcUnify.UniEnv.create None in
@@ -2976,7 +2978,8 @@ and trans_form_or_pattern env ?mv ?ps ue pf tt =
 
                   let test target =
                     try
-                      ignore (EcMatching.FPosition.select (fun _ -> test) target);
+                      let hyps = EcEnv.LDecl.init env [] in
+                      ignore (EcMatching.FPosition.select (fun _ -> test) hyps target);
                       false
                     with E.MatchFound -> true in
 

--- a/src/phl/ecPhlPrRw.ml
+++ b/src/phl/ecPhlPrRw.ml
@@ -181,11 +181,11 @@ let t_pr_rewrite_low (s,dof) tc =
     | `MuSum   -> select_pr (fun _ev -> true)
   in
 
-  let select xs fp = if select xs fp then `Accept (-1) else `Continue in
-  let env, _, concl = FApi.tc1_eflat tc in
+  let select xs _ fp = if select xs fp then `Accept (-1) else `Continue in
+  let env, hyps, concl = FApi.tc1_eflat tc in
   let torw =
     try
-      ignore (EcMatching.FPosition.select select concl);
+      ignore (EcMatching.FPosition.select select hyps concl);
       tc_error !!tc "cannot find a pattern for %s" s
     with FoundPr f -> f in
 


### PR DESCRIPTION
Fix #72, fix #142