### PR TITLE
Improve constant-propagation

### DIFF
--- a/src/ecAst.ml
+++ b/src/ecAst.ml
@@ -97,7 +97,6 @@ and ebinding  = EcIdent.t * ty
 and ebindings = ebinding list
 
 (* -------------------------------------------------------------------- *)
-
 and lvalue =
   | LvVar   of (prog_var * ty)
   | LvTuple of (prog_var * ty) list

--- a/src/ecCoreModules.ml
+++ b/src/ecCoreModules.ml
@@ -36,6 +36,10 @@ let lv_to_list = function
   | LvVar (pv, _) -> [pv]
   | LvTuple pvs -> List.fst pvs
 
+let lv_to_ty_list = function
+  | LvVar (pv, ty) -> [pv, ty]
+  | LvTuple pvs -> pvs
+
 let name_of_lv lv =
   match lv with
   | LvVar (pv, _) ->

--- a/src/ecCoreModules.mli
+++ b/src/ecCoreModules.mli
@@ -7,13 +7,14 @@ open EcTypes
 (* -------------------------------------------------------------------- *)
 type lvalue = EcAst.lvalue
 
-val lv_equal     : lvalue -> lvalue -> bool
-val symbol_of_lv : lvalue -> symbol
-val ty_of_lv     : lvalue -> EcTypes.ty
-val lv_of_list   : (prog_var * ty) list -> lvalue option
-val lv_to_list   : lvalue -> prog_var list
-val name_of_lv   : lvalue -> string
-val lv_of_expr   : expr -> lvalue
+val lv_equal        : lvalue -> lvalue -> bool
+val symbol_of_lv    : lvalue -> symbol
+val ty_of_lv        : lvalue -> EcTypes.ty
+val lv_of_list      : (prog_var * ty) list -> lvalue option
+val lv_to_list      : lvalue -> prog_var list
+val lv_to_ty_list   : lvalue -> (prog_var * ty) list
+val name_of_lv      : lvalue -> string
+val lv_of_expr      : expr -> lvalue
 
 (* --------------------------------------------------------------------- *)
 type instr = EcAst.instr

--- a/src/ecPV.ml
+++ b/src/ecPV.ml
@@ -72,10 +72,19 @@ module Mpv = struct
     check_npv env pv m;
     { m with s_pv = Mnpv.add pv f m.s_pv }
 
+  let remove env pv m =
+    let pv = pvm env pv in
+    { m with s_pv = Mnpv.remove pv m.s_pv }
+
   let find env pv m =
     let pv = pvm env pv in
     try Mnpv.find pv m.s_pv
     with Not_found -> check_npv env pv m; raise Not_found
+
+  let mem env pv m =
+    match find env pv m with
+    | _ -> true
+    | exception Not_found -> false
 
   let check_mp_mp env mp restr mp' restr' =
     if not (EcPath.m_equal mp mp') &&

--- a/src/ecPV.mli
+++ b/src/ecPV.mli
@@ -46,13 +46,20 @@ module Mpv : sig
 
   val add : env -> prog_var -> 'a -> ('a,'b) t -> ('a,'b) t
 
+  val remove : env -> prog_var -> ('a,'b) t -> ('a,'b) t
+
   val add_glob : env -> mpath -> 'b -> ('a,'b) t -> ('a,'b) t
 
   val find : env -> prog_var -> ('a,'b) t -> 'a
 
+  val mem : env -> prog_var -> ('a,'b) t -> bool
+
   val find_glob : env -> mpath -> ('a,'b) t -> 'b
 
+  val esubst : env -> (expr, unit) t -> expr -> expr 
   val issubst : env -> (expr, unit) t -> instr list -> instr list
+  val isubst : env -> (expr, unit) t -> instr -> instr 
+  val ssubst : env -> (expr, unit) t -> stmt -> stmt
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3040,11 +3040,8 @@ phltactic:
 | INTERLEAVE info=loc(interleave_info)
     { Pinterleave info }
 
-| CFOLD s=side? c=codepos NOT n=word
-    { Pcfold (s, c, Some n) }
-
-| CFOLD s=side? c=codepos
-    { Pcfold (s, c, None) }
+| CFOLD s=side? c=codepos n=word?
+    { Pcfold (s, c, n) }
 
 | RND s=side? info=rnd_info c=prefix(COLON, semrndpos)?
     { Prnd (s, c, info) }

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -586,6 +586,29 @@ module List = struct
 
   let has_dup ?(cmp = Stdlib.compare) (xs : 'a list) =
     Option.is_some (find_dup ~cmp xs)
+
+  (* Separate list into a prefix for which p is true and the rest *)
+  let takedrop_while (p: 'a -> bool) (xs : 'a list) = 
+    let rec doit (acc: 'a list) (xs : 'a list) =
+    match xs with
+    | [] -> (List.rev acc, [])
+    | x::xs -> if p x then doit (x::acc) xs else (List.rev acc, x::xs)
+    in doit [] xs
+
+
+  type 'a interruptible = [`Interrupt | `Continue of 'a]
+
+  let fold_left_map_while (f : 'a -> 'b -> ('a * 'c) interruptible) =
+    let rec aux (state : 'a) (acc : 'c list) (xs : 'b list) =
+      match xs with
+      | [] -> (state, List.rev acc, [])
+      | y :: ys -> begin
+        match f state y with
+        | `Continue (state, y) -> aux state (y :: acc) ys
+        | `Interrupt -> (state, List.rev acc, xs)
+      end
+
+    in fun state xs -> aux state [] xs
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecUtils.mli
+++ b/src/ecUtils.mli
@@ -294,6 +294,12 @@ module List : sig
   val find_dup   : ?cmp:('a -> 'a -> int) -> 'a list -> 'a option
   val has_dup    : ?cmp:('a -> 'a -> int) -> 'a list -> bool
 
+  val takedrop_while : ('a -> bool) -> 'a list -> 'a list * 'a list
+
+  val fold_left_map_while :
+       ('a -> 'b -> [`Interrupt | `Continue of 'a * 'c])
+    -> 'a -> 'b list -> 'a * 'c list * 'b list
+
   (* ------------------------------------------------------------------ *)
   val ksort:
         ?stable:bool -> ?rev:bool

--- a/tests/cfold.ec
+++ b/tests/cfold.ec
@@ -1,0 +1,114 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore Distr.
+
+(* -------------------------------------------------------------------- *)
+theory CfoldStopIf.
+  module M = {
+    proc f(a : int, b : int) : int = {
+      var c : int;
+      var d : int;
+      
+      c <- 0;
+      d <- c + 1;
+      c <- b + a;
+      
+      if (a + b = c) {
+        c <- 0;
+        a <- c;
+      } else {
+        c <- 1;
+        b <- c;
+      }
+      return c;
+    }
+  }.
+  
+  lemma L : hoare[M.f : true ==> res = 0].
+  proof.
+  proc.
+  cfold 1.
+  by auto => /> ?; apply addzC.
+  qed.
+end CfoldStopIf.
+
+(* -------------------------------------------------------------------- *)
+theory CfoldTuple.
+  module M = {
+    proc f( x : int * int) : int = {
+      var a : int;
+      var b : int;
+      var c : int <- 0;
+
+      x <- (0, 0);
+      a <- x.`1;
+      b <- snd x;
+
+      while (a + b <> b + a) {
+        c <- c + 1;
+      }
+      return c;
+    }
+  }.
+  
+  lemma L : hoare[M.f : true ==> res = 0].
+  proof.
+  proc.
+  cfold 2.
+  by rcondf ^while; auto.
+  qed.
+end CfoldTuple.
+
+theory CfoldN.
+  module M = {
+    proc f(a : int, b : int) : int = {
+      var c : int;
+      c <- 0;
+      a <- c;
+      c <- 1;
+      b <- 2;
+      c <- 2;
+      a <- 3;
+      c <- 3;
+      if (a <> b) {
+        c <- 0;
+      } 
+      return c;
+    }
+  }.
+
+  lemma L : hoare[M.f : true ==> res = 0].
+  proof.
+  proc.
+  cfold 1 4.
+  by auto => />.
+  qed.
+end CfoldN.
+
+theory CfoldWhileUnroll.
+  module M = {
+    proc f(a : int, b : int) : int = {
+      var c : int;
+      c <- 0;
+      c <- c + 1;
+      c <- 0;
+      while (c < 10) {
+        a <- c;
+        c <- c + 1;
+      }
+      b <- c;
+      if (a <> b) {
+        c <- 0;
+      }
+      return c;
+    }
+  }.
+
+  lemma L : hoare[M.f : true ==> res = 0].
+  proof.
+  proc.
+  cfold 1.
+  unroll for 2.
+  cfold 1.
+  by auto => />.
+  qed.
+end CfoldWhileUnroll.


### PR DESCRIPTION
This new version of constant-propagation doesn't stop after the propagation. Instead, it continues as far as possible.

The tactic takes as argument a limit `n`. In that case, the constant propagation will only be applied for the first `n` lines of the program.