### PR TITLE
[external CI] use dev branch for XSalsa checks

### DIFF
--- a/.github/workflows/external.json
+++ b/.github/workflows/external.json
@@ -34,7 +34,7 @@
 
   { "name"       : "xsalsa20"
   , "repository" : "https://gitlab.com/fdupress/ec-xsalsa"
-  , "branch"     : "master"
+  , "branch"     : "ec-main"
   , "subdir"     : "."
   , "config"     : "config/tests.config"
   , "scenario"   : "xsalsa"


### PR DESCRIPTION
The external CI is currently configured to use the `master` branch of the XSalsa repo, which follows the latest EC release instead of EasyCrypt's `main`. This points the external CI to the correct branch.