### PR TITLE
Fixing code blocks display in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,26 +182,26 @@ following [these instructions](https://nixos.org/manual/nix/stable/#chap-install
 
 Then, at the root of the EasyCrypt source tree, type:
 
-    ```
-    $> make nix-build
-    ```
+```
+$> make nix-build
+```
 
 Once completed, you will find the EasyCrypt binary in `result/bin`.
 
 You can also run
 
-    ```
-    $> make nix-build-with-provers
-    ```
+```
+$> make nix-build-with-provers
+```
 
 to install EasyCrypt along with a set of provers.
 
 
 For getting a development environment, you can run:
 
-    ```
-    $> make nix-develop
-    ```
+```
+$> make nix-develop
+```
 
 These will install all the required dependencies, a set of provers and
 will then drop you into a shell. From there, simply run `make` to


### PR DESCRIPTION
The original text was using both the fenced markers (```) and the spacing to give the instructions for NIX.