### PR TITLE
Add tactic for lossless while

### DIFF
--- a/examples/RWhileSampling.ec
+++ b/examples/RWhileSampling.ec
@@ -1,0 +1,75 @@
+require import Real Distr.
+
+type t.
+
+op sample: t distr.
+axiom sample_ll: is_lossless sample.
+
+op test: t -> bool.
+axiom pr_ntest: 0%r < mu sample (predC test).
+
+module Sample = {
+  proc sample () : bool = {
+     var r : t;
+     var ret : bool;
+
+     ret <- true;
+     r <$ sample;
+
+     while (test r) {
+        r <$ sample;
+     }
+     return ret;
+   }
+    proc idle () : bool = {
+      var ret : bool;
+
+      ret <- true;
+
+      return ret;
+  }
+}.
+
+lemma Sample_lossless:
+  equiv[Sample.sample ~ Sample.idle : true ==> ={res}].
+proof.
+proc; seq  2 1: (={ret});auto.
+split.
+ + by exact /sample_ll.
+ by auto.
+while {1} (={ret}).
+ + by auto; rewrite sample_ll.
+ + auto.
+   seq 0 : true => //=.
+   while true (if test r then 1 else 0) 1 (mu sample (predC test)) => //.
+    + by move => _ r; case: (test r).
+    + move => ih; seq  1: true => //.
+      by auto; rewrite sample_ll.
+    + by auto; rewrite sample_ll.
+    rewrite pr_ntest=> /= z; conseq (: true ==> !test r).
+     + by smt().
+     by rnd; auto.
+ by auto.
+qed.
+
+lemma Sample_lossless2:
+  equiv[Sample.idle ~ Sample.sample : true ==> ={res}].
+proof.
+proc; seq  1 2: (={ret});auto.
+split.
+ + by exact /sample_ll.
+ by auto.
+while {2} (={ret}).
+ + by auto; rewrite sample_ll.
+ + auto.
+   seq 0 : true => //=.
+   while true (if test r then 1 else 0) 1 (mu sample (predC test)) => //.
+    + by move => _ r; case: (test r).
+    + move => ih; seq  1: true => //.
+      by auto; rewrite sample_ll.
+    + by auto; rewrite sample_ll.
+    rewrite pr_ntest=> /= z; conseq (: true ==> !test r).
+     + by smt().
+     by rnd; auto.
+ by auto.
+qed.

--- a/src/phl/ecPhlWhile.ml
+++ b/src/phl/ecPhlWhile.ml
@@ -340,103 +340,7 @@ let t_equiv_while_disj_r side vrnt inv tc =
   FApi.xmutate1 tc `While [b_concl; concl]
 
 (* -------------------------------------------------------------------- *)
-let t_equiv_while_r inv tc =
-  let env = FApi.tc1_env tc in
-  let es = tc1_as_equivS tc in
-  let (el, cl), sl = tc1_last_while tc es.es_sl in
-  let (er, cr), sr = tc1_last_while tc es.es_sr in
-  let ml = EcMemory.memory es.es_ml in
-  let mr = EcMemory.memory es.es_mr in
-  let el = form_of_expr ml el in
-  let er = form_of_expr mr er in
-  let sync_cond = f_iff_simpl el er in
-
-  (* 1. The body preserves the invariant *)
-  let b_pre  = f_ands_simpl [inv; el] er in
-  let b_post = f_and_simpl inv sync_cond in
-  let b_concl = f_equivS es.es_ml es.es_mr b_pre cl cr b_post in
-
-  (* 2. WP of the while *)
-  let post = f_imps_simpl [f_not_simpl el;f_not_simpl er; inv] es.es_po in
-  let modil = s_write env cl in
-  let modir = s_write env cr in
-  let post = generalize_mod env mr modir post in
-  let post = generalize_mod env ml modil post in
-  let post = f_and_simpl b_post post in
-  let concl = f_equivS_r { es with es_sl = sl; es_sr = sr; es_po = post; } in
-
-  FApi.xmutate1 tc `While [b_concl; concl]
-
-(* -------------------------------------------------------------------- *)
-let t_hoare_while           = FApi.t_low1 "hoare-while"   t_hoare_while_r
-let t_bdhoare_while         = FApi.t_low2 "bdhoare-while" t_bdhoare_while_r
-let t_bdhoare_while_rev_geq = FApi.t_low4 "bdhoare-while" t_bdhoare_while_rev_geq_r
-let t_bdhoare_while_rev     = FApi.t_low1 "bdhoare-while" t_bdhoare_while_rev_r
-let t_equiv_while           = FApi.t_low1 "equiv-while"   t_equiv_while_r
-let t_equiv_while_disj      = FApi.t_low3 "equiv-while"   t_equiv_while_disj_r
-
-(* -------------------------------------------------------------------- *)
-let process_while side winfos tc =
-  let { EP.wh_inv  = phi ;
-        EP.wh_vrnt = vrnt;
-        EP.wh_bds  = bds ; } = winfos in
-
-  match (FApi.tc1_goal tc).f_node with
-  | FhoareS _ -> begin
-      match vrnt with
-      | None ->
-        t_hoare_while
-          (snd (TTC.tc1_process_Xhl_formula tc phi))
-          tc
-      | _    -> tc_error !!tc "invalid arguments"
-    end
-
-  | FeHoareS _ ->
-      let _, inv = TTC.tc1_process_Xhl_formula_xreal tc phi in
-      t_ehoare_while inv tc
-
-  | FbdHoareS _ -> begin
-      match vrnt, bds with
-      | Some vrnt, None ->
-          let _, phi = TTC.tc1_process_Xhl_formula tc phi in
-          let _, vrnt = TTC.tc1_process_Xhl_form tc tint vrnt in
-
-          t_bdhoare_while phi vrnt tc
-
-      | Some vrnt, Some (`Bd (k, eps)) ->
-        let _, phi = TTC.tc1_process_Xhl_formula tc phi in
-        let _, vrnt = TTC.tc1_process_Xhl_form tc tint vrnt in
-        let _, k = TTC.tc1_process_Xhl_form tc tint k in
-        let _, eps = TTC.tc1_process_Xhl_form tc treal eps in
-
-        t_bdhoare_while_rev_geq phi vrnt k eps tc
-
-      | None, None ->
-          let _, phi = TTC.tc1_process_Xhl_formula tc phi in
-          t_bdhoare_while_rev phi tc
-
-      | None, Some _ ->
-        tc_error !!tc "invalid arguments"
-  end
-
-  | FequivS _ -> begin
-      match side, vrnt with
-      | None, None ->
-          t_equiv_while (TTC.tc1_process_prhl_formula tc phi) tc
-
-      | Some side, Some vrnt ->
-          t_equiv_while_disj side
-            (TTC.tc1_process_prhl_form    tc tint vrnt)
-            (TTC.tc1_process_prhl_formula tc phi)
-            tc
-
-      | _ -> tc_error !!tc "invalid arguments"
-  end
-
-  | _ -> tc_error !!tc "expecting a hoare[...]/equiv[...]"
-
-(* -------------------------------------------------------------------- *)
-module ASyncWhile = struct
+module LossLess = struct
   exception CannotTranslate
 
   let form_of_expr env mother mh =
@@ -501,7 +405,185 @@ module ASyncWhile = struct
       | _ -> raise CannotTranslate
 
     in fun f -> let e = aux f in (e, !map)
+
+  let xhyps evs =
+    let mtypes = Mid.of_list [evs.es_ml; evs.es_mr] in
+
+    fun m fp ->
+      let fp =
+        Mid.fold (fun mh pvs fp ->
+            let mty = Mid.find_opt mh mtypes in
+            let fp  =
+              EcPV.Mnpv.fold (fun pv (x, ty) fp ->
+                  f_let1 x (f_pvar pv ty mh) fp)
+                (EcPV.PVMap.raw pvs) fp
+            in f_forall_mems [mh, oget mty] fp)
+          m fp
+      and cnt =
+        Mid.fold
+          (fun _ pvs i -> i + 1 + EcPV.Mnpv.cardinal (EcPV.PVMap.raw pvs))
+          m 0
+      in (cnt, fp)
 end
+
+(* -------------------------------------------------------------------- *)
+let t_equiv_ll_while_disj_r side inv tc =
+  let env = FApi.tc1_env tc in
+  let es = tc1_as_equivS tc in
+  let s, m_side, m_other =
+    match side with
+    | `Left  -> es.es_sl, es.es_ml, es.es_mr
+    | `Right -> es.es_sr, es.es_mr, es.es_ml in
+  let (e, c), s = tc1_last_while tc s in
+  let e = form_of_expr (EcMemory.memory m_side) e in
+
+  let (_,ll) =
+    try
+      let evs = tc1_as_equivS tc in
+      let ml = EcMemory.memory m_side in
+      let subst = Fsubst.f_bind_mem Fsubst.f_subst_id ml mhr in
+      let inv = Fsubst.f_subst subst inv in
+      let e, m = LossLess.form_of_expr env (EcMemory.memory m_other) ml e in
+      let c = s_while (e, c) in
+      LossLess.xhyps evs m
+        (f_bdHoareS (mhr, EcMemory.memtype m_side) inv c f_true FHeq f_r1)
+    with LossLess.CannotTranslate ->
+        tc_error !!tc
+          "while linking predicates cannot be converted to expressions"
+  in
+
+  (* 1. The body preserves the invariant and the loop is lossless. *)
+
+  let m_other' = (EcIdent.create "&m", EcMemory.memtype m_other) in
+
+  let smem = Fsubst.f_subst_id in
+  let smem = Fsubst.f_bind_mem smem (EcMemory.memory m_side ) mhr in
+  let smem =
+    Fsubst.f_bind_mem smem (EcMemory.memory m_other) (EcMemory.memory m_other')
+  in
+
+  let b_pre   = f_and_simpl inv e in
+  let b_pre   = Fsubst.f_subst smem b_pre in
+  let b_post  = inv in
+  let b_post  = Fsubst.f_subst smem b_post in
+  let b_concl =
+    f_bdHoareS (mhr, EcMemory.memtype m_side) b_pre c b_post FHeq f_r1
+  in
+  let b_concl = b_concl in
+  let b_concl = f_forall_mems [m_other'] b_concl in
+
+  (* 2. WP of the while *)
+  let post = f_imps_simpl [f_not_simpl e; inv] es.es_po in
+  let modi = s_write env c in
+  let post = generalize_mod env (EcMemory.memory m_side) modi post in
+  let post = f_and_simpl inv post in
+  let concl =
+    match side with
+    | `Left  -> f_equivS_r { es with es_sl = s; es_po=post; }
+    | `Right -> f_equivS_r { es with es_sr = s; es_po=post; }
+  in
+
+  FApi.xmutate1 tc `While [b_concl; ll; concl]
+
+(* -------------------------------------------------------------------- *)
+let t_equiv_while_r inv tc =
+  let env = FApi.tc1_env tc in
+  let es = tc1_as_equivS tc in
+  let (el, cl), sl = tc1_last_while tc es.es_sl in
+  let (er, cr), sr = tc1_last_while tc es.es_sr in
+  let ml = EcMemory.memory es.es_ml in
+  let mr = EcMemory.memory es.es_mr in
+  let el = form_of_expr ml el in
+  let er = form_of_expr mr er in
+  let sync_cond = f_iff_simpl el er in
+
+  (* 1. The body preserves the invariant *)
+  let b_pre  = f_ands_simpl [inv; el] er in
+  let b_post = f_and_simpl inv sync_cond in
+  let b_concl = f_equivS es.es_ml es.es_mr b_pre cl cr b_post in
+
+  (* 2. WP of the while *)
+  let post = f_imps_simpl [f_not_simpl el;f_not_simpl er; inv] es.es_po in
+  let modil = s_write env cl in
+  let modir = s_write env cr in
+  let post = generalize_mod env mr modir post in
+  let post = generalize_mod env ml modil post in
+  let post = f_and_simpl b_post post in
+  let concl = f_equivS_r { es with es_sl = sl; es_sr = sr; es_po = post; } in
+
+  FApi.xmutate1 tc `While [b_concl; concl]
+
+(* -------------------------------------------------------------------- *)
+let t_hoare_while           = FApi.t_low1 "hoare-while"   t_hoare_while_r
+let t_bdhoare_while         = FApi.t_low2 "bdhoare-while" t_bdhoare_while_r
+let t_bdhoare_while_rev_geq = FApi.t_low4 "bdhoare-while" t_bdhoare_while_rev_geq_r
+let t_bdhoare_while_rev     = FApi.t_low1 "bdhoare-while" t_bdhoare_while_rev_r
+let t_equiv_while           = FApi.t_low1 "equiv-while"   t_equiv_while_r
+let t_equiv_while_disj      = FApi.t_low3 "equiv-while"   t_equiv_while_disj_r
+let t_equiv_ll_while_disj   = FApi.t_low2 "equiv-while"   t_equiv_ll_while_disj_r
+
+(* -------------------------------------------------------------------- *)
+let process_while side winfos tc =
+  let { EP.wh_inv  = phi ;
+        EP.wh_vrnt = vrnt;
+        EP.wh_bds  = bds ; } = winfos in
+
+  match (FApi.tc1_goal tc).f_node with
+  | FhoareS _ -> begin
+      match vrnt with
+      | None ->
+        t_hoare_while
+          (snd (TTC.tc1_process_Xhl_formula tc phi))
+          tc
+      | _    -> tc_error !!tc "invalid arguments"
+    end
+
+  | FeHoareS _ ->
+      let _, inv = TTC.tc1_process_Xhl_formula_xreal tc phi in
+      t_ehoare_while inv tc
+
+  | FbdHoareS _ -> begin
+      match vrnt, bds with
+      | Some vrnt, None ->
+          let _, phi = TTC.tc1_process_Xhl_formula tc phi in
+          let _, vrnt = TTC.tc1_process_Xhl_form tc tint vrnt in
+          t_bdhoare_while phi vrnt tc
+
+      | Some vrnt, Some (`Bd (k, eps)) ->
+        let _, phi = TTC.tc1_process_Xhl_formula tc phi in
+        let _, vrnt = TTC.tc1_process_Xhl_form tc tint vrnt in
+        let _, k = TTC.tc1_process_Xhl_form tc tint k in
+        let _, eps = TTC.tc1_process_Xhl_form tc treal eps in
+
+        t_bdhoare_while_rev_geq phi vrnt k eps tc
+      | None, None ->
+          let _, phi = TTC.tc1_process_Xhl_formula tc phi in
+          t_bdhoare_while_rev phi tc
+
+      | None, Some _ ->
+        tc_error !!tc "invalid arguments"
+  end
+
+  | FequivS _ -> begin
+      match side, vrnt with
+      | None, None ->
+          t_equiv_while (TTC.tc1_process_prhl_formula tc phi) tc
+
+      | Some side, Some vrnt ->
+          t_equiv_while_disj side
+            (TTC.tc1_process_prhl_form    tc tint vrnt)
+            (TTC.tc1_process_prhl_formula tc phi)
+            tc
+
+      | Some side, None ->
+        t_equiv_ll_while_disj side
+            (TTC.tc1_process_prhl_formula tc phi)
+            tc
+
+      | _ -> tc_error !!tc "invalid arguments"
+  end
+
+  | _ -> tc_error !!tc "expecting a hoare[...]/equiv[...]"
 
 (* -------------------------------------------------------------------- *)
 let process_async_while (winfos : EP.async_while_info) tc =
@@ -587,49 +669,29 @@ let process_async_while (winfos : EP.async_while_info) tc =
     in (hr1, hr2)
   in
 
-  let xhyps =
-    let mtypes = Mid.of_list [evs.es_ml; evs.es_mr] in
-
-    fun m fp ->
-      let fp =
-        Mid.fold (fun mh pvs fp ->
-          let mty = Mid.find_opt mh mtypes in
-          let fp  =
-            EcPV.Mnpv.fold (fun pv (x, ty) fp ->
-              f_let1 x (f_pvar pv ty mh) fp)
-            (EcPV.PVMap.raw pvs) fp
-          in f_forall_mems [mh, oget mty] fp)
-        m fp
-      and cnt =
-        Mid.fold
-          (fun _ pvs i -> i + 1 + EcPV.Mnpv.cardinal (EcPV.PVMap.raw pvs))
-          m 0
-      in (cnt, fp)
-  in
-
   let (c1, ll1), (c2, ll2) =
     try
       let ll1 =
         let subst   = Fsubst.f_bind_mem Fsubst.f_subst_id ml mhr in
         let inv     = Fsubst.f_subst subst inv in
         let test    = f_ands [fe1; f_not p0; p1] in
-        let test, m = ASyncWhile.form_of_expr env (EcMemory.memory evs.es_mr) ml test in
+        let test, m = LossLess.form_of_expr env (EcMemory.memory evs.es_mr) ml test in
         let c       = s_while (test, cl) in
-        xhyps m
+        LossLess.xhyps evs m
           (f_bdHoareS (mhr, EcMemory.memtype evs.es_ml) inv c f_true FHeq f_r1)
 
       and ll2 =
         let subst   = Fsubst.f_bind_mem Fsubst.f_subst_id mr mhr in
         let inv     = Fsubst.f_subst subst inv in
         let test    = f_ands [fe1; f_not p0; f_not p1] in
-        let test, m = ASyncWhile.form_of_expr env (EcMemory.memory evs.es_ml) mr test in
+        let test, m = LossLess.form_of_expr env (EcMemory.memory evs.es_ml) mr test in
         let c       = s_while (test, cr) in
-        xhyps m
+        LossLess.xhyps evs m
           (f_bdHoareS (mhr, EcMemory.memtype evs.es_mr) inv c f_true FHeq f_r1)
 
       in (ll1, ll2)
 
-    with ASyncWhile.CannotTranslate ->
+    with LossLess.CannotTranslate ->
       tc_error !!tc
         "async-while linking predicates cannot be converted to expressions"
   in


### PR DESCRIPTION
Add tactic for one-sided while rule with lossless proof:

```   
    {I} while b do c {T}   {I}c{I}   P => I /\ (not b => I => Q)
    ------------------------------------------------------------
                 {P} while b do c ~ skip {Q}
```

```
    {I} while b do c {T}   {I}c{I}   P => I /\ (not b => I => Q)
    ------------------------------------------------------------
                 {P} skip ~ while b do c {Q}
```