### PR TITLE
Reworked outline tactic

### DIFF
--- a/examples/MEE-CBC/CBC.eca
+++ b/examples/MEE-CBC/CBC.eca
@@ -187,7 +187,7 @@ section Random_Ideal.
   equiv Random_Ideal: Random.enc ~ Ideal.enc: size p{1} = size p{2} ==> ={res}.
   proof.
   proc.
-  outline {2} [1] { r <@ Sampling.Sample.sample(size p + 1); }.
+  outline {2} 1 by { r <@ Sampling.Sample.sample(size p + 1); }.
   rewrite equiv[{2} 1 Sampling.Sample_LoopSnoc_eq].
   by inline; wp; while (={i} /\ c{1} = l{2} /\ size p{1} + 1 = n{2}); auto=> /#.
   qed.

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -2904,7 +2904,7 @@ interleave_info:
    { (s, c1, c2 :: c3, k) }
 
 %inline outline_kind:
-| s=brace(stmt) { OKstmt(s) }
+| BY s=brace(stmt) { OKstmt(s) }
 | TILD f=loc(fident) { OKproc(f, true) }
 | f=loc(fident) { OKproc(f, false) }
 
@@ -2986,11 +2986,10 @@ interleave_info:
 | INLINE s=side? u=inlineopt? p=codepos
     { Pinline (`CodePos (s, u, p)) }
 
-| OUTLINE s=side LBRACKET st=codepos1 e=option(MINUS e=codepos1 {e}) RBRACKET k=outline_kind
+| OUTLINE s=side cpr=codepos_or_range k=outline_kind
     { Poutline {
 	  outline_side  = s;
-	  outline_start = st;
-	  outline_end   = odfl st e;
+	  outline_range = cpr;
 	  outline_kind  = k }
     }
 

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -2905,7 +2905,8 @@ interleave_info:
 
 %inline outline_kind:
 | s=brace(stmt) { OKstmt(s) }
-| r=sexpr? LEAT f=loc(fident) { OKproc(f, r) }
+| TILD f=loc(fident) { OKproc(f, true) }
+| f=loc(fident) { OKproc(f, false) }
 
 %public phltactic:
 | PROC

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -669,8 +669,7 @@ type outline_kind =
 
 type outline_info = {
     outline_side: side;
-    outline_start: pcodepos1;
-    outline_end: pcodepos1;
+    outline_range: pcodepos_range;
     outline_kind: outline_kind;
 }
 

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -665,7 +665,7 @@ type inline_info = [
 (* -------------------------------------------------------------------- *)
 type outline_kind =
   | OKstmt of pstmt
-  | OKproc of pgamepath * pexpr option
+  | OKproc of pgamepath * bool
 
 type outline_info = {
     outline_side: side;

--- a/src/ecProofTyping.ml
+++ b/src/ecProofTyping.ml
@@ -174,18 +174,26 @@ let tc1_process_Xhl_formula_xreal tc pf =
   tc1_process_Xhl_form tc txreal pf
 
 (* ------------------------------------------------------------------ *)
+let tc1_process_codepos_range tc (side, cpr) =
+  let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
+  let env = FApi.tc1_env tc in
+  let env = EcEnv.Memory.push_active me env in
+  EcTyping.trans_codepos_range env cpr
+
+(* ------------------------------------------------------------------ *)
 let tc1_process_codepos tc (side, cpos) =
   let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
   let env = FApi.tc1_env tc in
   let env = EcEnv.Memory.push_active me env in
   EcTyping.trans_codepos env cpos
+
 (* ------------------------------------------------------------------ *)
 let tc1_process_codepos1 tc (side, cpos) =
   let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
   let env = FApi.tc1_env tc in
   let env = EcEnv.Memory.push_active me env in
   EcTyping.trans_codepos1 env cpos
-  
+
 (* ------------------------------------------------------------------ *)
 (* FIXME: factor out to typing module                                 *)
 (* FIXME: TC HOOK - check parameter constraints                       *)

--- a/src/ecProofTyping.mli
+++ b/src/ecProofTyping.mli
@@ -63,6 +63,7 @@ val tc1_process_stmt :
 val tc1_process_prhl_stmt :
      ?map:EcTyping.ismap -> tcenv1 -> side -> pstmt -> stmt
 
+val tc1_process_codepos_range : tcenv1 -> oside * pcodepos_range -> codepos_range
 val tc1_process_codepos : tcenv1 -> oside * pcodepos -> codepos
 val tc1_process_codepos1 : tcenv1 -> oside * pcodepos1 -> codepos1
 

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -230,6 +230,7 @@ type ismap = (instr list) EcMaps.Mstr.t
 val transstmt : ?map:ismap -> env -> EcUnify.unienv -> pstmt -> stmt
 
 (* -------------------------------------------------------------------- *)
+val trans_codepos_range : ?memory:EcMemory.memory -> env -> pcodepos_range -> codepos_range
 val trans_codepos1 : ?memory:EcMemory.memory -> env -> pcodepos1 -> codepos1
 val trans_codepos : ?memory:EcMemory.memory -> env -> pcodepos -> codepos
 val trans_dcodepos1 : ?memory:EcMemory.memory -> env -> pcodepos1 doption -> codepos1 doption

--- a/src/ecUnifyProc.ml
+++ b/src/ecUnifyProc.ml
@@ -5,8 +5,14 @@ open EcSymbols
 
 (*---------------------------------------------------------------------------------------*)
 type u_error =
+  | UE_AliasNoRet
+  | UE_AliasNotPv
   | UE_InvalidRetInstr
-  | UE_UnexpectedReturn
+  | UE_AbstractFun
+  | UE_TypeMismatch of expr * expr
+  | UE_UnificationFailArg of symbol
+  | UE_UnificationFailPv of symbol
+  | UE_LvNotInLockstep of lvalue * lvalue
   | UE_ExprNotInLockstep of expr * expr
   | UE_InstrNotInLockstep of instr * instr
   | UE_DifferentProgramLengths of stmt * stmt
@@ -15,101 +21,208 @@ exception UnificationError of u_error
 
 (*---------------------------------------------------------------------------------------*)
 type u_value =
-  | Empty
-  | Fixed of expr
- 
+  | Arg of expr option
+  | Local of prog_var option
+
 type umap = u_value Msym.t
 
 (*---------------------------------------------------------------------------------------*)
 let rec unify_exprs umap e1 e2 =
+  if not (EcTypes.ty_equal e1.e_ty e2.e_ty) then
+    raise (UnificationError (UE_TypeMismatch (e1, e2)));
+
   match e1.e_node, e2.e_node with
-  | Eint _, Eint _ -> umap
+  | Eint x1, Eint x2 when EcBigInt.equal x1 x2 -> umap
   | Elocal _, Elocal _ -> umap
-  | Evar pv, e2n ->
-     let var = symbol_of_pv pv in
+  | Evar (PVloc v), Evar pv ->
 
-     (* Only update a value if it hasn't been fixed previously *)
-     let update value =
-       match value with
-       | None ->
-          begin
-            match e2n with
-            | Evar _ -> None
-            | _ -> raise (UnificationError (UE_ExprNotInLockstep (e1, e2)))
-          end
-       | Some Empty -> Some (Fixed e2)
-       | _ -> value
-     in
+    let update value =
+      match value with
+      | Some (Local None) -> Some (Local (Some pv))
+      | Some (Arg None) -> Some (Arg (Some e2))
+      | _ -> value
+    in
+    Msym.change update v umap
 
-     Msym.change update var umap
-  | Eop _, Eop _ -> umap
+  | Evar (PVloc v), _ ->
+    (* NOTE: Only the arguments can unify with compound expressions *)
+    let update value =
+      match value with
+      | None ->
+        raise (UnificationError (UE_ExprNotInLockstep (e1, e2)))
+      | Some (Arg None) -> Some (Arg (Some e2))
+      | _ -> value
+    in
+    Msym.change update v umap
+  | Evar (PVglob xp1), Evar (PVglob xp2)
+    when EcPath.x_equal xp1 xp2 -> umap
+  | Eop (p1, _), Eop (p2, _)
+    when EcPath.p_equal p1 p2 -> umap
   | Eapp (f1, a1), Eapp (f2, a2) ->
-     let umap = unify_exprs umap f1 f2 in
-     List.fold_left (fun umap (e1, e2) -> unify_exprs umap e1 e2) umap (List.combine a1 a2)
-  | Equant (_, _, e1), Equant (_, _, e2) ->
-     unify_exprs umap e1 e2
+    let umap = unify_exprs umap f1 f2 in
+    if List.length a1 <> List.length a2 then
+      raise (UnificationError (UE_ExprNotInLockstep (e1, e2)));
+    List.fold_left2 (fun umap e1 e2 -> unify_exprs umap e1 e2) umap a1 a2
+  | Equant (q1, b1, e1), Equant (q2, b2, e2) when q1 = q2 ->
+    if List.length b1 <> List.length b2 then
+      raise (UnificationError (UE_ExprNotInLockstep (e1, e2)));
+    unify_exprs umap e1 e2
   | Elet (_, e1, u1), Elet (_, e2, u2) ->
-     let umap = unify_exprs umap e1 e2 in
-     unify_exprs umap u1 u2
+    let umap = unify_exprs umap e1 e2 in
+    unify_exprs umap u1 u2
   | Etuple t1, Etuple t2 ->
-     List.fold_left (fun umap (e1, e2) -> unify_exprs umap e1 e2) umap (List.combine t1 t2)
+    List.fold_left (fun umap (e1, e2) -> unify_exprs umap e1 e2) umap (List.combine t1 t2)
   | Eif (c1, t1, f1), Eif (c2, t2, f2) ->
-     let umap = unify_exprs umap c1 c2 in
-     let umap = unify_exprs umap t1 t2 in
-     unify_exprs umap f1 f2
+    let umap = unify_exprs umap c1 c2 in
+    let umap = unify_exprs umap t1 t2 in
+    unify_exprs umap f1 f2
   | Ematch (c1, p1, _), Ematch (c2, p2, _) ->
-     let umap = unify_exprs umap c1 c2 in
-     List.fold_left (fun umap (e1, e2) -> unify_exprs umap e1 e2) umap (List.combine p1 p2)
-  | Eproj (e1, _), Eproj (e2, _) ->
-     unify_exprs umap e1 e2
+    let umap = unify_exprs umap c1 c2 in
+    if List.length p1 <> List.length p2 then
+      raise (UnificationError (UE_ExprNotInLockstep (e1, e2)));
+    List.fold_left2 (fun umap e1 e2 -> unify_exprs umap e1 e2) umap p1 p2
+  | Eproj (e1, x1), Eproj (e2, x2) when x1 = x2 ->
+    unify_exprs umap e1 e2
   | _ -> raise (UnificationError (UE_ExprNotInLockstep (e1, e2)))
+
+(*---------------------------------------------------------------------------------------*)
+let unify_lv umap lv1 lv2 =
+  let update umap v pv t =
+    let doit x =
+      match x with
+      | Some (Local None) -> Some (Local (Some pv))
+      | Some (Arg None) -> Some (Arg (Some (e_var pv t)))
+      | _ -> x
+    in
+    Msym.change doit v umap
+  in
+
+  match lv1, lv2 with
+  | LvVar (PVglob xp1, _), LvVar (PVglob xp2, _)
+    when EcPath.x_equal xp1 xp2 -> umap
+  | LvVar (PVloc v, _), LvVar (pv, t) ->
+    update umap v pv t
+  | LvTuple pvs1, LvTuple pvs2 ->
+    if List.length pvs1 <> List.length pvs2 then
+      raise (UnificationError (UE_LvNotInLockstep (lv1, lv2)));
+
+    List.fold_left2 (fun umap (pv1, _) (pv2, t) ->
+      match pv1, pv2 with
+      | PVglob xp1, PVglob xp2
+        when EcPath.x_equal xp1 xp2 -> umap
+      | PVloc v, pv ->
+        update umap v pv t
+      | _ -> raise (UnificationError (UE_LvNotInLockstep (lv1, lv2)))
+      )
+      umap
+      pvs1
+      pvs2
+  | _, _ -> raise (UnificationError (UE_LvNotInLockstep (lv1, lv2)))
 
 (*---------------------------------------------------------------------------------------*)
 let rec unify_instrs umap i1 i2 =
  match i1.i_node, i2.i_node with
-  | Sasgn(_, e1), Sasgn(_, e2)
-  | Srnd(_, e1), Srnd(_, e2) ->
-     unify_exprs umap e1 e2
-  | Scall(_, _, args1), Scall(_, _, args2) ->
-     List.fold_left (fun umap (e1, e2) -> unify_exprs umap e1 e2) umap (List.combine args1 args2)
+  | Sasgn(lv1, e1), Sasgn(lv2, e2)
+  | Srnd(lv1, e1), Srnd(lv2, e2) ->
+    let umap = unify_lv umap lv1 lv2 in
+    unify_exprs umap e1 e2
+
+  | Scall(olv1, xp1, args1), Scall(olv2, xp2, args2) when EcPath.x_equal xp1 xp2 ->
+    let umap =
+      match olv1, olv2 with
+      | Some lv1, Some lv2 -> unify_lv umap lv1 lv2
+      | None, None -> umap
+      | _, _ -> raise (UnificationError (UE_InstrNotInLockstep (i1, i2)));
+    in
+    List.fold_left2 (fun umap e1 e2 -> unify_exprs umap e1 e2) umap args1 args2
   | Sif(e1, st1, sf1), Sif(e2, st2, sf2) ->
-     let umap = unify_exprs umap e1 e2 in
-     let umap = unify_stmts umap st1 st2 in
-     unify_stmts umap sf1 sf2
+    let umap = unify_exprs umap e1 e2 in
+    let umap = unify_stmts umap st1 st2 in
+    unify_stmts umap sf1 sf2
   | Swhile(e1, s1), Swhile(e2, s2) ->
-     let umap = unify_exprs umap e1 e2 in
-     unify_stmts umap s1 s2
+    let umap = unify_exprs umap e1 e2 in
+    unify_stmts umap s1 s2
   | Smatch(e1, bs1), Smatch(e2, bs2) ->
-     let umap = unify_exprs umap e1 e2 in
-     List.fold_left (fun umap (b1, b2) -> unify_stmts umap (snd b1) (snd b2)) umap (List.combine bs1 bs2)
+    let umap = unify_exprs umap e1 e2 in
+    List.fold_left2 (fun umap (p1, b1) (p2, b2) ->
+      if List.length p1 <> List.length p2 then
+        raise (UnificationError (UE_InstrNotInLockstep (i1, i2)));
+      unify_stmts umap b1 b2
+    )
+      umap
+      bs1
+      bs2
   | Sassert e1, Sassert e2 ->
-     unify_exprs umap e1 e2
-  | Sabstract _, Sabstract _ -> umap
+    unify_exprs umap e1 e2
+  | Sabstract x1, Sabstract x2 when EcIdent.id_equal x1 x2 -> umap
   | _ -> raise (UnificationError (UE_InstrNotInLockstep (i1, i2)));
 
-and unify_stmts umap s1 s2 =
+and unify_stmts (umap : umap) s1 s2 =
   let s1n, s2n = s1.s_node, s2.s_node in
   if List.length s1n <> List.length s2n then
     raise (UnificationError (UE_DifferentProgramLengths (s1, s2)));
-  List.fold_left (fun umap (i1, i2) -> unify_instrs umap i1 i2) umap (List.combine s1n s2n)
+  List.fold_left2 (fun umap i1 i2 -> unify_instrs umap i1 i2) umap s1n s2n
 
 (*---------------------------------------------------------------------------------------*)
-(* Given a function definition attempt to unify its body with the statements `sb` 
-   and if a return statement is given, also unify it's expression. *)
-let unify_func umap fdef sb sr =
-  (* Unify the body *)
-  let umap = unify_stmts umap fdef.f_body sb in
+let unify_func env mode fname s =
+  let f = EcEnv.Fun.by_xpath fname env in
+  let fdef =
+    match f.f_def with
+    | FBdef d -> d
+    | _ -> raise (UnificationError UE_AbstractFun)
+  in
 
-  (* Unify the return stmt (if it exists) and retrieve its lv *)
-  match sr with
-  | Some i -> begin
-      (* Check that there is a return expression to unify with *)
-      if fdef.f_ret = None then
-        raise (UnificationError UE_UnexpectedReturn);
+  let args = List.filter_map ov_name f.f_sig.fs_anames in
+  let locals = List.map v_name fdef.f_locals in
 
-      (* Only unify with assignment instructions *)
-      match i.i_node with
-      | Sasgn (lv, e) -> Some lv, unify_exprs umap (Option.get fdef.f_ret) e
-      | _ -> raise (UnificationError UE_InvalidRetInstr)
-  end
-  | _ -> None, umap
+  let umap = List.fold_left (fun umap a -> Msym.add a (Arg None) umap) Msym.empty args in
+  let umap = List.fold_left (fun umap a -> Msym.add a (Local None) umap) umap locals in
+
+  let close_args umap args =
+    List.map (fun a ->
+        match Msym.find a umap with
+        | Arg (Some e) -> e
+        | _ -> raise (UnificationError (UE_UnificationFailArg a))
+      )
+      args
+  in
+
+  match mode, fdef.f_ret with
+  | `Exact, None ->
+    let umap = unify_stmts umap fdef.f_body s in
+    s_call (None, fname, close_args umap args)
+  | `Exact, Some re -> begin
+    match EcLowPhlGoal.s_last destr_asgn s with
+    | None -> raise (UnificationError UE_InvalidRetInstr)
+    | Some ((lv, e), s) ->
+      let umap = unify_stmts umap fdef.f_body s in
+      let umap = unify_exprs umap re e in
+      let args = close_args umap args in
+      s_call (Some lv, fname, args)
+    end
+  | `Alias, None ->
+    raise (UnificationError UE_AliasNoRet)
+  | `Alias, Some e ->
+    if not (is_tuple_var e || is_var e) then
+      raise (UnificationError UE_AliasNotPv);
+    let umap = unify_stmts umap fdef.f_body s in
+    let args = close_args umap args in
+    let alias =
+      let pvs = lv_to_ty_list (lv_of_expr e) in
+      let pvs =
+        List.map
+          (fun (pv, t) ->
+            if is_loc pv then
+              match Msym.find (get_loc pv) umap with
+              | Arg (Some e) when is_var e -> destr_var e, e.e_ty
+              | Local (Some pv) -> pv, t
+              | _ -> raise (UnificationError (UE_UnificationFailPv (get_loc pv)))
+            else
+              pv, t
+          )
+          pvs
+      in
+      lv_of_list pvs
+    in
+    s_call (alias, fname, args)
+

--- a/src/ecUnifyProc.mli
+++ b/src/ecUnifyProc.mli
@@ -3,24 +3,15 @@ open EcModules
 open EcSymbols
 
 (*---------------------------------------------------------------------------------------*)
-(* `Unification` of procedures *)
-(*
-  Given: r <@ foo(a1: t1, a2: t2, ...); and s1; s2; ...; sr.
-  Attempt to find values for a1, a2, ... such that, the body of `foo` with a1, a2, ...
-  replaced will exactly match s1; s2; ..., and that `r <- res` match sr.
-  Where `res` is the return expression of `foo`.
-
-  Currently, this is done by traversing the respective ASTs and when a relevant
-  program variable is encountered on the lhs, use the rhs expression.
-
-  FIXME: This is incredibly basic and should be iterated on with a more advanced
-  procedure unification algorithm.
- *)
-
-(*---------------------------------------------------------------------------------------*)
 type u_error =
+  | UE_AliasNoRet
+  | UE_AliasNotPv
   | UE_InvalidRetInstr
-  | UE_UnexpectedReturn
+  | UE_AbstractFun
+  | UE_TypeMismatch of expr * expr
+  | UE_UnificationFailArg of symbol
+  | UE_UnificationFailPv of symbol
+  | UE_LvNotInLockstep of lvalue * lvalue
   | UE_ExprNotInLockstep of expr * expr
   | UE_InstrNotInLockstep of instr * instr
   | UE_DifferentProgramLengths of stmt * stmt
@@ -28,16 +19,18 @@ type u_error =
 exception UnificationError of u_error
 
 (*---------------------------------------------------------------------------------------*)
-type u_value =
-  | Empty
-  | Fixed of expr
+(* `Unification` of procedures *)
+(*
+  The basic problem is:
+    Given `r <@ f(a1, ..., an);` and a statement `s`, attempt to find values for
+    `r`, `a1`,..., `an` such that inlining `f` will exactly match s.
 
-type umap = u_value Msym.t
+  There are two modes of operation:
+  - Exact: assume `s` is of the form `b`; `r <- e;` and perform unification of
+    `b` with `f.body` and `e` with `f.res`.
+  - Alias: assume `f.ret` is a program variable or tuple of program variables, only
+    perform unification with `s` and `f.body`.
 
-(*---------------------------------------------------------------------------------------*)
-(* The following functions attempt to unify unknown program variables
-   in the lhs with expressions from the rhs *)
-val unify_exprs : umap -> expr -> expr -> umap
-val unify_instrs : umap -> instr -> instr -> umap
-val unify_stmts : umap -> stmt -> stmt -> umap
-val unify_func : umap -> function_def -> stmt -> instr option -> lvalue option * umap
+  Both modes result in a closed function call instruction `r' <@ f(a'1, ..., a'n);`
+ *)
+val unify_func : EcEnv.env -> [`Exact | `Alias] -> EcPath.xpath -> stmt -> stmt

--- a/src/phl/ecPhlOutline.ml
+++ b/src/phl/ecPhlOutline.ml
@@ -1,9 +1,5 @@
 open EcParsetree
-open EcFol
-open EcUtils
 open EcModules
-open EcTypes
-open EcSymbols
 open EcUnifyProc
 
 open EcCoreGoal
@@ -12,11 +8,12 @@ open EcLowPhlGoal
 
 (*---------------------------------------------------------------------------------------*)
 (*
-   This is the improved transitivity star from above but allows for a range of code
+   This is transitivity star but allows for a range of code
    positions to select the program slice that is changing. The prefix and suffix are
    extracted and copied across to build the new program.
+   This tactic fails if the new program cannot be shown equal to the old through the
+   tactic chain `by inline; sim; auto=> />`.
 *)
-(* FIXME: Maybe move to ecPhlTrans as well *)
 
 let t_outline_stmt side start_pos end_pos s tc =
   let env = FApi.tc1_env tc in
@@ -35,19 +32,19 @@ let t_outline_stmt side start_pos end_pos s tc =
   let new_prog = s_seq (s_seq (stmt code_pref) s) (stmt code_suff) in
   let tc = EcPhlTrans.t_equivS_trans_eq side new_prog tc in
 
-  (* The middle goal, showing equivalence with the replaced code, ideally solves. *)
+  (* Solve the equivalence with the replaced code. *)
   let tp = match side with | `Left -> 1 | `Right -> 2 in
   let p = EcHiGoal.process_tfocus tc (Some [Some tp, Some tp], None) in
   let tc =
     t_onselect
       p
-      (t_try (
-           t_seqs [
-               EcPhlInline.process_inline (`ByName (None, None, ([], None)));
-               EcPhlEqobs.process_eqobs_in none {sim_pos = none; sim_hint = ([], none); sim_eqs = none};
-               EcPhlAuto.t_auto;
-               EcHiGoal.process_done;
-         ]))
+      (t_seqs [
+        EcPhlInline.process_inline (`ByName (None, None, ([], None)));
+        EcPhlEqobs.process_eqobs_in None {sim_pos = None; sim_hint = ([], None); sim_eqs = None};
+        EcPhlAuto.t_auto;
+        EcLowGoal.t_crush;
+        EcHiGoal.process_done;
+      ])
       tc
   in
   tc
@@ -55,35 +52,18 @@ let t_outline_stmt side start_pos end_pos s tc =
 (*---------------------------------------------------------------------------------------*)
 (* The main tactic *)
 
-type out_error =
-  | OE_InvalidFunc
-  | OE_UnnecessaryReturn
-  | OE_UnificationFailure of EcSymbols.symbol
-
-exception OutlineError of out_error
-
 (*
   `outline` - replace a program slice with a procedure call.
 
   Arguments,
+    mode: dictates the method for function unification.
     side: selects the program (left or right) that will outlined.
     start_pos, end_pos: selects the particular slice of the program to outline.
     fname: path of the function that we are using to outline.
-    res_lv: optional left-value for the result.
-      when None, assume the entire slice contains the body and return.
-      otherwise, assume entire slice contains just the body.
 *)
-let t_outline_proc side start_pos end_pos fname res_lv tc =
+let t_outline_proc (mode : [`Exact | `Alias]) side start_pos end_pos fname tc =
   let env = tc1_env tc in
   let goal = tc1_as_equivS tc in
-
-  (* Extract the function args, body, and return expression *)
-  let func = EcEnv.Fun.by_xpath fname env in
-  let f_def =
-    match func.f_def with
-    | FBdef d -> d
-    | _ -> raise (OutlineError OE_InvalidFunc)
-  in
 
   (* Get the code from the side we are outlining *)
   let code = match side with
@@ -91,52 +71,18 @@ let t_outline_proc side start_pos end_pos fname res_lv tc =
     | `Right -> goal.es_sr
   in
 
-  (* Get the return statement and body we will attempt to unify *)
-  let old_code_body, old_code_ret =
-    let rest, ret_instr, _ = s_split_i env end_pos code in
-    let body =
-       if start_pos = end_pos then
-         s_empty
-       else
-         let _, hd, tl  = s_split_i env start_pos (stmt rest) in
-         stmt (hd :: tl)
-    in
-
-    match f_def.f_ret, res_lv with
-    | None, None ->
-       s_seq body (stmt [ret_instr]), None
-    | Some _, Some _ ->
-       s_seq body (stmt [ret_instr]), None
-    | Some _, None ->
-       body, Some ret_instr
-    | _, _ -> raise (OutlineError OE_UnnecessaryReturn)
+  (* Get the exact code chunk we are outlining *)
+  let code =
+    let rest, ret, _ = s_split_i env end_pos code in
+    if start_pos = end_pos then
+      stmt [ret]
+    else
+      let _, hd, tl  = s_split_i env start_pos (stmt rest) in
+      stmt (hd :: tl @ [ret])
   in
-
-  (* Get the symbol for each function argument used *)
-  let arg_names = func.f_sig.fs_anames in
-  let args = List.filter_map ov_name arg_names in
-
-  (* Insert all the argument symbols we are attempting to unify *)
-  let umap = List.fold_left (fun umap a -> Msym.add a Empty umap) Msym.empty args in
 
   (* Unify the function *)
-  let lv, args_map = unify_func umap f_def old_code_body old_code_ret in
-  (* Use the correct lv *)
-  let lv = match lv with | None -> res_lv | _ -> lv in
-
-  (* Check that we were able to unify all arguments *)
-  let args =
-    List.map
-      (fun a ->
-        match Msym.find a args_map with
-        | Empty -> raise (OutlineError (OE_UnificationFailure a))
-        | Fixed e -> e
-      )
-      args
-  in
-
-  (* Buid the call statement *)
-  let proc_call = s_call (lv, fname, args) in
+  let proc_call = unify_func env mode fname code in
 
   (* Offload to transitivity *)
   t_outline_stmt side start_pos end_pos proc_call tc
@@ -166,51 +112,35 @@ let process_outline info tc =
   try
     match info.outline_kind with
     | OKstmt s ->
-       let s = EcProofTyping.tc1_process_stmt tc (EcMemory.memtype mem) s in
-       t_outline_stmt side start_pos end_pos s tc
-    | OKproc (f, pres_lv) ->
-       let loc = EcLocation.loc f in
-       (* Get the function *)
-       let f = EcTyping.trans_gamepath env f in
-       let func = EcEnv.Fun.by_xpath f env in
-       let f_def =
-         match func.f_def with
-         | FBdef d -> d
-         | _ -> raise (OutlineError OE_InvalidFunc)
-       in
-
-       (* Translate the res_lv if given *)
-       let res_lv =
-         match pres_lv, f_def.f_ret with
-         | Some r, Some e -> begin
-             try
-               let subenv = EcEnv.Memory.push_active mem env in
-               let ue = EcUnify.UniEnv.create (Some []) in
-               let res = EcTyping.transexpcast subenv `InProc ue e.e_ty r in
-               let tu = EcUnify.UniEnv.close ue in
-               let sty = f_subst_init ~tu () in
-               let es = e_subst sty in
-               Some (lv_of_expr (es res))
-             with EcUnify.UninstanciateUni ->
-               EcTyping.tyerror loc env EcTyping.FreeTypeVariables
-           end
-         | None, _ -> None
-         | _, _ -> raise (OutlineError OE_UnnecessaryReturn)
-       in
-
-       t_outline_proc side start_pos end_pos f res_lv tc
+      let s = EcProofTyping.tc1_process_stmt tc (EcMemory.memtype mem) s in
+      t_outline_stmt side start_pos end_pos s tc
+    | OKproc (f, alias) ->
+      (* Get the function *)
+      let f = EcTyping.trans_gamepath env f in
+      let mode = if alias then `Alias else `Exact in
+      t_outline_proc mode side start_pos end_pos f tc
   with
-  | OutlineError OE_UnnecessaryReturn ->
-     tc_error !!tc "outline: left-value given when function does not return"
-  | OutlineError OE_InvalidFunc ->
-     tc_error !!tc "outline: cannot outline an abstract function"
-  | OutlineError (OE_UnificationFailure x) ->
-     tc_error !!tc "outline: unable to unify `%s`" x
+  | UnificationError (UE_UnificationFailArg x) ->
+     tc_error !!tc "Outline: unable to unify arg `%s`." x
+  | UnificationError (UE_UnificationFailPv x) ->
+     tc_error !!tc "Outline: unable to unify variable `%s`." x
+  | UnificationError UE_AbstractFun ->
+     tc_error !!tc "Outline: cannot unify abstract function."
+  | UnificationError UE_AliasNoRet ->
+     tc_error !!tc "Outline: cannot alias unit returning function. To use the aliasing mode, the function must return a program variable or a tuple of program variables."
+  | UnificationError UE_AliasNotPv ->
+     tc_error !!tc "Outline: cannot alias function which does not just return program variables. To use the aliasing mode, the function must return a program variable or a tuple of program variables."
+  | UnificationError (UE_TypeMismatch (e1, e2)) ->
+      tc_error !!tc "Outline: cannot unify expressions @[<hov>`%a`@ and `%a`@] they have different types @[`%a`@ <> `%a`@]."
+        (EcPrinting.pp_expr ppe) e1 (EcPrinting.pp_expr ppe) e2
+        (EcPrinting.pp_type ppe) e1.e_ty (EcPrinting.pp_type ppe) e2.e_ty
   | UnificationError UE_InvalidRetInstr ->
-     tc_error !!tc ("outline: return instruction kind not supported")
+     tc_error !!tc "Outline: return instruction must be an assign. Perhaps consider using the alias variant using `~`."
   | UnificationError (UE_DifferentProgramLengths (s1, s2)) ->
-     tc_error !!tc "outline: body's are different lengths\n%a ~ %a" (EcPrinting.pp_stmt ppe) s1 (EcPrinting.pp_stmt ppe) s2
+     tc_error !!tc "Outline: body's are different lengths\n%a ~ %a." (EcPrinting.pp_stmt ppe) s1 (EcPrinting.pp_stmt ppe) s2
   | UnificationError (UE_InstrNotInLockstep (i1, i2))->
-     tc_error !!tc "outline: instructions not in sync\n%a ~ %a" (EcPrinting.pp_instr ppe) i1 (EcPrinting.pp_instr ppe) i2
+     tc_error !!tc "outline: instructions not in sync\n%a ~ %a." (EcPrinting.pp_instr ppe) i1 (EcPrinting.pp_instr ppe) i2
+  | UnificationError (UE_LvNotInLockstep (_lv1, _lv2))->
+     tc_error !!tc "Outline: left values not in sync\n."
   | UnificationError (UE_ExprNotInLockstep (e1, e2))->
-     tc_error !!tc "outline: expressions not in sync\n%a ~ %a" (EcPrinting.pp_expr ppe) e1 (EcPrinting.pp_expr ppe) e2
+     tc_error !!tc "Outline: expressions not in sync\n%a ~ %a." (EcPrinting.pp_expr ppe) e1 (EcPrinting.pp_expr ppe) e2

--- a/src/phl/ecPhlOutline.ml
+++ b/src/phl/ecPhlOutline.ml
@@ -7,61 +7,25 @@ open EcCoreGoal.FApi
 open EcLowPhlGoal
 
 (*---------------------------------------------------------------------------------------*)
-(*
-   This is transitivity star but allows for a range of code
-   positions to select the program slice that is changing. The prefix and suffix are
-   extracted and copied across to build the new program.
-   This tactic fails if the new program cannot be shown equal to the old through the
-   tactic chain `by inline; sim; auto=> />`.
-*)
 
-let t_outline_stmt side start_pos end_pos s tc =
-  let env = FApi.tc1_env tc in
-  let goal = tc1_as_equivS tc in
-
-  (* Check which memory/program we are outlining *)
-  let code = match side with
-    | `Left  -> goal.es_sl
-    | `Right -> goal.es_sr
-  in
-
-  (* Extract the program prefix and suffix *)
-  let rest, code_suff  = s_split env end_pos code in
-  let code_pref, _, _ = s_split_i env start_pos (stmt rest) in
-
-  let new_prog = s_seq (s_seq (stmt code_pref) s) (stmt code_suff) in
-  let tc = EcPhlTrans.t_equivS_trans_eq side new_prog tc in
-
-  (* Solve the equivalence with the replaced code. *)
-  let tp = match side with | `Left -> 1 | `Right -> 2 in
-  let p = EcHiGoal.process_tfocus tc (Some [Some tp, Some tp], None) in
-  let tc =
-    t_onselect
-      p
-      (t_seqs [
-        EcPhlInline.process_inline (`ByName (None, None, ([], None)));
-        EcPhlEqobs.process_eqobs_in None {sim_pos = None; sim_hint = ([], None); sim_eqs = None};
-        EcPhlAuto.t_auto;
-        EcLowGoal.t_crush;
-        EcHiGoal.process_done;
-      ])
-      tc
-  in
-  tc
+(* `by inline; sim; auto=> />` *)
+let t_auto_equiv_sim =
+  t_seqs [
+    EcPhlInline.process_inline (`ByName (None, None, ([], None)));
+    EcPhlEqobs.process_eqobs_in None {sim_pos = None; sim_hint = ([], None); sim_eqs = None};
+    EcPhlAuto.t_auto;
+    EcLowGoal.t_crush;
+    EcHiGoal.process_done;
+    ]
 
 (*---------------------------------------------------------------------------------------*)
 (* The main tactic *)
 
-(*
-  `outline` - replace a program slice with a procedure call.
+type outline_variant =
+  | OV_Proc of [`Exact | `Alias] * EcPath.xpath
+  | OV_Stmt of stmt
 
-  Arguments,
-    mode: dictates the method for function unification.
-    side: selects the program (left or right) that will outlined.
-    start_pos, end_pos: selects the particular slice of the program to outline.
-    fname: path of the function that we are using to outline.
-*)
-let t_outline_proc (mode : [`Exact | `Alias]) side start_pos end_pos fname tc =
+let t_outline side cpr variant tc =
   let env = tc1_env tc in
   let goal = tc1_as_equivS tc in
 
@@ -71,21 +35,20 @@ let t_outline_proc (mode : [`Exact | `Alias]) side start_pos end_pos fname tc =
     | `Right -> goal.es_sr
   in
 
-  (* Get the exact code chunk we are outlining *)
-  let code =
-    let rest, ret, _ = s_split_i env end_pos code in
-    if start_pos = end_pos then
-      stmt [ret]
-    else
-      let _, hd, tl  = s_split_i env start_pos (stmt rest) in
-      stmt (hd :: tl @ [ret])
+  let doit env si =
+    match variant with
+    | OV_Proc (mode, f) -> (unify_func env mode f (stmt si)).s_node
+    | OV_Stmt s -> s.s_node
   in
-
-  (* Unify the function *)
-  let proc_call = unify_func env mode fname code in
+  let new_prog = EcMatching.Zipper.map_range env cpr doit code in
 
   (* Offload to transitivity *)
-  t_outline_stmt side start_pos end_pos proc_call tc
+  let tc = EcPhlTrans.t_equivS_trans_eq side new_prog tc in
+
+  (* Solve the equivalence with the replaced code. *)
+  let tp = match side with | `Left -> 1 | `Right -> 2 in
+  let p = EcHiGoal.process_tfocus tc (Some [Some tp, Some tp], None) in
+  t_onselect p t_auto_equiv_sim tc
 
 (*---------------------------------------------------------------------------------------*)
 (* Process a user call to outline *)
@@ -96,12 +59,9 @@ let process_outline info tc =
   let goal = tc1_as_equivS tc in
   let ppe = EcPrinting.PPEnv.ofenv env in
 
-  let start_pos =
-    EcProofTyping.tc1_process_codepos1 tc
-      (Some side, info.outline_start) in
-  let end_pos =
-    EcProofTyping.tc1_process_codepos1 tc
-      (Some side, info.outline_end) in
+  let range =
+    EcProofTyping.tc1_process_codepos_range tc
+      (Some side, info.outline_range) in
 
   (* Check which memory we are outlining *)
   let mem = match side with
@@ -113,12 +73,12 @@ let process_outline info tc =
     match info.outline_kind with
     | OKstmt s ->
       let s = EcProofTyping.tc1_process_stmt tc (EcMemory.memtype mem) s in
-      t_outline_stmt side start_pos end_pos s tc
+      t_outline side range (OV_Stmt s) tc
     | OKproc (f, alias) ->
       (* Get the function *)
       let f = EcTyping.trans_gamepath env f in
       let mode = if alias then `Alias else `Exact in
-      t_outline_proc mode side start_pos end_pos f tc
+      t_outline side range (OV_Proc (mode, f)) tc
   with
   | UnificationError (UE_UnificationFailArg x) ->
      tc_error !!tc "Outline: unable to unify arg `%s`." x

--- a/src/phl/ecPhlOutline.mli
+++ b/src/phl/ecPhlOutline.mli
@@ -5,6 +5,6 @@ open EcModules
 open EcPath
 
 val t_outline_stmt : side -> codepos1 -> codepos1 -> stmt -> backward
-val t_outline_proc : side -> codepos1 -> codepos1 -> xpath -> lvalue option -> backward
+  val t_outline_proc : [`Exact | `Alias] -> side -> codepos1 -> codepos1 -> xpath -> backward
 
 val process_outline : outline_info -> backward

--- a/src/phl/ecPhlOutline.mli
+++ b/src/phl/ecPhlOutline.mli
@@ -2,9 +2,21 @@ open EcCoreGoal.FApi
 open EcMatching.Position
 open EcParsetree
 open EcModules
-open EcPath
 
-val t_outline_stmt : side -> codepos1 -> codepos1 -> stmt -> backward
-  val t_outline_proc : [`Exact | `Alias] -> side -> codepos1 -> codepos1 -> xpath -> backward
+type outline_variant =
+  (* method of unification and path of procedure to outline *)
+  | OV_Proc of [`Exact | `Alias] * EcPath.xpath
+  (* replacement code *)
+  | OV_Stmt of stmt
+
+(*
+  `outline` - replace a program slice with a procedure call or statement.
+
+  Arguments,
+    side: selects the program (left or right) that will outlined.
+    cpr: selects the particular slice of the program to outline.
+    variant: choose the type of outlining: procedure or statement.
+*)
+val t_outline : side -> codepos_range -> outline_variant -> backward
 
 val process_outline : outline_info -> backward

--- a/tests/outline.ec
+++ b/tests/outline.ec
@@ -80,49 +80,49 @@ module N = {
 equiv outline_no_args_no_ret: N.g1 ~ N.g1: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [1] M.f1.
+outline {1} 1 M.f1.
 by sim.
 qed.
 
 equiv outline_no_ret: N.g2 ~ N.g2: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [2] M.f2.
+outline {1} 2 M.f2.
 by inline*; auto.
 qed.
 
 equiv outline_no_body: N.g3 ~ N.g3: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [3] M.f3.
+outline {1} 3 M.f3.
 by inline*; auto.
 qed.
 
 equiv outline_slice: N.g4 ~ N.g4: true ==> true.
 proc.
-outline {1} [1-2] M.f4.
+outline {1} [1 .. 2] M.f4.
 by inline*; auto.
 qed.
 
 equiv outline_explicit_ret: N.g5 ~ N.g5: true ==> true.
 proc.
-outline {1} [1] ~ M.f5.
+outline {1} 1 ~ M.f5.
 by inline*; auto.
 qed.
 
 equiv outline_multi: N.g6 ~ N.g6: true ==> true.
 proof.
 proc.
-outline {1} [3-4] N.g4.
-outline {1} [2] ~ M.f5.
-outline {1} [1] ~ M.f5.
+outline {1} 2 ~ M.f5.
+outline {1} [3 .. 4] N.g4.
+outline {1} 1 ~ M.f5.
 by inline*; auto.
 qed.
 
 equiv outline_stmt: N.g6 ~ N.g6: true ==> true.
 proof.
 proc.
-outline {1} [1-4] {
+outline {1} [1 .. 4] by {
   a <@ M.f5(dint);
   b <@ M.f5(dint);
   N.g4(a,b);

--- a/tests/outline.ec
+++ b/tests/outline.ec
@@ -34,6 +34,7 @@ module M = {
   }
 }.
 
+
 module N = {
   proc g1() : unit = {
     M.f1();
@@ -79,42 +80,42 @@ module N = {
 equiv outline_no_args_no_ret: N.g1 ~ N.g1: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [1] <@ M.f1.
+outline {1} [1] M.f1.
 by sim.
 qed.
 
 equiv outline_no_ret: N.g2 ~ N.g2: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [2] <@ M.f2.
+outline {1} [2] M.f2.
 by inline*; auto.
 qed.
 
 equiv outline_no_body: N.g3 ~ N.g3: true ==> true.
 proc.
 inline {1} 1.
-outline {1} [3] <@ M.f3.
+outline {1} [3] M.f3.
 by inline*; auto.
 qed.
 
 equiv outline_slice: N.g4 ~ N.g4: true ==> true.
 proc.
-outline {1} [1-2] <@ M.f4.
+outline {1} [1-2] M.f4.
 by inline*; auto.
 qed.
 
 equiv outline_explicit_ret: N.g5 ~ N.g5: true ==> true.
 proc.
-outline {1} [1] x <@ M.f5.
+outline {1} [1] ~ M.f5.
 by inline*; auto.
 qed.
 
 equiv outline_multi: N.g6 ~ N.g6: true ==> true.
 proof.
 proc.
-outline {1} [3-4] <@ N.g4.
-outline {1} [2] b <@ M.f5.
-outline {1} [1] a <@ M.f5.
+outline {1} [3-4] N.g4.
+outline {1} [2] ~ M.f5.
+outline {1} [1] ~ M.f5.
 by inline*; auto.
 qed.
 

--- a/theories/crypto/PRP.eca
+++ b/theories/crypto/PRP.eca
@@ -495,7 +495,7 @@ section PRPi_PRPi'_Indirect.
   equiv eq_Direct_Indirect: Direct.sample ~ Indirect.sample: ={X} ==> ={res}.
   proof.
   proc.
-  outline {1} [1] { r <@ S.direct((), fun _ => X); }.
+  outline {1} 1 by { r <@ S.direct((), fun _ => X); }.
   rewrite equiv[{1} 1 ll_direct_indirect_eq ((), fun _ => X :@ r)].
   + auto=> />; exact dD_ll.
   inline S.indirect.

--- a/theories/crypto/ROM.eca
+++ b/theories/crypto/ROM.eca
@@ -265,7 +265,7 @@ have eq_RO_LRO': equiv[Exp'(H.RO).main ~ Exp'(H.LRO).main: ={glob D, arg} ==> ={
 proc*.
 rewrite equiv[{1} 1 eq_LRO_RO].
 rewrite equiv[{2} 1 eq_ERO_RO].
-outline {2} [1] { r <@ MainD(D', RO).distinguish(x); }.
+outline {2} 1 by { r <@ MainD(D', RO).distinguish(x); }.
 rewrite equiv[{2} 1 (FullEager.RO_LRO D' dout_ll)].
 by sim.
 qed.

--- a/theories/crypto/SplitRO.ec
+++ b/theories/crypto/SplitRO.ec
@@ -153,7 +153,7 @@ section PROOFS.
     swap{2} 5 -3; swap{2} 6 -2; sp 0 2.
     seq 1 2 : (#pre /\ r{1} = ofpair (r{2}, r0{2})).
     + conseq />.
-      outline {2} [1-2] ~ S.sample2.
+      outline {2} [1 .. 2] ~ S.sample2.
       rewrite equiv[{2} 1 -sample_sample2].
       inline *; wp; rnd topair ofpair; auto => /> &2 ?; split.
       + by move=> ??; rewrite ofpairK. 
@@ -182,7 +182,7 @@ section PROOFS.
     + by proc; inline *; auto; smt (map_rem rem_merge mem_map mem_pair_map mem_rem).
     + proc *.
       inline {1} 1.
-      outline {2} [1] { RO_Pair(I1.RO, I2.RO).get(x); }.
+      outline {2} 1 by { RO_Pair(I1.RO, I2.RO).get(x); }.
       by call RO_get; auto.
     inline *; auto => />.
     have hn := o_pair_none <: from, to1, to2>. 

--- a/theories/crypto/SplitRO.ec
+++ b/theories/crypto/SplitRO.ec
@@ -153,7 +153,7 @@ section PROOFS.
     swap{2} 5 -3; swap{2} 6 -2; sp 0 2.
     seq 1 2 : (#pre /\ r{1} = ofpair (r{2}, r0{2})).
     + conseq />.
-      outline {2} [1-2] (r, r0) <@ S.sample2.
+      outline {2} [1-2] ~ S.sample2.
       rewrite equiv[{2} 1 -sample_sample2].
       inline *; wp; rnd topair ofpair; auto => /> &2 ?; split.
       + by move=> ??; rewrite ofpairK. 

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -194,9 +194,9 @@ theory DHIES.
   lemma mencDHIES_eq : equiv [MEnc.mencDHIES1 ~ MEnc.mencDHIES2: ={tag,ptxt,kks} ==> ={res}].
   proof.
   proc.
-  outline {1} [1] { mcph <@ MEncDHIES_loop.S.sample(encDHIES tag ptxt, kks); }.
+  outline {1} 1 by { mcph <@ MEncDHIES_loop.S.sample(encDHIES tag ptxt, kks); }.
   rewrite equiv[{1} 1 MEncDHIES_loop.Sample_Loop_eq].
-  outline {2} [2] { cs <@ MEnc_loop.S.sample(fun k => enc k tag ptxt, skeys); }.
+  outline {2} 2 by { cs <@ MEnc_loop.S.sample(fun k => enc k tag ptxt, skeys); }.
   rewrite equiv[{2} 2 MEnc_loop.Sample_Loop_eq].
   inline*; wp.
   while ( ={i,kks,tag,ptxt} /\
@@ -205,7 +205,7 @@ theory DHIES.
            l{1} = map (fun x:(_*(_*_))*_ => (x.`1.`1, (x.`1.`2.`1, x.`2)))
                       (zip (drop (i+1) kks) l){2}).
   + wp.
-    outline {1} [1] { r <@ EncDHIES_map.S.sample(enc (nth witness xs i).`2.`2 tag ptxt,
+    outline {1} 1 by { r <@ EncDHIES_map.S.sample(enc (nth witness xs i).`2.`2 tag ptxt,
                                                          fun c => ((nth witness xs i).`1,
                                                                   ((nth witness xs i).`2.`1,c))); }.
     rewrite equiv[{1} 1 EncDHIES_map.sample].
@@ -226,12 +226,12 @@ theory DHIES.
   lemma mrndkeys_def : equiv [MEnc.mrndkeys1 ~ MEnc.mrndkeys2: ={pkl} ==> ={res}].
   proof.
   proc.
-  outline {2} [2-3] { keys <@ MRnd_map.S.map(
+  outline {2} [2 .. 3] by { keys <@ MRnd_map.S.map(
                       dlist gen (size pkl),
                       fun (ks:K list) => amap (fun pk k => (g ^ x, k))
                                               (zip pkl ks)); }.
   rewrite equiv[{2} 2 -MRnd_map.sample].
-  outline {2} [1-2] { keys <@ MRnd_let.SampleDep.sample(dt,
+  outline {2} [1 .. 2] by { keys <@ MRnd_let.SampleDep.sample(dt,
                       fun x => dmap (dlist gen (size pkl))
                                     (fun ks => amap (fun pk k => (g ^ x, k))
                                                     (zip pkl ks))); }.
@@ -262,10 +262,10 @@ theory DHIES.
   rewrite equiv[{1} 1 MEncrypt_map.sample].
   inline*; swap{1} 2 1.
   proc rewrite {1} ^d<- dlet_lockedE.
-  outline {1} [1-2] {r1 <@ MEncDHIES_let.SampleDLet.sample(mkeyDHIES (elems mpk), mencDHIES tag ptxt); }.
+  outline {1} [1 .. 2] by { r1 <@ MEncDHIES_let.SampleDLet.sample(mkeyDHIES (elems mpk), mencDHIES tag ptxt); }.
   rewrite equiv[{1} 1 -MEncDHIES_let.SampleDepDLet].
   inline*; swap{1} 2 1. 
-  outline {1} [1-2] {t <@ MKey_map.S.sample(
+  outline {1} [1 .. 2] by {t <@ MKey_map.S.sample(
                             FD.dt,
                             (fun x =>
                                map (fun pk => (pk, (g ^ x, hash (pk ^ x))))
@@ -295,11 +295,11 @@ theory DHIES.
   proc*.
   rewrite equiv[{2} 1 -mencrypt_def1].
   inline.
-  outline {2} [7] { cphs <@ MEncDHIES_loop.S.sample(encDHIES tag ptxt, keys); }.
+  outline {2} 7 by { cphs <@ MEncDHIES_loop.S.sample(encDHIES tag ptxt, keys); }.
   rewrite equiv[{2} 7 MEncDHIES_loop.Sample_Loop_eq].
   inline*; wp.
   while (={mpk0,tag0,ptxt0,i} /\ pkl{1} = xs{2} /\ (d = encDHIES tag0 ptxt0){2} /\ cphList{1} = l{2}); last by auto.
-  outline {2} [1] {r0 <@ Enc_map.S.sample (
+  outline {2} 1 by {r0 <@ Enc_map.S.sample (
                        enc (nth witness xs i).`2.`2 tag0 ptxt0,
                        fun c =>((nth witness xs i).`1, ((nth witness xs i).`2.`1, c)));}.
   rewrite equiv[{2} 1 Enc_map.sample].
@@ -663,7 +663,7 @@ wp; call (_: inv (glob MRPKErnd_lor){1} (glob MRPKE_lor){2} (glob ODH_Orcl){2} A
   swap{2} 10 1.
   seq 1 10 : (#pre /\ keys{1} = hs{2} /\ (map fst hs = elems pks){2} /\
               (gygxlist = amap (fun pk (x:_*_) => x.`1) hs){2}).
-   outline {1} [1] { keys <@ MEnc.mrndkeys1(elems pks); }.
+   outline {1} 1 by { keys <@ MEnc.mrndkeys1(elems pks); }.
    rewrite equiv[{1} 1 mrndkeys_def].
    + inline*; wp; rnd; rnd; wp; skip; rewrite /inv /=; clear inv; progress.
        by rewrite H.
@@ -849,14 +849,14 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
   simplify; swap{2} 12 1; swap{2} [8..10] 2; swap{2} 3 6; swap{2} [4..6] 1.
   seq 1 4 : (#pre /\ keys{1} = (zip (elems pks) (map (fun k=>(g^x,k)) new_keys)){2} /\
               (n = size (elems pks) /\ n = size new_keys){2}).
-   outline {1} [1] { keys <@ MEnc.mrndkeys1(elems pks); }.
+   outline {1} 1 by { keys <@ MEnc.mrndkeys1(elems pks); }.
    rewrite equiv[{1} 1 mrndkeys_def].
    + inline*; wp; rnd; wp; rnd; wp; skip; rewrite /inv /=; clear inv; progress.
            by rewrite zip_mapr.
      smt (supp_dlist_size size_ge0).
   seq 1 4: (#pre /\ enclist{1} = (zip (elems pks) (map (fun k=>(g^x,k)) lctxt)){2} /\
             (size lctxt = size (elems pks) /\ aad = tag){2}).
-   outline {1} [1] { enclist <@ MEnc.mencDHIES1(tag,if MRPKE_lor.b then m1 else m0,keys); }.
+   outline {1} 1 by { enclist <@ MEnc.mencDHIES1(tag,if MRPKE_lor.b then m1 else m0,keys); }.
    rewrite equiv[{1} 1 mencDHIES_eq].
    + inline*; wp; rnd; wp; skip; rewrite /inv /=; clear inv; progress.
      - apply eq_distr; congr.

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -254,15 +254,15 @@ theory DHIES.
   lemma mencrypt_def1: equiv [MEnc.mencrypt ~ Scheme.mencrypt: ={mpk, tag, ptxt} ==> ={res}].
   proof.
   symmetry; proc.
-  outline {1} [1] { cph <@ MEncrypt_map.S.sample(
+  transitivity* {1} { cph <@ MEncrypt_map.S.sample(
                        dlet_locked (mkeyDHIES (elems mpk))
                        (mencDHIES tag ptxt),
                        FMap.ofassoc <: Pk, group * Cph> ); }.
   + by inline*; auto; rewrite dlet_lockedE.
   rewrite equiv[{1} 1 MEncrypt_map.sample].
   inline*; swap{1} 2 1.
+  proc rewrite {1} ^d<- dlet_lockedE.
   outline {1} [1-2] {r1 <@ MEncDHIES_let.SampleDLet.sample(mkeyDHIES (elems mpk), mencDHIES tag ptxt); }.
-  + by inline*; auto; rewrite dlet_lockedE.
   rewrite equiv[{1} 1 -MEncDHIES_let.SampleDepDLet].
   inline*; swap{1} 2 1. 
   outline {1} [1-2] {t <@ MKey_map.S.sample(

--- a/theories/crypto/prp_prf/Strong_RP_RF.eca
+++ b/theories/crypto/prp_prf/Strong_RP_RF.eca
@@ -519,7 +519,7 @@ section PRPi_PRPi'_Indirect.
   equiv eq_Direct_Indirect: Direct.sample ~ Indirect.sample: ={X} ==> ={res}.
   proof.
   proc.
-  outline {1} [1] { r <@ S.direct((), fun _ => X); }.
+  outline {1} 1 by { r <@ S.direct((), fun _ => X); }.
   rewrite equiv[{1} 1 ll_direct_indirect_eq ((), fun _ => X :@ r)].
   + auto=> />; exact dD_ll.
   inline S.indirect.

--- a/theories/distributions/DList.ec
+++ b/theories/distributions/DList.ec
@@ -381,7 +381,7 @@ abstract theory Program.
     rcondt{2} 4; 1:by auto; while (i < n); auto; smt().
     rcondf{2} 7; 1:by auto; while (i < n); auto; smt().
     wp; rnd.
-    outline {1} [1] rs <@ Sample.sample.
+    outline {1} [1] ~ Sample.sample.
     rewrite equiv[{1} 1 ih].
     inline.
     by wp; while (={i} /\ ={l} /\ n0{1} = n{2} - 1); auto; smt().
@@ -389,16 +389,9 @@ abstract theory Program.
 
   equiv Sample_LoopSnoc_eq: Sample.sample ~ LoopSnoc.sample: ={n} ==> ={res}.
   proof.
-    proc*. transitivity{1} { r <@ Sample.sample(n);
-                             r <- rev r;            }
-                           (={n} ==> ={r})
-                           (={n} ==> ={r})=> //=; 1:smt().
+    proc*. 
+    replace* {1} { x } by { x; r <- rev r; }.
       inline *; wp; rnd rev; auto.
-      move=> &1 &2 ->>; split=> /= [*|t {t}]; 1: by rewrite revK.
-      split.
-        move=> r; rewrite -/(support _ _); case (0 <= n{2})=> sign_n.
-          rewrite !dlist1E // (size_rev r)=> ?;congr;apply eq_big_perm.
-          by apply perm_eqP=> ?;rewrite count_rev. smt(dlist_rev).
       smt(revK dlist_rev).
     rewrite equiv[{1} 1 Sample_Loop_eq].
     inline *; wp; while (={i, n0} /\ rev l{1} = l{2}); auto => />.

--- a/theories/distributions/DList.ec
+++ b/theories/distributions/DList.ec
@@ -381,7 +381,7 @@ abstract theory Program.
     rcondt{2} 4; 1:by auto; while (i < n); auto; smt().
     rcondf{2} 7; 1:by auto; while (i < n); auto; smt().
     wp; rnd.
-    outline {1} [1] ~ Sample.sample.
+    outline {1} 1 ~ Sample.sample.
     rewrite equiv[{1} 1 ih].
     inline.
     by wp; while (={i} /\ ={l} /\ n0{1} = n{2} - 1); auto; smt().

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -335,7 +335,7 @@ have -> : Pr[Sample(A).main(d') @ &m : res] =
   byequiv => //; proc. 
   seq 1 1 : ((glob A){1} = (glob A){m} /\ du{2} = F /\ x{1} = t{2}).
   + by auto.
-  outline {2} [1] ~ S.sample. 
+  outline {2} 1 ~ S.sample.
   call (: d{2} = (F x){1} /\ (glob A){1} = (glob A){m} ==> ={res}).
   bypr (res{1}) (res{2}); 1:smt(). 
   move => &1 &2 a [-> eq_globA]; rewrite sampleE -(adv_mu1 A). 

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -335,7 +335,7 @@ have -> : Pr[Sample(A).main(d') @ &m : res] =
   byequiv => //; proc. 
   seq 1 1 : ((glob A){1} = (glob A){m} /\ du{2} = F /\ x{1} = t{2}).
   + by auto.
-  outline {2} [1] u <@ S.sample. 
+  outline {2} [1] ~ S.sample. 
   call (: d{2} = (F x){1} /\ (glob A){1} = (glob A){m} ==> ={res}).
   bypr (res{1}) (res{2}); 1:smt(). 
   move => &1 &2 a [-> eq_globA]; rewrite sampleE -(adv_mu1 A). 
@@ -540,7 +540,8 @@ have eq_main_O1e_O1l: equiv[Game(A, O1e).main ~ Gr(O1l).main:
 eager proc H (={glob Var}) => //; 2: by sim.
     proc*; inline *; rcondf{2} 6; [ by auto | by sp; if; auto].
 proc.
-outline {1} [1-2] r <@ Game(A, O1e).main.
+print Game.
+transitivity* {1} {r <@ Game(A, O1e).main(d);}.
 + by inline *; rcondt{2} 8; auto; call(: ={Var.x}); 1: sim; auto.
 rewrite equiv[{1} 1 eq_main_O1e_O1l].
 inline*. 

--- a/theories/looping/FoldProc.eca
+++ b/theories/looping/FoldProc.eca
@@ -68,7 +68,7 @@ section.
             ={glob O', t1, t2} ==> ={glob O'}.
   proof.
   proc.
-  outline {1} [1-2] { O'.s <@ Fold(O).fold_12(O'.s, t1, t2); }.
+  outline {1} [1 .. 2] by { O'.s <@ Fold(O).fold_12(O'.s, t1, t2); }.
   by rewrite equiv[{1} 1 fold_swap12]; inline*; sim.
   qed.
 

--- a/theories/looping/IterProc.eca
+++ b/theories/looping/IterProc.eca
@@ -123,7 +123,7 @@ section.
   rewrite equiv[{1} 1 -(iter_12_eq O) (i, i')].
   rewrite equiv[{1} 1 iter2_eq].
   rewrite equiv[{1} 1 (iter_21_eq O) ([i'; i])].
-  outline {1} [1-2] <@ Iter(O).iters.
+  outline {1} [1-2] Iter(O).iters.
   rewrite equiv[{1} 1 (iter_cat_cat O) ([i'], i :: (s1 ++ s2))].
   rewrite equiv[{1} 1 (iter_cat_cat O) ([i'], i :: s1 ++ s2)].
   inline Iter(O).iters; sp.

--- a/theories/looping/IterProc.eca
+++ b/theories/looping/IterProc.eca
@@ -123,7 +123,7 @@ section.
   rewrite equiv[{1} 1 -(iter_12_eq O) (i, i')].
   rewrite equiv[{1} 1 iter2_eq].
   rewrite equiv[{1} 1 (iter_21_eq O) ([i'; i])].
-  outline {1} [1-2] Iter(O).iters.
+  outline {1} [1 .. 2] Iter(O).iters.
   rewrite equiv[{1} 1 (iter_cat_cat O) ([i'], i :: (s1 ++ s2))].
   rewrite equiv[{1} 1 (iter_cat_cat O) ([i'], i :: s1 ++ s2)].
   inline Iter(O).iters; sp.

--- a/theories/modules/RndProd.eca
+++ b/theories/modules/RndProd.eca
@@ -149,7 +149,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 3!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] ~ PS.S.sample2.
+  outline {2} [1 .. 2] ~ PS.S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 + proc; inline*.
@@ -159,7 +159,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 2!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] ~ PS.S.sample2.
+  outline {2} [1 .. 2] ~ PS.S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 + proc; inline*.
@@ -169,7 +169,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 2!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] ~ S.sample2.
+  outline {2} [1 .. 2] ~ S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 smt(mem_empty fdom0).

--- a/theories/modules/RndProd.eca
+++ b/theories/modules/RndProd.eca
@@ -149,7 +149,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 3!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] (r, r0) <@ PS.S.sample2.
+  outline {2} [1-2] ~ PS.S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 + proc; inline*.
@@ -159,7 +159,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 2!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] (r, r0) <@ PS.S.sample2.
+  outline {2} [1-2] ~ PS.S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 + proc; inline*.
@@ -169,7 +169,7 @@ call(: map_prod ROab.RO.m{1} ROa.RO.m{2} ROb.RO.m{2}); auto.
     rewrite -3!mem_fdom -eqa -eqb=> />.
     rewrite mem_fdom 2!get_setE/= 3!fdom_set -eqa -eqb /=.
     smt(mem_set get_setE).
-  outline {2} [1-2] (r0, r) <@ PS.S.sample2.
+  outline {2} [1-2] ~ S.sample2.
   rewrite equiv[{2} 1 -PS.sample_sample2].
   by inline*; auto; rewrite /dab //= => _ _ _ [].
 smt(mem_empty fdom0).


### PR DESCRIPTION
A few changes:
- Replaced explicit left values with a more general *alias* mode. This should be used to prevent undue capture of program variables by the outlined function.
- Tweaked unification procedure to catch type mismatches.
- Code position ranges can now be used.
- Minor updates to error messages and syntax.
- Statement outlining fails if the intermediate goal cannot be discharged. `transitivity *` should be used in this case.