### PR TITLE
PR: Adding CoreLib bindings for List theory

### DIFF
--- a/src/ecCoreFol.ml
+++ b/src/ecCoreFol.ml
@@ -188,6 +188,34 @@ let f_false  = f_op EcCoreLib.CI_Bool.p_false [] tbool
 let f_bool   = fun b -> if b then f_true else f_false
 
 (* -------------------------------------------------------------------- *)
+(* TODO: check types here *)
+let ty_ftlist1 ty = toarrow (List.make 1 ty) (tlist ty)
+let ty_ftlist2 ty = toarrow ([ty; (tlist ty)]) (tlist ty)
+let ty_flist1 ty = toarrow (List.make 1 (tlist ty)) (tlist ty)
+let ty_flist2 ty = toarrow (List.make 2 (tlist ty)) (tlist ty)
+let ty_fllist ty = toarrow (List.make 1 (tlist @@ tlist ty)) (tlist ty)
+let ty_lmap ty1 ty2 = toarrow ([toarrow [ty1] ty2; tlist ty1]) (tlist ty2) 
+let ty_chunk ty = toarrow [tint; tlist ty] (tlist @@ tlist ty)
+let ty_all ty = toarrow [(toarrow [ty] tbool); tlist ty] tbool
+
+let fop_empty ty = f_op EcCoreLib.CI_List.p_empty [ty] (tlist ty)
+let fop_cons ty = f_op EcCoreLib.CI_List.p_cons [ty] (ty_ftlist2 ty)
+let fop_append ty = f_op EcCoreLib.CI_List.p_append [ty] (ty_flist2 ty)
+let fop_flatten ty = f_op EcCoreLib.CI_List.p_flatten [ty] (ty_fllist ty)
+let fop_lmap ty1 ty2 = f_op EcCoreLib.CI_List.p_map [ty2; ty1] (ty_lmap ty1 ty2)
+let fop_chunk ty = f_op EcCoreLib.CI_List.p_chunk [ty] (ty_chunk ty)
+let fop_all ty = f_op EcCoreLib.CI_List.p_all [ty] (ty_all ty)
+
+let f_append a b ty = f_app (fop_append ty) [a; b] (tlist ty)
+let f_cons a b ty = f_app (fop_cons ty) [a; b] (tlist ty)
+let f_flatten a ty = f_app (fop_flatten ty) [a] (tlist ty)
+let f_lmap f a ty1 ty2 = f_app (fop_lmap ty1 ty2) [f;a] (tlist ty2)
+let f_chunk a (n: int) ty2 = 
+  let ty = tfrom_tlist a.f_ty in
+  f_app (fop_chunk ty) [mk_form (Fint (BI.of_int n)) tint; a] (tlist @@ tlist ty)
+let f_all f a ty = f_app (fop_all ty) [f; a] tbool
+
+(* -------------------------------------------------------------------- *)
 let f_tuple args =
   match args with
   | []  -> f_tt
@@ -766,6 +794,8 @@ let is_op_not      p = EcPath.p_equal EcCoreLib.CI_Bool.p_not p
 let is_op_imp      p = EcPath.p_equal EcCoreLib.CI_Bool.p_imp p
 let is_op_iff      p = EcPath.p_equal EcCoreLib.CI_Bool.p_iff p
 let is_op_eq       p = EcPath.p_equal EcCoreLib.CI_Bool.p_eq  p
+let is_op_cons     p = EcPath.p_equal EcCoreLib.CI_List.p_cons p
+let is_op_witness  p = EcPath.p_equal EcCoreLib.CI_Witness.p_witness p
 
 (* -------------------------------------------------------------------- *)
 let destr_op = function
@@ -837,6 +867,20 @@ let destr_nots form =
     | Some form -> aux (not b) form
   in aux true form
 
+let destr_cons form = 
+  match destr_app form with
+  | {f_node = Fop (p, _)}, [h;t] when is_op_cons p -> (h, t)
+  | _ -> destr_error "cons"
+
+(* Returns empty list if not actually a list FIXME *)
+let destr_list form =
+  let rec aux form = 
+    match try Some (destr_cons form) with DestrError _ -> None with
+    | Some (h, t) -> h::(aux t)
+    | None -> []
+  in
+  aux form
+
 (* -------------------------------------------------------------------- *)
 let is_from_destr dt f =
   try ignore (dt f); true with DestrError _ -> false
@@ -870,6 +914,8 @@ let is_bdHoareS  f = is_from_destr destr_bdHoareS  f
 let is_bdHoareF  f = is_from_destr destr_bdHoareF  f
 let is_pr        f = is_from_destr destr_pr        f
 let is_eq_or_iff f = (is_eq f) || (is_iff f)
+
+let is_witness   f = destr_op f |> fst |> is_op_witness
 
 (* -------------------------------------------------------------------- *)
 let split_args f =

--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -151,6 +151,32 @@ val f_eagerF   : form -> stmt -> xpath -> xpath -> stmt -> form -> form
 val f_pr_r : pr -> form
 val f_pr   : memory -> xpath -> form -> form -> form
 
+(* FIXME: Check this V *)
+
+val ty_ftlist1 : ty -> ty
+val ty_ftlist2 : ty -> ty
+val ty_flist1  : ty -> ty
+val ty_flist2  : ty -> ty
+val ty_lmap    : ty -> ty -> ty
+val ty_chunk   : ty -> ty
+val ty_all     : ty -> ty
+
+val fop_empty   : ty -> form
+val fop_cons    : ty -> form
+val fop_append  : ty -> form
+val fop_flatten : ty -> form
+val fop_lmap    : ty -> ty -> form
+val fop_chunk   : ty -> form
+val fop_all     : ty -> form
+
+val f_append  : form -> form -> ty -> form
+val f_cons    : form -> form -> ty -> form
+val f_flatten : form -> ty -> form 
+val f_lmap    : form -> form -> ty -> ty -> form
+val f_chunk   : form -> int -> ty -> form
+val f_all     : form -> form -> ty -> form
+
+
 (* soft-constructors - unit *)
 val f_tt : form
 
@@ -289,6 +315,10 @@ val destr_int       : form -> zint
 
 val destr_glob      : form -> EcIdent.t        * memory
 val destr_pvar      : form -> EcTypes.prog_var * memory
+
+val destr_cons      : form -> form * form
+val destr_list      : form -> form list
+val is_witness      : form -> bool
 
 (* -------------------------------------------------------------------- *)
 val is_true      : form -> bool

--- a/src/ecCoreLib.ml
+++ b/src/ecCoreLib.ml
@@ -49,6 +49,29 @@ module CI_Bool = struct
 end
 
 (* -------------------------------------------------------------------- *)
+module CI_List = struct
+  let i_List = "List"
+  let p_List = EcPath.pqname p_top i_List
+  let _List  = fun x -> EcPath.pqname p_List x
+  let p_list = _List "list"
+
+  let p_empty = _List "[]"
+  let p_cons = _List "::"
+  let p_head = _List "head"
+  let p_behead = _List "behead"
+  let p_tail = p_behead
+  let p_append = _List "++"
+  let p_flatten = EcPath.pqname p_List "flatten"
+  let p_map = _List "map"
+  let p_mapi = _List "mapi"
+  let p_chunk = EcPath.pqname (EcPath.pqname (EcPath.pqname p_top "BitEncoding") "BitChunking") "chunk"
+  let p_all = _List "all"
+  let p_nth = _List "nth"
+  let p_size = _List "size"
+  let p_mkseq = _List "mkseq"
+end
+  
+(* -------------------------------------------------------------------- *)
 module CI_Option = struct
   let i_Option  = "Logic"
   let p_Option  = EcPath.pqname p_top i_Option

--- a/src/ecCoreLib.mli
+++ b/src/ecCoreLib.mli
@@ -49,6 +49,29 @@ module CI_Option : sig
   val p_oget   : path
 end
 
+
+(*-------------------------------------------------------------------- *)
+module CI_List : sig
+  val i_List    : symbol
+  val p_List    : path
+  val p_list    : path
+  
+  val p_empty   : path
+  val p_cons    : path
+  val p_head    : path
+  val p_behead  : path
+  val p_tail    : path
+  val p_append  : path
+  val p_flatten : path
+  val p_map     : path
+  val p_mapi    : path
+  val p_chunk   : path
+  val p_all     : path
+  val p_size    : path
+  val p_nth     : path
+  val p_mkseq   : path
+  end
+
 (*-------------------------------------------------------------------- *)
 module CI_Bool : sig
   val i_Bool : symbol

--- a/src/ecTypes.ml
+++ b/src/ecTypes.ml
@@ -72,6 +72,7 @@ let txint      = tconstr EcCoreLib.CI_xint .p_xint    []
 
 let tdistr ty  = tconstr EcCoreLib.CI_Distr.p_distr   [ty]
 let toption ty = tconstr EcCoreLib.CI_Option.p_option [ty]
+let tlist ty   = tconstr EcCoreLib.CI_List.p_list     [ty]
 let treal      = tconstr EcCoreLib.CI_Real .p_real    []
 let tcpred ty  = tfun ty tbool
 
@@ -86,6 +87,17 @@ let ttuple lt    =
 
 let toarrow dom ty =
   List.fold_right tfun dom ty
+
+let tfrom_tlist ty =
+  let p_list = EcCoreLib.CI_List.p_list in
+  match ty.ty_node with
+  | Tconstr (p, [ty]) when p = p_list -> ty
+  | _ -> assert false
+
+let tfrom_tfun2 ty =
+  match ty.ty_node with
+  | Tfun (a, b) -> (a, b)
+  | _ -> assert false
 
 let tpred t = tfun t tbool
 

--- a/src/ecTypes.mli
+++ b/src/ecTypes.mli
@@ -45,11 +45,15 @@ val txint   : ty
 val treal   : ty
 val tdistr  : ty -> ty
 val toption : ty -> ty
+val tlist   : ty -> ty
 val tcpred  : ty -> ty
 val toarrow : ty list -> ty -> ty
 
 val trealp : ty
 val txreal : ty
+
+val tfrom_tlist : ty -> ty
+val tfrom_tfun2 : ty -> ty * ty
 
 val tytuple_flat : ty -> ty list
 val tyfun_flat   : ty -> (dom * ty)


### PR DESCRIPTION
This adds bindings for the List theory in src/ecCoreLib.ml, form constructors for them in src/ecCoreFol.ml and a constructor for the list type in src/ecTypes.ml