### PR TITLE
Allow ^x<- to match on an element of a left value tuple.

### DIFF
--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -120,6 +120,9 @@ module Zipper = struct
             | LvVar (pv, _), `LvmVar pvm
                  when EcReduction.EqTest.for_pv env pv pvm
               -> i-1
+            | LvTuple pvs, `LvmVar pvm
+                  when List.exists (fun (pv, _) -> EcReduction.EqTest.for_pv env pv pvm) pvs
+              -> i-1
             | _ -> i
           end
 

--- a/tests/codepos-tuple-name.ec
+++ b/tests/codepos-tuple-name.ec
@@ -1,0 +1,23 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore.
+
+module M = {
+  proc f() = {
+    var x : int;
+    var y : int;
+    var z : int;
+
+    y <- 1;
+    (x, z) <- (0, 0);
+    return y;
+  }
+}.
+
+op p : int -> bool.
+
+lemma L : hoare[M.f : true ==> p res].
+proof.
+proc.
+swap ^x<- @ ^y<-.
+swap ^y<- @ ^z<-.
+abort.


### PR DESCRIPTION
For example: `^x<-` and `^y<-` and `^z<-` will all match on `(x, y, z) <- e`.