### PR TITLE
Extend `clear` tactic to allow clearing *all* unused items in the context recursively

### DIFF
--- a/src/ecHiGoal.mli
+++ b/src/ecHiGoal.mli
@@ -71,7 +71,7 @@ val process_mgenintros  : ?cf:bool -> ttenv -> introgenpattern list -> tactical
 val process_genintros   : ?cf:bool -> ttenv -> introgenpattern list -> backward
 val process_generalize  : ?doeq:bool -> genpattern list -> backward
 val process_move        : ?doeq:bool -> ppterm list -> prevert -> backward
-val process_clear       : psymbol list -> backward
+val process_clear       : clear_info -> backward
 val process_smt         : ?loc:EcLocation.t -> ttenv -> pprover_infos option -> backward
 val process_coq         : loc:EcLocation.t -> name:string -> ttenv -> EcProvers.coq_mode option -> pprover_infos -> backward
 val process_apply       : implicits:bool -> apply_t * prevert option -> backward

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -2682,8 +2682,14 @@ logtactic:
 | MOVE vw=prefix(SLASH, pterm)* gp=prefix(COLON, revert)?
    { Pmove { pr_rev = odfl prevert0 gp; pr_view = vw; } }
 
+| CLEAR
+   { Pclear (`Exclude []) }
+
+| CLEAR MINUS l=loc(ipcore_name)+
+   { Pclear (`Exclude l) }
+
 | CLEAR l=loc(ipcore_name)+
-   { Pclear l }
+   { Pclear (`Include l) }
 
 | CONGR
    { Pcongr }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -958,6 +958,12 @@ type apply_info = [
 ]
 
 (* -------------------------------------------------------------------- *)
+type clear_info = [
+  | `Exclude of psymbol list
+  | `Include of psymbol list
+]
+
+(* -------------------------------------------------------------------- *)
 type pgenhave = psymbol * intropattern option * psymbol list * pformula
 
 (* -------------------------------------------------------------------- *)
@@ -979,7 +985,7 @@ type logtactic =
   | Pcut        of pcut
   | Pcutdef     of (intropattern * pcutdef)
   | Pmove       of prevertv
-  | Pclear      of psymbol list
+  | Pclear      of clear_info
   | Prewrite    of (rwarg list * osymbol_r)
   | Prwnormal   of pformula * pqsymbol list
   | Psubst      of pformula list

--- a/tests/clear.ec
+++ b/tests/clear.ec
@@ -1,0 +1,21 @@
+lemma L: true.
+pose x:=false.
+clear x.
+(* `x` is now unbound *)
+pose x:=false.
+pose y:=x.
+pose z:=y.
+clear -y. 
+(* `z` is unbound, but `x` is not, since `y` depends on it *)
+pose z:=x.
+clear y.
+pose y:=z.
+clear. 
+(* everything is unbound, since nothing is in the goal *)
+pose x:=true.
+pose y:=false.
+clear. 
+(* we cannot clear `x` since it is in the goal,
+   but `y` is not used so it becomes unbound *)
+pose y:= x.
+abort.


### PR DESCRIPTION
This feature was requested at the retreat.

Please have patience with the review. This is literally the first OCaml code I've ever written.