### PR TITLE
 Propagate extended code positions to more tactics

### DIFF
--- a/src/ecCorePrinting.ml
+++ b/src/ecCorePrinting.ml
@@ -24,7 +24,7 @@ module type PrinterAPI = sig
 
   (* ------------------------------------------------------------------ *)
   val string_of_hcmp : EcFol.hoarecmp -> string
-  val string_of_cpos1 : EcParsetree.codepos1 -> string
+  val string_of_cpos1 : EcMatching.Position.codepos1 -> string
 
   (* ------------------------------------------------------------------ *)
   type 'a pp = Format.formatter -> 'a -> unit

--- a/src/ecHiTacticals.ml
+++ b/src/ecHiTacticals.ml
@@ -174,9 +174,9 @@ and process1_phl (_ : ttenv) (t : phltactic located) (tc : tcenv1) =
     | Pskip                     -> EcPhlSkip.t_skip
     | Papp info                 -> EcPhlApp.process_app info
     | Pwp wp                    -> EcPhlWp.process_wp wp
-    | Psp sp                    -> EcPhlSp.t_sp sp
+    | Psp sp                    -> EcPhlSp.process_sp sp
     | Prcond (side, b, i)       -> EcPhlRCond.process_rcond side b i
-    | Prmatch (side, c, i)      -> EcPhlRCond.t_rcond_match side c i
+    | Prmatch (side, c, i)      -> EcPhlRCond.process_rcond_match side c i
     | Pcond info                -> EcPhlHiCond.process_cond info
     | Pmatch infos              -> EcPhlHiCond.process_match infos
     | Pwhile (side, info)       -> EcPhlWhile.process_while side info

--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -6,7 +6,6 @@
 open EcUtils
 open EcMaps
 open EcIdent
-open EcParsetree
 open EcEnv
 open EcAst
 open EcTypes
@@ -15,7 +14,30 @@ open EcFol
 open EcGenRegexp
 
 (* -------------------------------------------------------------------- *)
+module Position = struct
+  type cp_match = [
+    | `If
+    | `While
+    | `Assign of lvmatch
+    | `Sample
+    | `Call
+  ]
+
+  and lvmatch = [ `LvmNone | `LvmVar of EcTypes.prog_var ]
+
+  type cp_base = [
+    | `ByPos of int
+    | `ByMatch of int option * cp_match
+  ]
+
+  type codepos1   = int * cp_base
+  type codepos    = (codepos1 * int) list * codepos1
+end
+
+(* -------------------------------------------------------------------- *)
 module Zipper = struct
+  open Position
+
   exception InvalidCPos
 
   module P = EcPath
@@ -41,7 +63,11 @@ module Zipper = struct
 
   let zipper hd tl zpr = { z_head = hd; z_tail = tl; z_path = zpr; }
 
-  let find_by_cp_match ((i, cm) : int option * cp_match) (s : stmt) =
+  let find_by_cp_match
+    (env     : EcEnv.env)
+    ((i, cm) : int option * cp_match)
+    (s       : stmt)
+  =
     let rec progress (acc : instr list) (s : instr list) (i : int) =
       if i <= 0 then
         let shd = oget (List.Exceptionless.hd acc) in
@@ -57,10 +83,19 @@ module Zipper = struct
         match ir.i_node, cm with
         | Swhile _, `While  -> i-1
         | Sif    _, `If     -> i-1
-        | Sasgn  _, `Assign -> i-1
         | Srnd   _, `Sample -> i-1
         | Scall  _, `Call   -> i-1
-        | _       , _       -> i
+
+        | Sasgn  (lv, _), `Assign lvm -> begin
+            match lv, lvm with
+            | _, `LvmNone -> i-1
+            | LvVar (pv, _), `LvmVar pvm
+                 when EcReduction.EqTest.for_pv env pv pvm
+              -> i-1
+            | _ -> i
+          end
+
+        | _ -> i
 
       in progress (ir :: acc) s i
 
@@ -76,7 +111,7 @@ module Zipper = struct
     | false -> (s1, ir, s2)
     | true  -> (s2, ir, s1)
 
-  let split_at_cp_base ~after (cb : cp_base) (s : stmt) =
+  let split_at_cp_base ~after (env : EcEnv.env) (cb : cp_base) (s : stmt) =
     match cb with
     | `ByPos i -> begin
         let i = if i < 0 then List.length s.s_node + i else i in
@@ -85,14 +120,14 @@ module Zipper = struct
       end
 
     | `ByMatch (i, cm) ->
-        let (s1, i, s2) = find_by_cp_match (i, cm) s in
+        let (s1, i, s2) = find_by_cp_match env (i, cm) s in
 
         match after with
         | false -> (List.rev s1, i :: s2)
         | true  -> (List.rev_append s1 [i], s2)
 
-  let split_at_cpos1 ~after ((ipos, cb) : codepos1) s =
-    let (s1, s2) = split_at_cp_base ~after cb s in
+  let split_at_cpos1 ~after (env : EcEnv.env) ((ipos, cb) : codepos1) s =
+    let (s1, s2) = split_at_cp_base ~after env cb s in
 
     let (s1, s2) =
       match ipos with
@@ -112,13 +147,13 @@ module Zipper = struct
 
     in (s1, s2)
 
-  let find_by_cpos1 ?(rev = true) (cpos1 : codepos1) s =
-    match split_at_cpos1 ~after:false cpos1 s with
+  let find_by_cpos1 ?(rev = true) (env : EcEnv.env) (cpos1 : codepos1) s =
+    match split_at_cpos1 ~after:false env cpos1 s with
     | (s1, i :: s2) -> ((if rev then List.rev s1 else s1), i, s2)
     | _ -> raise InvalidCPos
 
-  let zipper_at_nm_cpos1 ((cp1, sub) : codepos1 * int) s zpr =
-    let (s1, i, s2) = find_by_cpos1 cp1 s in
+  let zipper_at_nm_cpos1 (env : EcEnv.env) ((cp1, sub) : codepos1 * int) s zpr =
+    let (s1, i, s2) = find_by_cpos1 env cp1 s in
 
     match i.i_node, sub with
     | Swhile (e, sw), 0 ->
@@ -132,23 +167,23 @@ module Zipper = struct
 
     | _ -> raise InvalidCPos
 
-  let zipper_of_cpos ((nm, cp1) : codepos) s =
+  let zipper_of_cpos (env : EcEnv.env) ((nm, cp1) : codepos) s =
     let zpr, s =
       List.fold_left
-        (fun (zpr, s) nm1 -> zipper_at_nm_cpos1 nm1 s zpr)
+        (fun (zpr, s) nm1 -> zipper_at_nm_cpos1 env nm1 s zpr)
         (ZTop, s) nm in
 
-    let s1, i, s2 = find_by_cpos1 cp1 s in
+    let s1, i, s2 = find_by_cpos1 env cp1 s in
 
     zipper s1 (i :: s2) zpr
 
-  let split_at_cpos1 cpos1 s =
-    split_at_cpos1 ~after:true cpos1 s
+  let split_at_cpos1 env cpos1 s =
+    split_at_cpos1 ~after:true env cpos1 s
 
-  let may_split_at_cpos1 ?(rev = false) cpos1 s =
+  let may_split_at_cpos1 ?(rev = false) env cpos1 s =
     ofdfl
       (fun () -> if rev then (s.s_node, []) else ([], s.s_node))
-      (omap (split_at_cpos1^~ s) cpos1)
+      (omap ((split_at_cpos1 env)^~ s) cpos1)
 
   let rec zip i ((hd, tl), ip) =
     let s = stmt (List.rev_append hd (List.ocons i tl)) in
@@ -178,21 +213,21 @@ module Zipper = struct
     in
       List.rev after
 
-  let fold env cpos f state s =
-    let zpr = zipper_of_cpos cpos s in
+  let fold env cenv cpos f state s =
+    let zpr = zipper_of_cpos env cpos s in
 
       match zpr.z_tail with
       | []      -> raise InvalidCPos
       | i :: tl -> begin
-          match f env state i with
+          match f cenv state i with
           | (state', [i']) when i == i' && state == state' -> (state, s)
           | (state', si  ) -> (state', zip { zpr with z_tail = si @ tl })
       end
 
-  let map cpos f s =
+  let map env cpos f s =
     fst_map
       Option.get
-      (fold () cpos (fun () _ i -> fst_map some (f i)) None s)
+      (fold env () cpos (fun () _ i -> fst_map some (f i)) None s)
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecMatching.mli
+++ b/src/ecMatching.mli
@@ -1,7 +1,6 @@
 (* -------------------------------------------------------------------- *)
 open EcMaps
 open EcUid
-open EcParsetree
 open EcIdent
 open EcTypes
 open EcModules
@@ -11,7 +10,30 @@ open EcEnv
 open EcGenRegexp
 
 (* -------------------------------------------------------------------- *)
+module Position : sig
+  type cp_match = [
+    | `If
+    | `While
+    | `Assign of lvmatch
+    | `Sample
+    | `Call
+  ]
+
+  and lvmatch = [ `LvmNone | `LvmVar of EcTypes.prog_var ]
+
+  type cp_base = [
+    | `ByPos of int
+    | `ByMatch of int option * cp_match
+  ]
+
+  type codepos1   = int * cp_base
+  type codepos    = (codepos1 * int) list * codepos1
+end
+
+(* -------------------------------------------------------------------- *)
 module Zipper : sig
+  open Position
+
   type ipath =
   | ZTop
   | ZWhile  of expr * spath
@@ -32,18 +54,18 @@ module Zipper : sig
   val cpos : int -> codepos1
 
   (* Split a statement from a top-level position (codepos1) *)
-  val find_by_cpos1  : ?rev:bool -> codepos1 -> stmt -> instr list * instr * instr list
-  val split_at_cpos1 : codepos1 -> stmt -> instr list * instr list
+  val find_by_cpos1  : ?rev:bool -> env -> codepos1 -> stmt -> instr list * instr * instr list
+  val split_at_cpos1 : env -> codepos1 -> stmt -> instr list * instr list
 
   (* Split a statement from an optional top-level position (codepos1) *)
-  val may_split_at_cpos1 : ?rev:bool -> codepos1 option -> stmt -> instr list * instr list
+  val may_split_at_cpos1 : ?rev:bool -> env -> codepos1 option -> stmt -> instr list * instr list
 
   (* [zipper] soft constructor *)
   val zipper : instr list -> instr list -> ipath -> zipper
 
   (* Return the zipper for the stmt [stmt] at code position [codepos].
    * Raise [InvalidCPos] if [codepos] is not valid for [stmt]. *)
-  val zipper_of_cpos : codepos -> stmt -> zipper
+  val zipper_of_cpos : env -> codepos -> stmt -> zipper
 
   (* Zip the zipper, returning the corresponding statement *)
   val zip : zipper -> stmt
@@ -58,19 +80,19 @@ module Zipper : sig
 
   type ('a, 'state) folder = 'a -> 'state -> instr -> 'state * instr list
 
-  (* [fold v cpos f state s] create the zipper for [s] at [cpos], and apply
+  (* [fold env v cpos f state s] create the zipper for [s] at [cpos], and apply
    * [f] to it, along with [v] and the state [state]. [f] must return the
    * new [state] and a new [zipper]. These last are directly returned.
    *
    * Raise [InvalidCPos] if [cpos] is not valid for [s], or any exception
    * raised by [f].
    *)
-  val fold : 'a -> codepos -> ('a, 'state) folder -> 'state -> stmt -> 'state * stmt
+  val fold : env -> 'a -> codepos -> ('a, 'state) folder -> 'state -> stmt -> 'state * stmt
 
-  (* [map cpos f s] is a special case of [fold] where the state and the
+  (* [map cpos env f s] is a special case of [fold] where the state and the
    * out-of-band data are absent
    *)
-  val map : codepos -> (instr -> 'a * instr list) -> stmt -> 'a * stmt
+  val map : env -> codepos -> (instr -> 'a * instr list) -> stmt -> 'a * stmt
 
 end
 

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -487,12 +487,21 @@ type preduction = {
 }
 
 (* -------------------------------------------------------------------- *)
-type cp_match = [ `If | `While | `Assign | `Sample | `Call ]
-type cp_base  = [ `ByPos of int | `ByMatch of int option * cp_match ]
+type pcp_match = [
+  | `If
+  | `While
+  | `Assign of plvmatch
+  | `Sample
+  | `Call
+]
 
-type codepos1 = int * cp_base
-type codepos  = (codepos1 * int) list * codepos1
-type docodepos1 = codepos1 doption option
+and plvmatch = [ `LvmNone | `LvmVar of pqsymbol ]
+
+type pcp_base  = [ `ByPos of int | `ByMatch of int option * pcp_match ]
+
+type pcodepos1 = int * pcp_base
+type pcodepos  = (pcodepos1 * int) list * pcodepos1
+type pdocodepos1 = pcodepos1 doption option
 
 (* -------------------------------------------------------------------- *)
 type swap_kind =
@@ -530,7 +539,7 @@ type ('a, 'b, 'c) rnd_tac_info =
 type rnd_tac_info_f =
   (pformula, pformula option, pformula) rnd_tac_info
 
-type semrndpos = (bool * codepos1) doption
+type psemrndpos = (bool * pcodepos1) doption
 
 type tac_dir = Backs | Fwds
 
@@ -597,13 +606,13 @@ type fun_info = [
 
 (* -------------------------------------------------------------------- *)
 type app_info =
-  oside * tac_dir * codepos1 doption * pformula doption * p_app_xt_info
+  oside * tac_dir * pcodepos1 doption * pformula doption * p_app_xt_info
 
 (* -------------------------------------------------------------------- *)
 type pcond_info = [
   | `Head   of oside
-  | `Seq    of oside * codepos1 option pair * pformula
-  | `SeqOne of  side * codepos1 option * pformula * pformula
+  | `Seq    of oside * pcodepos1 option pair * pformula
+  | `SeqOne of  side * pcodepos1 option * pformula * pformula
 ]
 
 (* -------------------------------------------------------------------- *)
@@ -634,7 +643,7 @@ type inline_pat = ([ `DIFF | `UNION] * inline_pat1) list
 
 type inline_info = [
   | `ByName    of oside * inlineopt * (inline_pat * int list option)
-  | `CodePos   of (oside * inlineopt * codepos)
+  | `CodePos   of (oside * inlineopt * pcodepos)
  (* | `All       of oside * inlineopt *)
 ]
 
@@ -645,8 +654,8 @@ type outline_kind =
 
 type outline_info = {
     outline_side: side;
-    outline_start: codepos1;
-    outline_end: codepos1;
+    outline_start: pcodepos1;
+    outline_end: pcodepos1;
     outline_kind: outline_kind;
 }
 
@@ -670,7 +679,7 @@ type conseq_ppterm = ((pformula option pair) * (conseq_info) option) gppterm
 
 (* -------------------------------------------------------------------- *)
 type sim_info = {
-  sim_pos  : codepos1 pair option;
+  sim_pos  : pcodepos1 pair option;
   sim_hint : (pgamepath option pair * pformula) list * pformula option;
   sim_eqs  : pformula option
 }
@@ -679,7 +688,7 @@ type sim_info = {
 type rw_eqv_info = {
   rw_eqv_side  : side;
   rw_eqv_dir   : [`LtoR | `RtoL];
-  rw_eqv_pos   : codepos1;
+  rw_eqv_pos   : pcodepos1;
   rw_eqv_lemma : ppterm;
   rw_eqv_proc  : (pexpr list located * pexpr option) option;
 }
@@ -706,32 +715,32 @@ type phltactic =
   | Prepl_stmt     of trans_info
   | Pfun           of fun_info
   | Papp           of app_info
-  | Pwp            of docodepos1
-  | Psp            of docodepos1
+  | Pwp            of pdocodepos1
+  | Psp            of pdocodepos1
   | Pwhile         of (oside * while_info)
   | Pasyncwhile    of async_while_info
-  | Pfission       of (oside * codepos * (int * (int * int)))
-  | Pfusion        of (oside * codepos * (int * (int * int)))
-  | Punroll        of (oside * codepos * bool)
-  | Psplitwhile    of (pexpr * oside * codepos)
+  | Pfission       of (oside * pcodepos * (int * (int * int)))
+  | Pfusion        of (oside * pcodepos * (int * (int * int)))
+  | Punroll        of (oside * pcodepos * bool)
+  | Psplitwhile    of (pexpr * oside * pcodepos)
   | Pcall          of oside * call_info gppterm
   | Pcallconcave   of (pformula * call_info gppterm)
-  | Prcond         of (oside * bool * codepos1)
-  | Prmatch        of (oside * symbol * codepos1)
+  | Prcond         of (oside * bool * pcodepos1)
+  | Prmatch        of (oside * symbol * pcodepos1)
   | Pcond          of pcond_info
   | Pmatch         of matchmode
   | Pswap          of ((oside * swap_kind) located list)
-  | Pcfold         of (oside * codepos * int option)
+  | Pcfold         of (oside * pcodepos * int option)
   | Pinline        of inline_info
   | Poutline       of outline_info
   | Pinterleave    of interleave_info located
-  | Pkill          of (oside * codepos * int option)
-  | Pasgncase      of (oside * codepos)
-  | Prnd           of oside * semrndpos option * rnd_tac_info_f
-  | Prndsem        of bool * oside * codepos1
-  | Palias         of (oside * codepos * osymbol_r)
+  | Pkill          of (oside * pcodepos * int option)
+  | Pasgncase      of (oside * pcodepos)
+  | Prnd           of oside * psemrndpos option * rnd_tac_info_f
+  | Prndsem        of bool * oside * pcodepos1
+  | Palias         of (oside * pcodepos * osymbol_r)
   | Pweakmem       of (oside * psymbol * fun_params)
-  | Pset           of (oside * codepos * bool * psymbol * pexpr)
+  | Pset           of (oside * pcodepos * bool * psymbol * pexpr)
   | Pconseq        of (pcqoptions * (conseq_ppterm option tuple3))
   | Pconseqauto    of crushmode
   | Pconcave       of (pformula option tuple2 gppterm * pformula)
@@ -742,7 +751,7 @@ type phltactic =
   | Pbydeno        of ([`PHoare | `Equiv | `EHoare ] * (deno_ppterm * bool * pformula option))
   | PPr            of (pformula * pformula) option
   | Pbyupto
-  | Pfel           of (codepos1 * fel_info)
+  | Pfel           of (pcodepos1 * fel_info)
   | Phoare
   | Pprbounded
   | Psim           of crushmode option* sim_info
@@ -750,11 +759,11 @@ type phltactic =
   | Prw_equiv      of rw_eqv_info
   | Psymmetry
   | Pbdhoare_split of bdh_split
-  | Pprocchange    of side option * codepos * pexpr
-  | Pprocrewrite   of side option * codepos * prrewrite
+  | Pprocchange    of side option * pcodepos * pexpr
+  | Pprocrewrite   of side option * pcodepos * prrewrite
 
     (* Eager *)
-  | Peager_seq       of (eager_info * codepos1 pair * pformula)
+  | Peager_seq       of (eager_info * pcodepos1 pair * pformula)
   | Peager_if
   | Peager_while     of (eager_info)
   | Peager_fun_def

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -1316,7 +1316,7 @@ let pp_locality fmt lc =
   Format.fprintf fmt "%s" (odfl "" (string_of_locality lc))
 
 (* -------------------------------------------------------------------- *)
-let string_of_cpos1 ((off, cp) : EcParsetree.codepos1) =
+let string_of_cpos1 ((off, cp) : EcMatching.Position.codepos1) =
   let s =
     match cp with
     | `ByPos i ->
@@ -1326,11 +1326,11 @@ let string_of_cpos1 ((off, cp) : EcParsetree.codepos1) =
         let s =
           let k =
             match k with
-            | `If     -> "if"
-            | `While  -> "while"
-            | `Assign -> "<-"
-            | `Sample -> "<$"
-            | `Call   -> "<@"
+            | `If       -> "if"
+            | `While    -> "while"
+            | `Assign _ -> "<-"
+            | `Sample   -> "<$"
+            | `Call     -> "<@"
           in Printf.sprintf "^%s" k in
 
         match i with

--- a/src/ecProofTyping.ml
+++ b/src/ecProofTyping.ml
@@ -174,6 +174,19 @@ let tc1_process_Xhl_formula_xreal tc pf =
   tc1_process_Xhl_form tc txreal pf
 
 (* ------------------------------------------------------------------ *)
+let tc1_process_codepos tc (side, cpos) =
+  let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
+  let env = FApi.tc1_env tc in
+  let env = EcEnv.Memory.push_active me env in
+  EcTyping.trans_codepos env cpos
+(* ------------------------------------------------------------------ *)
+let tc1_process_codepos1 tc (side, cpos) =
+  let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
+  let env = FApi.tc1_env tc in
+  let env = EcEnv.Memory.push_active me env in
+  EcTyping.trans_codepos1 env cpos
+  
+(* ------------------------------------------------------------------ *)
 (* FIXME: factor out to typing module                                 *)
 (* FIXME: TC HOOK - check parameter constraints                       *)
 (* ------------------------------------------------------------------ *)

--- a/src/ecProofTyping.mli
+++ b/src/ecProofTyping.mli
@@ -8,6 +8,7 @@ open EcModules
 open EcEnv
 open EcCoreGoal
 open EcMemory
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 type ptnenv = ty Mid.t * EcUnify.unienv
@@ -61,6 +62,9 @@ val tc1_process_stmt :
 
 val tc1_process_prhl_stmt :
      ?map:EcTyping.ismap -> tcenv1 -> side -> pstmt -> stmt
+
+val tc1_process_codepos : tcenv1 -> oside * pcodepos -> codepos
+val tc1_process_codepos1 : tcenv1 -> oside * pcodepos1 -> codepos1
 
 (* -------------------------------------------------------------------- *)
 exception NoMatch

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -10,6 +10,7 @@ open EcParsetree
 open EcTypes
 open EcModules
 open EcFol
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 type wp = EcEnv.env -> EcMemory.memenv -> stmt -> EcFol.form -> EcFol.form option
@@ -210,15 +211,23 @@ val transexpcast_opt :
   env -> [`InProc|`InOp] -> EcUnify.unienv -> ty option -> pexpr -> expr
 
 (* -------------------------------------------------------------------- *)
+val trans_pv : EcEnv.env -> pqsymbol -> prog_var * ty
+
+(* -------------------------------------------------------------------- *)
 type ismap = (instr list) EcMaps.Mstr.t
 
 val transstmt : ?map:ismap -> env -> EcUnify.unienv -> pstmt -> stmt
 
 (* -------------------------------------------------------------------- *)
+val trans_codepos1 : ?memory:EcMemory.memory -> env -> pcodepos1 -> codepos1
+val trans_codepos : ?memory:EcMemory.memory -> env -> pcodepos -> codepos
+val trans_dcodepos1 : ?memory:EcMemory.memory -> env -> pcodepos1 doption -> codepos1 doption
+
+(* -------------------------------------------------------------------- *)
 type ptnmap = ty EcIdent.Mid.t ref
 type metavs = EcFol.form Msym.t
 
-val transmem       : env -> EcSymbols.symbol located -> EcIdent.t
+val transmem : env -> EcSymbols.symbol located -> EcIdent.t
 
 val trans_form_opt :
   env -> ?mv:metavs -> EcUnify.unienv -> pformula -> ty option -> EcFol.form
@@ -258,7 +267,6 @@ val trans_args :
   -> expr list * EcTypes.ty
 
 (* -------------------------------------------------------------------- *)
-
 (* This only checks the memory restrictions. *)
 val check_mem_restr_fun :
   env -> xpath -> mod_restr -> unit

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -278,6 +278,13 @@ type 'a doption =
   | Single of 'a
   | Double of ('a * 'a)
 
+module DOption = struct
+  let map (type a b) (f : a -> b) (x : a doption) : b doption =
+    match x with
+    | Single v -> Single (f v)
+    | Double (v1, v2) -> Double (f v1, f v2)
+end
+
 (* -------------------------------------------------------------------- *)
 type ('a, 'b) tagged = Tagged of ('a * 'b option)
 

--- a/src/ecUtils.mli
+++ b/src/ecUtils.mli
@@ -147,6 +147,10 @@ type 'a doption =
   | Single of 'a
   | Double of ('a * 'a)
 
+module DOption : sig
+  val map : ('a -> 'b) -> 'a doption -> 'b doption
+end
+
 (* -------------------------------------------------------------------- *)
 type ('a, 'b) tagged = Tagged of ('a * 'b option)
 

--- a/src/phl/ecPhlApp.mli
+++ b/src/phl/ecPhlApp.mli
@@ -3,6 +3,7 @@ open EcUtils
 open EcParsetree
 open EcFol
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_app   : codepos1 -> form -> backward

--- a/src/phl/ecPhlCodeTx.ml
+++ b/src/phl/ecPhlCodeTx.ml
@@ -293,16 +293,20 @@ let t_cfold = FApi.t_low3 "code-tx-cfold" t_cfold_r
 
 (* -------------------------------------------------------------------- *)
 let process_cfold (side, cpos, olen) tc =
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_cfold side cpos olen tc
 
 let process_kill (side, cpos, len) tc =
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_kill side cpos len tc
 
 let process_alias (side, cpos, id) tc =
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_alias side cpos id tc
 
 let process_set (side, cpos, fresh, id, e) tc =
   let e = TTC.tc1_process_Xhl_exp tc side None e in
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_set side cpos (fresh, id) e tc
 
 (* -------------------------------------------------------------------- *)
@@ -363,7 +367,7 @@ let process_weakmem (side, id, params) tc =
   FApi.xmutate1 tc `WeakenMem [concl]
 
 (* -------------------------------------------------------------------- *)
-let process_case ((side, pos) : side option * codepos) (tc : tcenv1) =
+let process_case ((side, pos) : side option * pcodepos) (tc : tcenv1) =
   let (env, _, concl) = FApi.tc1_eflat tc in
 
   let change (i : instr) =
@@ -396,8 +400,8 @@ let process_case ((side, pos) : side option * codepos) (tc : tcenv1) =
     assert false;
 
   let _, s = EcLowPhlGoal.tc1_get_stmt side tc in
-  let goals, s = EcMatching.Zipper.map pos change s in
+  let pos = EcProofTyping.tc1_process_codepos tc (side, pos) in
+  let goals, s = EcMatching.Zipper.map env pos change s in
   let concl = EcLowPhlGoal.hl_set_stmt side concl s in
 
   FApi.xmutate1 tc `ProcCase (goals @ [concl])
-

--- a/src/phl/ecPhlCodeTx.mli
+++ b/src/phl/ecPhlCodeTx.mli
@@ -2,6 +2,7 @@
 open EcParsetree
 open EcTypes
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 val t_kill  : oside -> codepos -> int option -> backward
@@ -10,11 +11,11 @@ val t_set   : oside -> codepos -> bool * psymbol -> expr -> backward
 val t_cfold : oside -> codepos -> int option -> backward
 
 (* -------------------------------------------------------------------- *)
-val process_kill  : oside * codepos * int option -> backward
-val process_alias : oside * codepos * psymbol option -> backward
-val process_set   : oside * codepos * bool * psymbol * pexpr -> backward
-val process_cfold : oside * codepos * int option -> backward
-val process_case  : oside * codepos -> backward
+val process_kill  : oside * pcodepos * int option -> backward
+val process_alias : oside * pcodepos * psymbol option -> backward
+val process_set   : oside * pcodepos * bool * psymbol * pexpr -> backward
+val process_cfold : oside * pcodepos * int option -> backward
+val process_case  : oside * pcodepos -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_weakmem : (oside * psymbol * fun_params) -> backward

--- a/src/phl/ecPhlEager.ml
+++ b/src/phl/ecPhlEager.ml
@@ -32,10 +32,11 @@ let pf_hSS pf hyps h =
 
 (* -------------------------------------------------------------------- *)
 let tc1_destr_eagerS tc s s' =
+  let env = FApi.tc1_env tc in
   let es = tc1_as_equivS tc in
   let c , c' = es.es_sl, es.es_sr in
-  let s1, c  = s_split (Zpr.cpos (List.length s.s_node)) c in
-  let c',s1' = s_split (Zpr.cpos (List.length c'.s_node - List.length s'.s_node)) c' in
+  let s1, c  = s_split env (Zpr.cpos (List.length s.s_node)) c in
+  let c',s1' = s_split env (Zpr.cpos (List.length c'.s_node - List.length s'.s_node)) c' in
 
   if not (List.all2 i_equal s1 s.s_node) then begin
     let ppe  = EcPrinting.PPEnv.ofenv (FApi.tc1_env tc) in
@@ -103,8 +104,8 @@ let t_eager_seq_r i j eqR h tc =
   pf_compat !!tc env (s_write env s) (s_write env s') seqR eqIs eqXs;
 
   let eqO2 = Mpv2.eq_refl (PV.fv env (fst eC.es_mr) eC.es_po) in
-  let c1 ,c2  = s_split i c in
-  let c1',c2' = s_split j c' in
+  let c1 ,c2  = s_split env i c in
+  let c1',c2' = s_split env j c' in
 
   let to_form eq =  Mpv2.to_form (fst eC.es_ml) (fst eC.es_mr) eq f_true in
 
@@ -613,6 +614,8 @@ let process_info info tc =
 let process_seq info (i, j) eqR tc =
   let eqR   = TTC.tc1_process_prhl_form tc tbool eqR in
   let gs, h = process_info info tc in
+  let i = EcProofTyping.tc1_process_codepos1 tc (Some `Left , i) in
+  let j = EcProofTyping.tc1_process_codepos1 tc (Some `Right, j) in
   FApi.t_last (t_eager_seq i j eqR h) gs
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlEager.mli
+++ b/src/phl/ecPhlEager.mli
@@ -3,6 +3,7 @@ open EcUtils
 open EcParsetree
 open EcFol
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 val t_eager_seq     : codepos1 -> codepos1 -> form -> EcIdent.t -> backward
@@ -13,7 +14,7 @@ val t_eager_fun_abs : EcFol.form -> EcIdent.t -> backward
 val t_eager_call    : form -> form -> backward
 
 (* -------------------------------------------------------------------- *)
-val process_seq     : eager_info -> codepos1 pair -> pformula -> backward
+val process_seq     : eager_info -> pcodepos1 pair -> pformula -> backward
 val process_if      : backward
 val process_while   : eager_info -> backward
 val process_fun_def : backward

--- a/src/phl/ecPhlEqobs.ml
+++ b/src/phl/ecPhlEqobs.ml
@@ -434,8 +434,10 @@ let process_eqobs_inS info tc =
         (FApi.t_try (FApi.t_seq EcPhlSkip.t_skip t_trivial))
         (t_eqobs_inS sim eqo tc)
     | Some(p1,p2) ->
-      let _,sl2 = s_split p1 es.es_sl in
-      let _,sr2 = s_split p2 es.es_sr in
+      let p1 = EcProofTyping.tc1_process_codepos1 tc (Some `Left , p1) in
+      let p2 = EcProofTyping.tc1_process_codepos1 tc (Some `Right, p2) in
+      let _,sl2 = s_split env p1 es.es_sl in
+      let _,sr2 = s_split env p2 es.es_sr in
       let _, eqi =
         try s_eqobs_in_full (stmt sl2) (stmt sr2) sim Mpv2.empty_local eqo
         with EqObsInError -> tc_error !!tc "cannot apply sim" in

--- a/src/phl/ecPhlFel.ml
+++ b/src/phl/ecPhlFel.ml
@@ -133,7 +133,7 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
     with _ -> tc_error !!tc "not applicable to abstract functions"
   in
 
-  let s_hd, s_tl = EcLowPhlGoal.s_split at_pos fdef.f_body in
+  let s_hd, s_tl = EcLowPhlGoal.s_split env at_pos fdef.f_body in
   let fve        = PV.fv env mhr f_event in
   let fvc        = PV.fv env mhr cntr in
   let fvi        = PV.fv env mhr inv in
@@ -256,6 +256,7 @@ let process_fel at_pos (infos : fel_info) tc =
       -> destr_pr pr
     | _ -> tc_error !!tc "a goal of the form Pr[ _ ] <= _ is required" in
 
+  let at_pos  = EcTyping.trans_codepos1 env at_pos in
   let hyps    = LDecl.inv_memenv1 hyps1 in
   let cntr    = TTC.pf_process_form !!tc hyps tint infos.pfel_cntr in
   let ash     = TTC.pf_process_form !!tc hyps (tfun tint treal) infos.pfel_asg in

--- a/src/phl/ecPhlFel.mli
+++ b/src/phl/ecPhlFel.mli
@@ -3,6 +3,7 @@ open EcPath
 open EcParsetree
 open EcFol
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 val t_failure_event :
@@ -13,4 +14,4 @@ val t_failure_event :
   -> backward
 
 (* -------------------------------------------------------------------- *)
-val process_fel : codepos1 -> fel_info -> backward
+val process_fel : pcodepos1 -> fel_info -> backward

--- a/src/phl/ecPhlHiCond.ml
+++ b/src/phl/ecPhlHiCond.ml
@@ -4,10 +4,11 @@ open EcCoreGoal
 open EcLowGoal
 open EcLowPhlGoal
 open EcPhlCond
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
-let process_cond info tc =
-  let default_if (i : EcParsetree.codepos1 option) s =
+let process_cond (info : EcParsetree.pcond_info) tc =
+  let default_if (i : codepos1 option) s =
     ofdfl (fun _ -> Zpr.cpos (tc1_pos_last_if tc s)) i in
 
   match info with
@@ -21,6 +22,8 @@ let process_cond info tc =
   | `Seq (side, (i1, i2), f) ->
     let es = tc1_as_equivS tc in
     let f  = EcProofTyping.tc1_process_prhl_formula tc f in
+    let i1 = Option.map (fun i1 -> EcProofTyping.tc1_process_codepos1 tc (side, i1)) i1 in
+    let i2 = Option.map (fun i2 -> EcProofTyping.tc1_process_codepos1 tc (side, i2)) i2 in
     let n1 = default_if i1 es.es_sl in
     let n2 = default_if i2 es.es_sr in
     FApi.t_seqsub (EcPhlApp.t_equiv_app (n1, n2) f)
@@ -28,6 +31,7 @@ let process_cond info tc =
 
   | `SeqOne (s, i, f1, f2) ->
     let es = tc1_as_equivS tc in
+    let i = Option.map (fun i1 -> EcProofTyping.tc1_process_codepos1 tc (Some s, i1)) i in
     let n = default_if i (match s with `Left -> es.es_sl | `Right -> es.es_sr) in
     let _, f1 = EcProofTyping.tc1_process_Xhl_formula ~side:s tc f1 in
     let _, f2 = EcProofTyping.tc1_process_Xhl_formula ~side:s tc f2 in

--- a/src/phl/ecPhlInline.ml
+++ b/src/phl/ecPhlInline.ml
@@ -316,10 +316,10 @@ module HiInternal = struct
     in fun (p : Zp.spath) -> aux_s IPpat p
 
   (* ------------------------------------------------------------------ *)
-  let pat_of_codepos pos stmt =
+  let pat_of_codepos env pos stmt =
     let module Zp = EcMatching.Zipper in
 
-    let zip = Zp.zipper_of_cpos pos stmt in
+    let zip = Zp.zipper_of_cpos env pos stmt in
     match zip.Zp.z_tail with
     | { i_node = Scall _ } :: tl ->
          pat_of_spath ((zip.Zp.z_head, tl), zip.Zp.z_path)
@@ -400,21 +400,23 @@ let process_inline_occs ~use_tuple side cond occs tc =
 
 (* -------------------------------------------------------------------- *)
 let process_inline_codepos ~use_tuple side pos tc =
+  let env = FApi.tc1_env tc in
   let concl = FApi.tc1_goal tc in
+  let pos = EcProofTyping.tc1_process_codepos tc (side, pos) in
 
   try
     match concl.f_node, side with
     | FequivS es, Some b ->
         let st = sideif b es.es_sl es.es_sr in
-        let sp = HiInternal.pat_of_codepos pos st in
+        let sp = HiInternal.pat_of_codepos env pos st in
         t_inline_equiv ~use_tuple b sp tc
 
     | FhoareS hs, None ->
-        let sp = HiInternal.pat_of_codepos pos hs.hs_s in
+        let sp = HiInternal.pat_of_codepos env pos hs.hs_s in
         t_inline_hoare ~use_tuple sp tc
 
     | FbdHoareS bhs, None ->
-        let sp = HiInternal.pat_of_codepos pos bhs.bhs_s in
+        let sp = HiInternal.pat_of_codepos env pos bhs.bhs_s in
         t_inline_bdhoare ~use_tuple sp tc
 
     | _, _ -> tc_error !!tc "invalid arguments"

--- a/src/phl/ecPhlLoopTx.ml
+++ b/src/phl/ecPhlLoopTx.ml
@@ -18,10 +18,10 @@ module Zpr = EcMatching.Zipper
 module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
-type fission_t    = oside * codepos * (int * (int * int))
-type fusion_t     = oside * codepos * (int * (int * int))
-type unroll_t     = oside * codepos * bool
-type splitwhile_t = pexpr * oside * codepos
+type fission_t    = oside * pcodepos * (int * (int * int))
+type fusion_t     = oside * pcodepos * (int * (int * int))
+type unroll_t     = oside * pcodepos * bool
+type splitwhile_t = pexpr * oside * pcodepos
 
 (* -------------------------------------------------------------------- *)
 let check_independence (pf, hyps) b init c1 c2 c3 =
@@ -205,26 +205,27 @@ let t_splitwhile = FApi.t_low3 "split-while" t_splitwhile_r
 
 (* -------------------------------------------------------------------- *)
 let process_fission (side, cpos, infos) tc =
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_fission side cpos infos tc
 
 let process_fusion (side, cpos, infos) tc =
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   t_fusion side cpos infos tc
 
 let process_splitwhile (b, side, cpos) tc =
   let b =
     try  TTC.tc1_process_Xhl_exp tc side (Some tbool) b
-    with EcFol.DestrError _ -> tc_error !!tc "goal must be a *HL statement"
-  in t_splitwhile b side cpos tc
+    with EcFol.DestrError _ -> tc_error !!tc "goal must be a *HL statement" in
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
+  t_splitwhile b side cpos tc
 
 (* -------------------------------------------------------------------- *)
 let process_unroll_for side cpos tc =
-  if not (List.is_empty (fst cpos)) then
-    tc_error !!tc "cannot use deep code position";
-
   let env  = FApi.tc1_env tc in
   let hyps = FApi.tc1_hyps tc in
   let _, c = EcLowPhlGoal.tc1_get_stmt side tc in
-  let z    = Zpr.zipper_of_cpos cpos c in
+  let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
+  let z    = Zpr.zipper_of_cpos env cpos c in
   let pos  = 1 + List.length z.Zpr.z_head in
 
   (* Extract loop condition / body *)
@@ -320,6 +321,9 @@ let process_unroll_for side cpos tc =
 
 (* -------------------------------------------------------------------- *)
 let process_unroll (side, cpos, for_) tc =
-  if   for_
-  then process_unroll_for side cpos tc
-  else t_unroll side cpos tc
+  if for_ then
+    process_unroll_for side cpos tc
+  else begin
+    let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
+    t_unroll side cpos tc
+  end

--- a/src/phl/ecPhlLoopTx.mli
+++ b/src/phl/ecPhlLoopTx.mli
@@ -2,21 +2,21 @@
 open EcParsetree
 open EcTypes
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
-type fission_t    = oside * codepos * (int * (int * int))
-type fusion_t     = oside * codepos * (int * (int * int))
-type unroll_t     = oside * codepos * bool
-type splitwhile_t = pexpr * oside * codepos
-
 val t_fission    : oside -> codepos -> int * (int * int) -> backward
 val t_fusion     : oside -> codepos -> int * (int * int) -> backward
 val t_unroll     : oside -> codepos -> backward
 val t_splitwhile : expr -> oside -> codepos -> backward
 
-
 (* -------------------------------------------------------------------- *)
-val process_unroll_for : oside -> codepos -> backward
+type fission_t    = oside * pcodepos * (int * (int * int))
+type fusion_t     = oside * pcodepos * (int * (int * int))
+type unroll_t     = oside * pcodepos * bool
+type splitwhile_t = pexpr * oside * pcodepos
+
+val process_unroll_for : oside -> pcodepos -> backward
 val process_fission    : fission_t -> backward
 val process_fusion     : fusion_t -> backward
 val process_unroll     : unroll_t -> backward

--- a/src/phl/ecPhlOutline.mli
+++ b/src/phl/ecPhlOutline.mli
@@ -1,4 +1,5 @@
 open EcCoreGoal.FApi
+open EcMatching.Position
 open EcParsetree
 open EcModules
 open EcPath

--- a/src/phl/ecPhlRCond.mli
+++ b/src/phl/ecPhlRCond.mli
@@ -2,6 +2,7 @@
 open EcSymbols
 open EcParsetree
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 module Low : sig
@@ -20,5 +21,8 @@ end
 
 (* -------------------------------------------------------------------- *)
 val t_rcond       : oside -> bool -> codepos1 -> backward
-val process_rcond : oside -> bool -> codepos1 -> backward
-val t_rcond_match : oside -> symbol -> codepos1 -> backward
+val process_rcond : oside -> bool -> pcodepos1 -> backward
+
+(* -------------------------------------------------------------------- *)
+val process_rcond_match : oside -> symbol -> pcodepos1 -> backward
+val t_rcond_match       : oside -> symbol -> codepos1 -> backward

--- a/src/phl/ecPhlRewrite.mli
+++ b/src/phl/ecPhlRewrite.mli
@@ -3,8 +3,8 @@ open EcParsetree
 open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
-val process_change : side option -> codepos -> pexpr -> backward
+val process_change : side option -> pcodepos -> pexpr -> backward
 
-val process_rewrite_rw    : side option -> codepos -> ppterm -> backward
-val process_rewrite_simpl : side option -> codepos -> backward
-val process_rewrite       : side option -> codepos -> prrewrite -> backward
+val process_rewrite_rw    : side option -> pcodepos -> ppterm -> backward
+val process_rewrite_simpl : side option -> pcodepos -> backward
+val process_rewrite       : side option -> pcodepos -> prrewrite -> backward

--- a/src/phl/ecPhlRnd.ml
+++ b/src/phl/ecPhlRnd.ml
@@ -7,6 +7,7 @@ open EcModules
 open EcFol
 open EcPV
 
+open EcMatching.Position
 open EcCoreGoal
 open EcLowGoal
 open EcLowPhlGoal
@@ -18,6 +19,7 @@ type chl_infos_t = (form, form option, form) rnd_tac_info
 type bhl_infos_t = (form, ty -> form option, ty -> form) rnd_tac_info
 type rnd_infos_t = (pformula, pformula option, pformula) rnd_tac_info
 type mkbij_t     = EcTypes.ty -> EcTypes.ty -> EcFol.form
+type semrndpos   = (bool * codepos1) doption
 
 (* -------------------------------------------------------------------- *)
 module Core = struct
@@ -375,8 +377,9 @@ module Core = struct
 
   (* -------------------------------------------------------------------- *)
   let t_hoare_rndsem_r reduce pos tc =
+    let env = FApi.tc1_env tc in
     let hs = tc1_as_hoareS tc in
-    let s1, s2 = o_split (Some pos) hs.hs_s in
+    let s1, s2 = o_split env (Some pos) hs.hs_s in
     let fv =
       if reduce then
         Some (PV.fv (FApi.tc1_env tc) (fst hs.hs_m) hs.hs_po)
@@ -387,8 +390,9 @@ module Core = struct
 
  (* -------------------------------------------------------------------- *)
   let t_bdhoare_rndsem_r reduce pos tc =
+    let env = FApi.tc1_env tc in
     let bhs = tc1_as_bdhoareS tc in
-    let s1, s2 = o_split (Some pos) bhs.bhs_s in
+    let s1, s2 = o_split env (Some pos) bhs.bhs_s in
     let fv =
       if reduce then
         Some (PV.fv (FApi.tc1_env tc) (fst bhs.bhs_m) bhs.bhs_po)
@@ -399,12 +403,13 @@ module Core = struct
 
  (* -------------------------------------------------------------------- *)
   let t_equiv_rndsem_r reduce side pos tc =
+    let env = FApi.tc1_env tc in
     let es = tc1_as_equivS tc in
     let s, m =
       match side with
       | `Left  -> es.es_sl, es.es_ml
       | `Right -> es.es_sr, es.es_mr in
-    let s1, s2 = o_split (Some pos) s in
+    let s1, s2 = o_split env (Some pos) s in
     let fv =
       if reduce then
         Some (PV.fv (FApi.tc1_env tc) (fst m) es.es_po)
@@ -645,9 +650,23 @@ let process_rnd side pos tac_info tc =
       | PSingleRndParam f -> Some (process_form f), None
       | PTwoRndParams (f, finv) -> Some (process_form f), Some (process_form finv)
       | _ -> tc_error !!tc "invalid arguments"
-
     in
-      t_equiv_rnd side ?pos bij_info tc
+
+    let pos = pos |> Option.map (function
+      | Single (b, p) ->
+          let p =
+            if Option.is_some side then
+              EcProofTyping.tc1_process_codepos1 tc (side, p)
+            else EcTyping.trans_codepos1 (FApi.tc1_env tc) p
+          in Single (b, p)
+      | Double ((b1, p1), (b2, p2)) ->
+          let p1 = EcProofTyping.tc1_process_codepos1 tc (Some `Left , p1) in
+          let p2 = EcProofTyping.tc1_process_codepos1 tc (Some `Right, p2) in
+          Double ((b1, p1), (b2, p2))
+    )
+    in
+    
+    t_equiv_rnd side ?pos bij_info tc
 
   | _ -> tc_error !!tc "invalid arguments"
 
@@ -659,6 +678,7 @@ let t_equiv_rndsem   = FApi.t_low3 "equiv-rndsem"   Core.t_equiv_rndsem_r
 (* -------------------------------------------------------------------- *)
 let process_rndsem ~reduce side pos tc =
   let concl = FApi.tc1_goal tc in
+  let pos = EcProofTyping.tc1_process_codepos1 tc (side, pos) in
 
   match side with
   | None when is_hoareS concl ->

--- a/src/phl/ecPhlRnd.mli
+++ b/src/phl/ecPhlRnd.mli
@@ -4,6 +4,7 @@ open EcParsetree
 open EcTypes
 open EcFol
 open EcCoreGoal.FApi
+open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 type chl_infos_t = (form, form option, form) rnd_tac_info
@@ -16,12 +17,14 @@ val wp_equiv_disj_rnd : side -> backward
 val wp_equiv_rnd      : (mkbij_t pair) option -> backward
 
 (* -------------------------------------------------------------------- *)
+type semrndpos = (bool * codepos1) doption
+
 val t_hoare_rnd   : backward
 val t_bdhoare_rnd : bhl_infos_t -> backward
 val t_equiv_rnd   : ?pos:semrndpos -> oside -> (mkbij_t option) pair -> backward
 
 (* -------------------------------------------------------------------- *)
-val process_rnd : oside -> semrndpos option -> rnd_infos_t -> backward
+val process_rnd : oside -> psemrndpos option -> rnd_infos_t -> backward
 
 (* -------------------------------------------------------------------- *)
-val process_rndsem : reduce:bool -> oside -> codepos1 -> backward
+val process_rndsem : reduce:bool -> oside -> pcodepos1 -> backward

--- a/src/phl/ecPhlRwEquiv.ml
+++ b/src/phl/ecPhlRwEquiv.ml
@@ -55,7 +55,8 @@ let t_rewrite_equiv side dir cp (equiv : equivF) equiv_pt rargslv tc =
 
   (* Extract the call statement and surrounding code *)
   let prefix, (llv, func, largs), suffix =
-    let p, i, s = s_split_i cp code in
+    let cp = EcProofTyping.tc1_process_codepos1 tc (Some side, cp) in
+    let p, i, s = s_split_i env cp code in
     if not (is_call i) then
       rwe_error RWE_InvalidPosition;
     stmt p, destr_call i, stmt s

--- a/src/phl/ecPhlRwEquiv.mli
+++ b/src/phl/ecPhlRwEquiv.mli
@@ -6,7 +6,7 @@ open EcAst
 val t_rewrite_equiv :
   side ->
   [`LtoR | `RtoL ] ->
-  codepos1 ->
+  pcodepos1 ->
   equivF ->
   proofterm ->
   (expr list * lvalue option) option ->

--- a/src/phl/ecPhlSp.mli
+++ b/src/phl/ecPhlSp.mli
@@ -1,7 +1,11 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
+open EcMatching.Position
 open EcCoreGoal.FApi
 open EcUtils
 
 (* -------------------------------------------------------------------- *)
 val t_sp : (codepos1 doption) option -> backward
+
+(* -------------------------------------------------------------------- *)
+val process_sp : (pcodepos1 doption) option -> backward

--- a/src/phl/ecPhlWp.ml
+++ b/src/phl/ecPhlWp.ml
@@ -142,7 +142,7 @@ module TacInternal = struct
   let t_hoare_wp ?(uselet=true) i tc =
     let env = FApi.tc1_env tc in
     let hs = tc1_as_hoareS tc in
-    let (s_hd, s_wp) = o_split i hs.hs_s in
+    let (s_hd, s_wp) = o_split env i hs.hs_s in
     let s_wp = EcModules.stmt s_wp in
     let s_wp, post =
       wp ~uselet ~onesided:true env hs.hs_m s_wp hs.hs_po in
@@ -154,7 +154,7 @@ module TacInternal = struct
   let t_ehoare_wp ?(uselet=true) i tc =
     let env = FApi.tc1_env tc in
     let hs = tc1_as_ehoareS tc in
-    let (s_hd, s_wp) = o_split i hs.ehs_s in
+    let (s_hd, s_wp) = o_split env i hs.ehs_s in
     let s_wp = EcModules.stmt s_wp in
     let (s_wp, post) = ewp ~uselet env hs.ehs_m s_wp hs.ehs_po in
     check_wp_progress tc i hs.ehs_s s_wp;
@@ -165,7 +165,7 @@ module TacInternal = struct
   let t_bdhoare_wp ?(uselet=true) i tc =
     let env = FApi.tc1_env tc in
     let bhs = tc1_as_bdhoareS tc in
-    let (s_hd, s_wp) = o_split i bhs.bhs_s in
+    let (s_hd, s_wp) = o_split env i bhs.bhs_s in
     let s_wp = EcModules.stmt s_wp in
     let s_wp,post = wp ~uselet env bhs.bhs_m s_wp bhs.bhs_po in
     check_wp_progress tc i bhs.bhs_s s_wp;
@@ -177,8 +177,8 @@ module TacInternal = struct
     let env = FApi.tc1_env tc in
     let es = tc1_as_equivS tc in
     let i = omap fst ij and j = omap snd ij in
-    let s_hdl,s_wpl = o_split i es.es_sl in
-    let s_hdr,s_wpr = o_split j es.es_sr in
+    let s_hdl,s_wpl = o_split env i es.es_sl in
+    let s_hdr,s_wpr = o_split env j es.es_sr in
     let meml, s_wpl = es.es_ml, EcModules.stmt s_wpl in
     let memr, s_wpr = es.es_mr, EcModules.stmt s_wpr in
     let post = es.es_po in
@@ -223,5 +223,7 @@ let typing_wp env m s f =
 let () = EcTyping.wp := Some typing_wp
 
 (* -------------------------------------------------------------------- *)
-let process_wp k tc =
-  t_wp k tc
+let process_wp pos tc =
+  let pos =
+    Option.map (EcTyping.trans_dcodepos1 (FApi.tc1_env tc)) pos
+  in t_wp pos tc

--- a/src/phl/ecPhlWp.mli
+++ b/src/phl/ecPhlWp.mli
@@ -1,6 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
+open EcMatching.Position
 
 open EcCoreGoal.FApi
 
@@ -13,4 +14,4 @@ open EcCoreGoal.FApi
 
 val t_wp : ?uselet:bool -> (codepos1 doption) option -> backward
 
-val process_wp : (codepos1 doption) option -> backward
+val process_wp : (pcodepos1 doption) option -> backward

--- a/tests/codepos-assign-with-name.ec
+++ b/tests/codepos-assign-with-name.ec
@@ -1,0 +1,23 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore.
+
+module M = {
+  proc f() = {
+    var x : int;
+    var y : int;
+
+    y <- 1;
+    x <- 0;
+    return y;
+  }
+}.
+
+op p : int -> bool.
+
+lemma L : hoare[M.f : true ==> p res].
+proof.
+proc.
+fail kill ^y<-.
+kill ^x<-.
+abort.
+


### PR DESCRIPTION
    Nearly all program tactics (`wp`, `sp`, ...) can now take extended
    code positions as arguments.
    
    Moreover, extended code positions have been extended s.t. they
    can now target a assignment with a specific variable. The syntax is
    `^x<-` where `x` is the program variable name.