### PR TITLE
`proc rewrite` now supports the `/=` rule

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3241,7 +3241,10 @@ phltactic:
     { Pprocchange (side, pos, f) }
 
 | PROC REWRITE side=side? pos=codepos f=pterm
-    { Pprocrewrite (side, pos, f) }
+    { Pprocrewrite (side, pos, `Rw f) }
+
+| PROC REWRITE side=side? pos=codepos SLASHEQ
+    { Pprocrewrite (side, pos, `Simpl) }
 
 bdhoare_split:
 | b1=sform b2=sform b3=sform?

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -698,6 +698,9 @@ type matchmode = [
 ]
 
 (* -------------------------------------------------------------------- *)
+type prrewrite = [`Rw of ppterm | `Simpl]
+
+(* -------------------------------------------------------------------- *)
 type phltactic =
   | Pskip
   | Prepl_stmt     of trans_info
@@ -748,7 +751,7 @@ type phltactic =
   | Psymmetry
   | Pbdhoare_split of bdh_split
   | Pprocchange    of side option * codepos * pexpr
-  | Pprocrewrite   of side option * codepos * ppterm
+  | Pprocrewrite   of side option * codepos * prrewrite
 
     (* Eager *)
   | Peager_seq       of (eager_info * codepos1 pair * pformula)

--- a/src/phl/ecPhlRewrite.mli
+++ b/src/phl/ecPhlRewrite.mli
@@ -4,4 +4,7 @@ open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
 val process_change : side option -> codepos -> pexpr -> backward
-val process_rewrite : side option -> codepos -> ppterm -> backward
+
+val process_rewrite_rw    : side option -> codepos -> ppterm -> backward
+val process_rewrite_simpl : side option -> codepos -> backward
+val process_rewrite       : side option -> codepos -> prrewrite -> backward

--- a/tests/procrewrite-simpl.ec
+++ b/tests/procrewrite-simpl.ec
@@ -1,0 +1,14 @@
+require import AllCore.
+
+module M = {
+  proc f(x : int) : int = {
+    x <- x * 0;
+    return x;
+  }
+}.
+
+lemma L : hoare[M.f : true ==> true].
+proof.
+proc.
+proc rewrite 1 /=.
+abort.


### PR DESCRIPTION
The implementation is outside of the TCB.
