### PR TITLE
stop normalizing lemmas/operators w.r.t. module aliases

### DIFF
--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -233,7 +233,6 @@ module NormMp : sig
   val norm_mpath    : env -> mpath -> mpath
   val norm_xfun     : env -> xpath -> xpath
   val norm_pvar     : env -> EcTypes.prog_var -> EcTypes.prog_var
-  val norm_form     : env -> form -> form
   val mod_use       : env -> mpath -> use
   val fun_use       : env -> xpath -> use
   val restr_use     : env -> mod_restr -> use use_restr


### PR DESCRIPTION
The environment module is currently pre-normalizin module aliases in lemmas & operators. This legacy code was a work-around w.r.t. the glob unsoundness.

This behavior is now useless and kills the benefit of module aliases. This commit removes it.