### PR TITLE
Added formosa-25519 curve25519 to external CI

### DIFF
--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -73,4 +73,15 @@
   , "scenario"   : "sphincsplus"
   , "options"    : ""
   }
+
+  ,
+
+  { "name"       : "curve25519"
+  , "repository" : "https://github.com/formosa-crypto/formosa-25519"
+  , "branch"     : "main"
+  , "subdir"     : "proof/crypto_scalarmult/curve25519"
+  , "config"     : "tests.config"
+  , "scenario"   : "curve25519"
+  , "options"    : ""
+  }
 ]

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -80,7 +80,7 @@
   , "repository" : "https://github.com/formosa-crypto/formosa-25519"
   , "branch"     : "main"
   , "subdir"     : "proof/crypto_scalarmult/curve25519"
-  , "config"     : "../../tests.config"
+  , "config"     : "tests.config"
   , "scenario"   : "curve25519"
   , "options"    : ""
   }

--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -80,7 +80,7 @@
   , "repository" : "https://github.com/formosa-crypto/formosa-25519"
   , "branch"     : "main"
   , "subdir"     : "proof/crypto_scalarmult/curve25519"
-  , "config"     : "tests.config"
+  , "config"     : "../../tests.config"
   , "scenario"   : "curve25519"
   , "options"    : ""
   }


### PR DESCRIPTION
Added formosa-25519's Curve25519 proof to the external CI.

Draft as the changes necessary to the formosa-25519' such that it can the proofs can be checked by the CI. There is a PR for this https://github.com/formosa-crypto/formosa-25519/pull/25.
