### PR TITLE
Better operators overloading inference

### DIFF
--- a/src/ecHiInductive.ml
+++ b/src/ecHiInductive.ml
@@ -284,7 +284,7 @@ let trans_matchfix
           let filter = fun _ op -> EcDecl.is_ctor op in
           let PPApp ((cname, tvi), cargs) = pb.pop_pattern in
           let tvi = tvi |> omap (TT.transtvi env ue) in
-          let cts = EcUnify.select_op ~filter tvi env (unloc cname) ue [] in
+          let cts = EcUnify.select_op ~filter tvi env (unloc cname) ue ([], None) in
 
           match cts with
           | [] ->

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -941,7 +941,7 @@ let pp_opapp
       (es      : 'a list))
 =
   let (nm, opname) =
-    PPEnv.op_symb ppe op (Some (pred, tvi, List.map t_ty es)) in
+    PPEnv.op_symb ppe op (Some (pred, tvi, (List.map t_ty es, None))) in
 
   let inm = if nm = [] then fst outer else nm in
 
@@ -1250,7 +1250,7 @@ let pp_chained_orderings (ppe : PPEnv.t) t_ty pp_sub outer fmt (f, fs) =
         ignore (List.fold_left
           (fun fe (op, tvi, f) ->
             let (nm, opname) =
-              PPEnv.op_symb ppe op (Some (`Form, tvi, [t_ty fe; t_ty f]))
+              PPEnv.op_symb ppe op (Some (`Form, tvi, ([t_ty fe; t_ty f], None)))
             in
               Format.fprintf fmt " %t@ %a"
                 (fun fmt ->
@@ -1343,7 +1343,7 @@ let lower_left (ppe : PPEnv.t) (t_ty : form -> EcTypes.ty) (f : form)
         else l_l f2 onm e_bin_prio_rop4
     | Fapp ({f_node = Fop (op, tys)}, [f1; f2]) ->
         (let (inm, opname) =
-           PPEnv.op_symb ppe op (Some (`Form, tys, List.map t_ty [f1; f2])) in
+           PPEnv.op_symb ppe op (Some (`Form, tys, (List.map t_ty [f1; f2], None))) in
          if inm <> [] && inm <> onm
          then None
          else match priority_of_binop opname with

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -1689,7 +1689,7 @@ module Ty = struct
         let tvi = List.map (TT.transty tp_tydecl env ue) tvi in
         let selected =
           EcUnify.select_op ~filter:(fun _ -> EcDecl.is_oper)
-            (Some (EcUnify.TVIunamed tvi)) env (unloc op) ue []
+            (Some (EcUnify.TVIunamed tvi)) env (unloc op) ue ([], None)
         in
         let op =
           match selected with

--- a/src/ecUnify.ml
+++ b/src/ecUnify.ml
@@ -396,15 +396,15 @@ let hastc env ue ty tc =
     ue := { !ue with ue_uf = uf; }
 
 (* -------------------------------------------------------------------- *)
-let tfun_expected ue psig =
-  let tres = UniEnv.fresh ue in
-    EcTypes.toarrow psig tres
+let tfun_expected ue ?retty psig =
+  let retty = ofdfl (fun () -> UniEnv.fresh ue) retty in
+  EcTypes.toarrow psig retty
 
 (* -------------------------------------------------------------------- *)
 type sbody = ((EcIdent.t * ty) list * expr) Lazy.t
 
 (* -------------------------------------------------------------------- *)
-let select_op ?(hidden = false) ?(filter = fun _ _ -> true) tvi env name ue psig =
+let select_op ?(hidden = false) ?(filter = fun _ _ -> true) tvi env name ue (psig, retty) =
   ignore hidden;                (* FIXME *)
 
   let module D = EcDecl in
@@ -457,7 +457,7 @@ let select_op ?(hidden = false) ?(filter = fun _ _ -> true) tvi env name ue psig
 
       let (tip, tvs) = UniEnv.openty_r subue op.D.op_tparams tvi in
       let top = ty_subst tip op.D.op_ty in
-      let texpected = tfun_expected subue psig in
+      let texpected = tfun_expected subue ?retty psig in
 
       (try  unify env subue top texpected
        with UnificationFailure _ -> raise E.Failure);

--- a/src/ecUnify.mli
+++ b/src/ecUnify.mli
@@ -37,7 +37,7 @@ end
 val unify : EcEnv.env -> unienv -> ty -> ty -> unit
 val hastc : EcEnv.env -> unienv -> ty -> Sp.t -> unit
 
-val tfun_expected : unienv -> EcTypes.ty list -> EcTypes.ty
+val tfun_expected : unienv -> ?retty:ty -> EcTypes.ty list -> EcTypes.ty
 
 type sbody = ((EcIdent.t * ty) list * expr) Lazy.t
 
@@ -48,5 +48,5 @@ val select_op :
   -> EcEnv.env
   -> qsymbol
   -> unienv
-  -> dom
+  -> dom * ty option
   -> ((EcPath.path * ty list) * ty * unienv * sbody option) list

--- a/tests/overloading.ec
+++ b/tests/overloading.ec
@@ -1,0 +1,24 @@
+require import AllCore List.
+
+theory T.
+  op o : int.
+  op a : int -> int -> int.
+end T.
+
+theory U.
+  op o : bool.
+  op a : bool -> bool -> bool.
+end U.
+
+import T U.
+
+op foo : int -> unit.
+
+op bar = foo o.
+
+op plop1 = foldr a false [].
+
+op plop2 = foldr (fun x => a x) false [].
+
+op plop3 = foldr (fun x y => a x y) false [].
+


### PR DESCRIPTION
This PR is about using more type information to resolve the overloading of operators. Currently, the following is now accepted:

```
require import AllCore List.

theory T.
  op o : int.
  op a : int -> int -> int.
end T.

theory U.
  op o : bool.
  op a : bool -> bool -> bool.
end U.

import T U.

op foo : int -> unit.

op bar = foo o.

op plop1 = foldr a false [].

op plop2 = foldr (fun x => a x) false [].

op plop3 = foldr (fun x y => a x y) false [].
```