### PR TITLE
The tactic `swap` now takes generalized code position.

### DIFF
--- a/src/ecCorePrinting.ml
+++ b/src/ecCorePrinting.ml
@@ -24,7 +24,6 @@ module type PrinterAPI = sig
 
   (* ------------------------------------------------------------------ *)
   val string_of_hcmp : EcFol.hoarecmp -> string
-  val string_of_cpos1 : EcMatching.Position.codepos1 -> string
 
   (* ------------------------------------------------------------------ *)
   type 'a pp = Format.formatter -> 'a -> unit
@@ -62,6 +61,10 @@ module type PrinterAPI = sig
   val pp_tyvar    : PPEnv.t -> ident pp
   val pp_tyunivar : PPEnv.t -> EcUid.uid pp
   val pp_path     : path pp
+
+  (* ------------------------------------------------------------------ *)
+  val pp_codepos1    : PPEnv.t -> EcMatching.Position.codepos1 pp
+  val pp_codeoffset1 : PPEnv.t -> EcMatching.Position.codeoffset1 pp
 
   (* ------------------------------------------------------------------ *)
   val pp_typedecl    : PPEnv.t -> (path * tydecl                  ) pp

--- a/src/ecHiTacticals.ml
+++ b/src/ecHiTacticals.ml
@@ -236,8 +236,9 @@ and process1_phl (_ : ttenv) (t : phltactic located) (tc : tcenv1) =
   with (* PHL Specific low errors *)
   | EcLowPhlGoal.InvalidSplit cpos1 ->
       tc_error_lazy !!tc (fun fmt ->
-        Format.fprintf fmt "invalid split index: %s"
-          (EcPrinting.string_of_cpos1 cpos1))
+        let ppe = EcPrinting.PPEnv.ofenv (FApi.tc1_env tc) in
+        Format.fprintf fmt "invalid split index: %a"
+          (EcPrinting.pp_codepos1 ppe) cpos1)
 
 (* -------------------------------------------------------------------- *)
 and process_sub (ttenv : ttenv) tts tc =

--- a/src/ecMatching.mli
+++ b/src/ecMatching.mli
@@ -26,8 +26,12 @@ module Position : sig
     | `ByMatch of int option * cp_match
   ]
 
-  type codepos1   = int * cp_base
-  type codepos    = (codepos1 * int) list * codepos1
+  type codepos1    = int * cp_base
+  type codepos     = (codepos1 * int) list * codepos1
+  type codeoffset1 = [`ByOffset of int | `ByPosition of codepos1]
+
+  val shift : offset:int -> codepos1 -> codepos1
+  val resolve_offset : base:codepos1 -> offset:codeoffset1 -> codepos1
 end
 
 (* -------------------------------------------------------------------- *)
@@ -59,6 +63,9 @@ module Zipper : sig
 
   (* Split a statement from an optional top-level position (codepos1) *)
   val may_split_at_cpos1 : ?rev:bool -> env -> codepos1 option -> stmt -> instr list * instr list
+
+  (* Find the absolute offset of a top-level position (codepos1) w.r.t. a given statement *)
+  val offset_of_position : env -> codepos1 -> stmt -> int
 
   (* [zipper] soft constructor *)
   val zipper : instr list -> instr list -> ipath -> zipper

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -503,12 +503,16 @@ type pcodepos1 = int * pcp_base
 type pcodepos  = (pcodepos1 * int) list * pcodepos1
 type pdocodepos1 = pcodepos1 doption option
 
+type pcodeoffset1 = [
+  | `ByOffset   of int
+  | `ByPosition of pcodepos1
+]
+
 (* -------------------------------------------------------------------- *)
-type swap_kind =
-  | SKbase      of int * int * int
-  | SKmove      of int
-  | SKmovei     of int * int
-  | SKmoveinter of int * int * int
+type pswap_kind = {
+  interval : (pcodepos1 * pcodepos1 option) option;
+  offset   : pcodeoffset1;
+}
 
 type interleave_info = oside * (int * int) * ((int * int) list) * int
 
@@ -729,7 +733,7 @@ type phltactic =
   | Prmatch        of (oside * symbol * pcodepos1)
   | Pcond          of pcond_info
   | Pmatch         of matchmode
-  | Pswap          of ((oside * swap_kind) located list)
+  | Pswap          of ((oside * pswap_kind) located list)
   | Pcfold         of (oside * pcodepos * int option)
   | Pinline        of inline_info
   | Poutline       of outline_info

--- a/src/phl/ecPhlSwap.mli
+++ b/src/phl/ecPhlSwap.mli
@@ -1,15 +1,20 @@
 (* -------------------------------------------------------------------- *)
 open EcLocation
 open EcParsetree
+open EcMatching.Position
 open EcCoreGoal.FApi
 
 (* -------------------------------------------------------------------- *)
-val t_hoare_swap   : int -> int -> int -> backward
-val t_bdhoare_swap : int -> int -> int -> backward
-val t_equiv_swap   : side -> int -> int -> int -> backward
+type swap_kind = {
+  interval : (codepos1 * codepos1 option) option;
+  offset   : codeoffset1;
+}
 
 (* -------------------------------------------------------------------- *)
-val process_swap : (oside * swap_kind) located list -> backward
+val t_swap : oside -> swap_kind -> backward
+
+(* -------------------------------------------------------------------- *)
+val process_swap : (oside * pswap_kind) located list -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_interleave : interleave_info located -> backward

--- a/theories/distributions/DJoin.ec
+++ b/theories/distributions/DJoin.ec
@@ -79,7 +79,7 @@ module S = {
 
 equiv Sample_Loop_eq: S.sample ~ S.loop: ={d, xs} ==> ={res}.
 proof. 
-  proc => /=;  alias{1} 0 rb = witness <:tb>.
+  proc => /=; alias{1} 1 rb = witness <:tb>.
   sp 1 2; exlim xs{1}, l{2} => xs_ l2.
   pose xs' := List."[]" <:ta>.
   conseq (: ={d} /\ l{2} = l2 /\ i{2} = size xs_ - 1 /\ xs{1} = xs_ /\ xs{2} = xs_ ++ xs'
@@ -118,7 +118,7 @@ qed.
 
 equiv Sample_Loop_first_eq: S.sample ~ S.loop_first : ={d, xs} ==> ={res}.
 proof. 
-  proc => /=;  alias{1} 0 rb = witness <:tb>.
+  proc => /=;  alias{1} 1 rb = witness <:tb>.
   sp 1 1; exlim xs{1}, l{2} => xs_ l2.
   conseq (: ={d,xs} /\ l{2} = l2 /\ xs{2} = xs_ 
              ==> l2++r{1} = l{2}); 1,2: by move=> />.


### PR DESCRIPTION
Moreover, offsets can bow be absolute (i.e. can be a code-position). In that case, the meaning is "move the code block before the targetted instruction".
    
This work brings some breaking changes:
    
- the variant `swap i1 i2 i3` has been removed. It was a way to give a direct access to the low-level functionality, but its interface is brittle and is not used by any development
    
- a bug has been found in the resolution of negative code position (they were all shifted by one, making impossible to target the last instruction). This now has been fixed.