### PR TITLE
Improvements to module tweaks

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1444,6 +1444,9 @@ mod_item:
 | IMPORT VAR ms=loc(mod_qident)+
     { Pst_import ms }
 
+mod_remove_var:
+| MINUS VAR xs=plist1(lident, COMMA) { xs }
+
 mod_update_var:
 | v=var_decl { v }
 
@@ -1453,19 +1456,20 @@ mod_update_fun:
 
 update_stmt:
 | PLUS s=brace(stmt){ [Pups_add (s, true)] }
-| MINUS s=brace(stmt){ [Pups_add (s, false)] }
+| PLUS HAT s=brace(stmt){ [Pups_add (s, false)] }
 | TILD s=brace(stmt) { [Pups_del; Pups_add (s, true)] }
 | MINUS { [Pups_del] }
 
 update_cond:
-| PLUS e=sexpr { Pupc_add e }
+| PLUS e=sexpr { Pupc_add (e, true) }
+| PLUS HAT e=sexpr { Pupc_add (e, false) }
 | TILD e=sexpr { Pupc_mod e }
 | MINUS bs=branch_select { Pupc_del bs }
 
 fun_update:
-| cp=loc(codepos) sup=update_stmt
+| cp=loc(codepos_or_range) sup=update_stmt
   { List.map (fun v -> (cp, Pup_stmt v)) sup }
-| cp=loc(codepos) cup=update_cond
+| cp=loc(codepos_or_range) cup=update_cond
   { [(cp, Pup_cond cup)] }
 
 (* -------------------------------------------------------------------- *)
@@ -1478,8 +1482,8 @@ mod_body:
 | LBRACE stt=loc(mod_item)* RBRACE
     { Pm_struct stt }
 
-| m=mod_qident WITH LBRACE vs=mod_update_var* fs=mod_update_fun* RBRACE
-  { Pm_update (m, vs, fs) }
+| m=mod_qident WITH LBRACE dvs=mod_remove_var? vs=mod_update_var* fs=mod_update_fun* RBRACE
+  { Pm_update (m, odfl [] dvs, vs, fs) }
 
 mod_def_or_decl:
 | locality=locality MODULE header=mod_header c=mod_cast? EQ ptm_body=loc(mod_body)
@@ -2536,6 +2540,14 @@ branch_select:
 codepos:
 | nm=rlist0(nm1_codepos, empty) i=codepos1
     { (nm, i) }
+
+codepos_range:
+| LBRACKET cps=codepos DOTDOT cpe=codepos RBRACKET { (cps, `Base cpe) }
+| LBRACKET cps=codepos MINUS cpe=codepos1 RBRACKET { (cps, `Offset cpe) }
+
+codepos_or_range:
+| cp=codepos { (cp, `Offset (0, `ByPos 0)) }
+| cpr=codepos_range  { cpr }
 
 codeoffset1:
 | i=sword       { (`ByOffset   i :> pcodeoffset1) }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -53,6 +53,7 @@ type pcp_base  = [ `ByPos of int | `ByMatch of int option * pcp_match ]
 type pbranch_select = [`Cond of bool | `Match of psymbol]
 type pcodepos1 = int * pcp_base
 type pcodepos  = (pcodepos1 * pbranch_select) list * pcodepos1
+type pcodepos_range  = pcodepos * [`Base of pcodepos | `Offset of pcodepos1]
 type pdocodepos1 = pcodepos1 doption option
 
 type pcodeoffset1 = [
@@ -330,7 +331,7 @@ and pmodule_params = (psymbol * pmodule_type) list
 and pmodule_expr_r =
   | Pm_ident  of pmsymbol
   | Pm_struct of pstructure
-  | Pm_update of pmsymbol * pupdate_var list * pupdate_fun list
+  | Pm_update of pmsymbol * psymbol list * pupdate_var list * pupdate_fun list
 
 and pmodule_expr = pmodule_expr_r located
 
@@ -345,7 +346,7 @@ and pstructure_item =
   | Pst_import   of (pmsymbol located) list
 
 and pupdate_var = psymbol list * pty
-and pupdate_fun = psymbol * (psymbol list * pty) list * ((pcodepos located * pupdate_item) list * pexpr option)
+and pupdate_fun = psymbol * (psymbol list * pty) list * ((pcodepos_range located * pupdate_item) list * pexpr option)
 
 and pupdate_item =
   | Pup_stmt of pupdate_stmt
@@ -356,7 +357,7 @@ and pupdate_stmt =
   | Pups_del
 
 and pupdate_cond =
-  | Pupc_add of pexpr
+  | Pupc_add of (pexpr * bool)
   | Pupc_mod of pexpr
   | Pupc_del of pbranch_select
 

--- a/tests/fine-grained-module-defs.ec
+++ b/tests/fine-grained-module-defs.ec
@@ -31,11 +31,10 @@ end;
 
 module A_count (B : T) = A(B) with {
   var c : int
-  proc f [1 - { c <- c + 1;}]
-  proc g [1 ~ { c <- c - 1;} 2 -] res ~ (x + 1)
+  proc f [1 + ^ { c <- c + 1;}]
+  proc g [[^x<- .. ^ <@] ~ { c <- c - 1;}] res ~ (x + 1)
   proc h [^match - #Some.]
 }.
-print A_count.
 
 equiv A_A_count (B <: T{-A_count, -A}) : A(B).f ~ A_count(B).f: ={arg, glob B} /\ ={x}(A, A_count) ==> ={res, glob B} /\ ={x}(A, A_count).
 proof.


### PR DESCRIPTION
- Allow for code position ranges to specify blocks of changes.
  + `[cp .. cp]` specify a block using two code positions.
  + `[cp - cp1]` specify a block using an initial position and another position relative to it.
- Minor change to syntax for adding above a statement ( `+ ^`).
- Allow for removing a module variable.