### PR TITLE
New vernacular command: theory aliases

### DIFF
--- a/src/ecCommands.ml
+++ b/src/ecCommands.ml
@@ -291,7 +291,7 @@ module HiPrinting = struct
     let ppe = EcPrinting.PPEnv.ofenv env in
 
     let pp_path =
-      EcPrinting.pp_shorten_path
+      EcPrinting.pp_shorten_path ppe
         (fun (p : EcPath.path) (q : EcSymbols.qsymbol) ->
           Option.equal EcPath.p_equal
             (Some p)
@@ -594,6 +594,11 @@ and process_th_clone (scope : EcScope.scope) thcl =
   EcScope.Cloning.clone scope (Pragma.get ()).pm_check thcl
 
 (* -------------------------------------------------------------------- *)
+and process_th_alias (scope : EcScope.scope) (thcl : psymbol * pqsymbol) =
+  EcScope.check_state `InTop "theory alias" scope;
+  EcScope.Theory.alias scope thcl
+
+  (* -------------------------------------------------------------------- *)
 and process_mod_import (scope : EcScope.scope) mods =
   EcScope.check_state `InTop "module var import" scope;
   List.fold_left EcScope.Mod.import scope mods
@@ -768,6 +773,7 @@ and process (ld : Loader.loader) (scope : EcScope.scope) g =
       | GthImport    name -> `Fct   (fun scope -> process_th_import  scope  name)
       | GthExport    name -> `Fct   (fun scope -> process_th_export  scope  name)
       | GthClone     thcl -> `Fct   (fun scope -> process_th_clone   scope  thcl)
+      | GthAlias     als  -> `Fct   (fun scope -> process_th_alias   scope  als)
       | GModImport   mods -> `Fct   (fun scope -> process_mod_import scope  mods)
       | GsctOpen     name -> `Fct   (fun scope -> process_sct_open   scope  name)
       | GsctClose    name -> `Fct   (fun scope -> process_sct_close  scope  name)

--- a/src/ecCorePrinting.ml
+++ b/src/ecCorePrinting.ml
@@ -54,7 +54,7 @@ module type PrinterAPI = sig
   val pp_tyname  : PPEnv.t -> path pp
   val pp_axname  : PPEnv.t -> path pp
   val pp_tcname  : PPEnv.t -> path pp
-  val pp_thname  : PPEnv.t -> path pp
+  val pp_thname  : ?alias:bool -> PPEnv.t -> path pp
 
   val pp_mem      : PPEnv.t -> EcIdent.t pp
   val pp_memtype  : PPEnv.t -> EcMemory.memtype pp
@@ -63,9 +63,9 @@ module type PrinterAPI = sig
   val pp_path     : path pp
   
   (* ------------------------------------------------------------------ *)
-  val shorten_path : (path -> qsymbol -> bool) -> path -> qsymbol * qsymbol option
+  val shorten_path : PPEnv.t -> (path -> qsymbol -> bool) -> path -> qsymbol * qsymbol option
 
-  val pp_shorten_path : (path -> qsymbol -> bool) -> path pp
+  val pp_shorten_path : PPEnv.t -> (path -> qsymbol -> bool) -> path pp
 
   (* ------------------------------------------------------------------ *)
   val pp_codepos1    : PPEnv.t -> EcMatching.Position.codepos1 pp

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -293,6 +293,9 @@ module Theory : sig
     -> EcTypes.is_local
     -> EcTheory.thmode
     -> env -> compiled_theory option
+
+  val alias : ?import:import -> symbol -> path -> env -> env
+  val aliases : env -> path Mp.t
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1984,7 +1984,7 @@ theory_clear_items:
 | xs=theory_clear_item1* { xs }
 
 theory_open:
-| loca=is_local b=boption(ABSTRACT) THEORY x=uident
+| loca=is_local b=iboption(ABSTRACT) THEORY x=uident
     { (loca, b, x) }
 
 theory_close:
@@ -3655,6 +3655,13 @@ realize:
 | REALIZE x=qident BY bracket(empty)
     {  { pr_name = x; pr_proof = Some None; } }
 
+
+(* -------------------------------------------------------------------- *)
+(* Theory aliasing                                                      *)
+
+theory_alias: (* FIXME: THEORY ALIAS -> S/R conflict *)
+| THEORY name=uident EQ target=uqident { (name, target) }
+
 (* -------------------------------------------------------------------- *)
 (* Printing                                                             *)
 phint:
@@ -3792,6 +3799,7 @@ global_action:
 | theory_export    { GthExport    $1 }
 | theory_clone     { GthClone     $1 }
 | theory_clear     { GthClear     $1 }
+| theory_alias     { GthAlias     $1 }
 | module_import    { GModImport   $1 }
 | section_open     { GsctOpen     $1 }
 | section_close    { GsctClose    $1 }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1293,6 +1293,7 @@ type global_action =
   | GthImport    of pqsymbol list
   | GthExport    of pqsymbol list
   | GthClone     of theory_cloning
+  | GthAlias     of (psymbol * pqsymbol)
   | GModImport   of pmsymbol located list
   | GsctOpen     of osymbol_r
   | GsctClose    of osymbol_r

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -143,7 +143,25 @@ module PPEnv = struct
             (fun env x -> EcEnv.Mod.bind_param x mty env)
             ppe.ppe_env xs; }
 
-  let p_shorten cond (nm, x) =
+  let reverse_theory_alias (ppe : t) (path : P.path) : P.path =
+    let aliases = EcEnv.Theory.aliases ppe.ppe_env in
+
+    let rec reverse (suffix : symbol list) (p : P.path option) =
+      Option.bind p (fun prefix ->
+        match P.Mp.find_opt prefix aliases with
+        | None -> reverse (P.basename prefix :: suffix) (P.prefix prefix)
+        | Some prefix -> Some (EcPath.extend prefix suffix)
+      )
+    in Option.value ~default:path (reverse [] (Some path))
+
+  let p_shorten
+    ?(alias = true)
+    ?(istheory = false)
+     (ppe  : t)
+     (cond : qsymbol -> bool)
+     (p    : qsymbol)
+    : qsymbol
+  =
     let rec shorten prefix (nm, x) =
       match cond (nm, x) with
       | true  -> (nm, x)
@@ -154,35 +172,46 @@ module PPEnv = struct
       end
     in
 
+    let p = EcPath.fromqsymbol p in
+    let p =
+      if alias then begin
+        if istheory then
+          reverse_theory_alias ppe p
+        else
+          let thpath, base = P.prefix p, P.basename p in
+          let thpath = Option.map (reverse_theory_alias ppe) thpath in
+          P.pqoname thpath base
+      end else p in
+    let (nm, x) = EcPath.toqsymbol p in
     shorten (List.rev nm) ([], x)
 
   let ty_symb (ppe : t) p =
-      let exists sm =
+    let exists sm =
       try  EcPath.p_equal (EcEnv.Ty.lookup_path ~unique:true sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ppe exists (P.toqsymbol p)
 
   let tc_symb (ppe : t) p =
-      let exists sm =
+    let exists sm =
       try  EcPath.p_equal (EcEnv.TypeClass.lookup_path sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ppe exists (P.toqsymbol p)
 
   let rw_symb (ppe : t) p =
-      let exists sm =
+    let exists sm =
       try  EcPath.p_equal (EcEnv.BaseRw.lookup_path sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ppe exists (P.toqsymbol p)
 
   let ax_symb (ppe : t) p =
-      let exists sm =
+    let exists sm =
       try  EcPath.p_equal (EcEnv.Ax.lookup_path sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ppe exists (P.toqsymbol p)
 
   let op_symb (ppe : t) p info =
     let specs = [1, EcPath.pqoname (EcPath.prefix EcCoreLib.CI_Bool.p_eq) "<>"] in
@@ -220,21 +249,21 @@ module PPEnv = struct
       (* FIXME: for special operators, do check `info` *)
       if   List.exists (fun (_, sp) -> EcPath.p_equal sp p) specs
       then ([], EcPath.basename p)
-      else p_shorten exists (P.toqsymbol p)
+      else p_shorten ppe exists (P.toqsymbol p)
 
   let ax_symb (ppe : t) p =
     let exists sm =
       try  EcPath.p_equal (EcEnv.Ax.lookup_path sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ppe exists (P.toqsymbol p)
 
-  let th_symb (ppe : t) p =
+  let th_symb ?alias (ppe : t) p =
     let exists sm =
       try  EcPath.p_equal (EcEnv.Theory.lookup_path sm ppe.ppe_env) p
       with EcEnv.LookupFailure _ -> false
     in
-      p_shorten exists (P.toqsymbol p)
+      p_shorten ?alias ~istheory:true ppe exists (P.toqsymbol p)
 
   let rec mod_symb (ppe : t) mp : EcSymbols.msymbol =
     let (nm, x, p2) =
@@ -360,13 +389,18 @@ module PPEnv = struct
 end
 
 (* -------------------------------------------------------------------- *)
-let shorten_path (cond : P.path -> qsymbol -> bool) (p : P.path) : qsymbol * qsymbol option =
+let shorten_path
+  (ppe  : PPEnv.t)
+  (cond : P.path -> qsymbol -> bool)
+  (p    : P.path)
+  : qsymbol * qsymbol option
+=
   let (nm, x) = EcPath.toqsymbol p in
   let nm =
     match nm with
     | top :: nm when top = EcCoreLib.i_top -> nm
     | _ -> nm in
-  let nm', x' = PPEnv.p_shorten (cond p) (nm, x) in
+  let nm', x' = PPEnv.p_shorten ppe (cond p) (nm, x) in
   let plong, pshort = (nm, x), (nm', x') in
 
   (plong, if plong = pshort then None else Some pshort)
@@ -445,8 +479,13 @@ let pp_path fmt p =
   Format.fprintf fmt "%s" (P.tostring p)
 
 (* -------------------------------------------------------------------- *)
-let pp_shorten_path (cond : P.path -> qsymbol -> bool) (fmt : Format.formatter) (p : P.path) =
-  let plong, pshort  = shorten_path cond p in
+let pp_shorten_path
+  (ppe  : PPEnv.t)
+  (cond : P.path -> qsymbol -> bool)
+  (fmt  : Format.formatter)
+  (p    : P.path)
+=
+  let plong, pshort = shorten_path ppe cond p in
 
   match pshort with
   | None ->
@@ -507,8 +546,8 @@ let pp_axhnt ppe fmt (p, b) =
   Format.fprintf fmt "%a%s" (pp_axname ppe) p b
 
 (* -------------------------------------------------------------------- *)
-let pp_thname ppe fmt p =
-  EcSymbols.pp_qsymbol fmt (PPEnv.th_symb ppe p)
+let pp_thname ?alias ppe fmt p =
+  EcSymbols.pp_qsymbol fmt (PPEnv.th_symb ?alias ppe p)
 
 (* -------------------------------------------------------------------- *)
 let pp_funname (ppe : PPEnv.t) fmt p =
@@ -3564,6 +3603,9 @@ let rec pp_theory ppe (fmt : Format.formatter) (path, cth) =
         pp_locality locality
         level (odfl "" base)
         (pp_list "@ " (pp_axhnt ppe)) axioms
+
+  | EcTheory.Th_alias (name, target) ->
+      Format.fprintf fmt "theory %s = %a." name (pp_thname ~alias:false ppe) target
 
 (* -------------------------------------------------------------------- *)
 let pp_stmt_with_nums (ppe : PPEnv.t) fmt stmt =

--- a/src/ecScope.mli
+++ b/src/ecScope.mli
@@ -175,6 +175,10 @@ module Theory : sig
   val add_clears : (pqsymbol option) list -> scope -> scope
 
   val required : scope -> required
+
+  (* [alias scope (name, thname)] create a theory alias [name] to
+   * [thname] *)
+  val alias : scope -> ?import:EcTheory.import -> psymbol * pqsymbol -> scope
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -1051,6 +1051,7 @@ let rec set_local_item item =
     | Th_addrw     (p,ps,lc) -> Th_addrw     (p, ps, set_local lc)
     | Th_reduction       r   -> Th_reduction r
     | Th_auto       auto_rl  -> Th_auto      {auto_rl with locality=set_local auto_rl.locality}
+    | Th_alias         alias -> Th_alias     alias
 
   in { item with ti_item = lcitem }
 
@@ -1353,6 +1354,7 @@ let add_item_ (item : theory_item) (scenv:scenv) =
     | Th_addrw (p,ps,lc)     -> EcEnv.BaseRw.addto p ps lc env
     | Th_auto auto           -> EcEnv.Auto.add ~level:auto.level ?base:auto.base
                                   auto.axioms auto.locality env
+    | Th_alias     (n,p) -> EcEnv.Theory.alias n p env
     | Th_reduction r         -> EcEnv.Reduction.add r env
     | _                      -> assert false
   in
@@ -1381,6 +1383,7 @@ let rec generalize_th_item (to_gen : to_gen) (prefix : path) (th_item : theory_i
     | Th_addrw (p,ps,lc) -> generalize_addrw to_gen (p, ps, lc)
     | Th_reduction rl    -> generalize_reduction to_gen rl
     | Th_auto hints      -> generalize_auto to_gen hints
+    | Th_alias _         -> (to_gen, None) (* FIXME:ALIAS *)
 
   in
 
@@ -1503,6 +1506,7 @@ let check_item scenv item =
       hierror "local hint can only be declared inside section";
   | Th_reduction _ -> ()
   | Th_theory  _   -> assert false
+  | Th_alias _     -> () (* FIXME:ALIAS *)
 
 let rec add_item (item : theory_item) (scenv : scenv) =
   let item = if scenv.sc_loca = `Local then set_local_item item else item in

--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -1079,6 +1079,9 @@ let rec subst_theory_item_r (s : subst) (item : theory_item_r) =
       Th_auto { auto_rl with axioms =
         List.map (fst_map (subst_path s)) axioms }
 
+  | Th_alias (name, target) ->
+      Th_alias (name, subst_path s target)
+
 (* -------------------------------------------------------------------- *)
 and subst_theory (s : subst) (items : theory) =
   List.map (subst_theory_item s) items

--- a/src/ecThCloning.ml
+++ b/src/ecThCloning.ml
@@ -457,6 +457,7 @@ end = struct
       | Th_addrw  _     -> (proofs, evc)
       | Th_reduction _  -> (proofs, evc)
       | Th_auto _       -> (proofs, evc)
+      | Th_alias _      -> (proofs, evc)
 
     and doit prefix (proofs, evc) dth =
       doit_r prefix (proofs, evc) dth.ti_item

--- a/src/ecTheory.ml
+++ b/src/ecTheory.ml
@@ -38,6 +38,7 @@ and theory_item_r =
   | Th_addrw     of EcPath.path * EcPath.path list * is_local
   | Th_reduction of (EcPath.path * rule_option * rule option) list
   | Th_auto      of auto_rule
+  | Th_alias     of (symbol * path) (* FIXME: currently, only theories *)
 
 and thsource = {
   ths_base : EcPath.path;

--- a/src/ecTheory.mli
+++ b/src/ecTheory.mli
@@ -35,6 +35,7 @@ and theory_item_r =
   (* reduction rule does not survive to section so no locality *)
   | Th_reduction of (EcPath.path * rule_option * rule option) list
   | Th_auto      of auto_rule
+  | Th_alias     of (symbol * path)
 
 and thsource = {
   ths_base : EcPath.path;

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -1007,6 +1007,20 @@ and replay_instance
     (subst, ops, proofs, scope)
 
 (* -------------------------------------------------------------------- *)
+and replay_alias
+  (ove : _ ovrenv) (subst, ops, proofs, scope) (import, name, target)
+=
+  let scenv = ove.ovre_hooks.henv scope in
+  let env = EcSection.env scenv in
+  let p = EcSubst.subst_path subst target in
+
+  if is_none (EcEnv.Theory.by_path_opt p env) then
+    (subst, ops, proofs, scope)
+  else
+    let scope = ove.ovre_hooks.hadd_item scope import (Th_alias (name, target)) in
+    (subst, ops, proofs, scope)
+
+(* -------------------------------------------------------------------- *)
 and replay1 (ove : _ ovrenv) (subst, ops, proofs, scope) item =
   match item.ti_item with
   | Th_type (x, otyd) ->
@@ -1050,6 +1064,9 @@ and replay1 (ove : _ ovrenv) (subst, ops, proofs, scope) item =
 
   | Th_instance ((typ, ty), tc, lc) ->
      replay_instance ove (subst, ops, proofs, scope) (item.ti_import, (typ, ty), tc, lc)
+
+  | Th_alias (name, target) ->
+     replay_alias ove (subst, ops, proofs, scope) (item.ti_import, name, target)
 
   | Th_theory (ox, cth) -> begin
       let thmode = cth.cth_mode in

--- a/tests/theory-alias.ec
+++ b/tests/theory-alias.ec
@@ -1,0 +1,13 @@
+theory T.
+  theory V.
+    op foo : int.
+  end V.
+
+  theory U = V.
+end T.
+
+import T.
+
+op bar : int = U.foo.
+
+print T.


### PR DESCRIPTION
Syntax this: `theory T = Path.To.Theory`

Theory aliases allow giving alternate names to theories - mainly
for readability issues. They are purely syntactic sugar and are
fully resolved (desugared) during typing.

The pretty-printer uses them when printing path, using a
longest-then-lastly-introduced strategy.