### PR TITLE
Type annotated getters/setters

### DIFF
--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -148,7 +148,7 @@ type glob_or_var =
 type plvalue_r =
   | PLvSymbol of pqsymbol
   | PLvTuple  of pqsymbol list
-  | PLvMap    of pqsymbol * ptyannot option * pexpr list
+  | PLvMap    of pqsymbol * ptyannot option * pty option * pexpr list
 
 and plvalue = plvalue_r located
 

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -213,7 +213,7 @@ val trans_gbinding : env -> EcUnify.unienv -> pgtybindings ->
 
 (* -------------------------------------------------------------------- *)
 val transexp :
-  env -> [`InProc|`InOp] -> EcUnify.unienv -> pexpr -> expr * ty
+  env -> ?tt:ty -> [`InProc|`InOp] -> EcUnify.unienv -> pexpr -> expr * ty
 
 val transexpcast :
   env -> [`InProc|`InOp] -> EcUnify.unienv -> ty -> pexpr -> expr

--- a/tests/annotated-getter-setter.ec
+++ b/tests/annotated-getter-setter.ec
@@ -1,0 +1,39 @@
+(* -------------------------------------------------------------------- *)
+require import AllCore.
+
+type u32, u64.
+
+type key.
+type map.
+
+theory GS32.
+  op "_.[_]" : map -> key -> u32.
+  op "_.[_<-_]" : map -> key -> u32 -> map.
+end GS32.
+
+theory GS64.
+  op "_.[_]" : map -> key -> u64.
+  op "_.[_<-_]" : map -> key -> u64 -> map.
+end GS64.
+
+import GS32 GS64.
+
+op myget32 (m : map) k = m.[:(u32) k].
+
+op myset32 (m : map) k v = m.[:(u32) k <- v].
+
+op myget64 (m : map) k = m.[:(u64) k].
+
+op myset64 (m : map) k v = m.[:(u64) k <- v].
+
+module M = {
+  proc f32(m : map, k, v) = {
+    m.[:(u32) k] <- v;
+    return m;
+  }
+
+  proc f64(m : map, k, v) = {
+    m.[:(u64) k] <- v;
+    return m;
+  }
+}.


### PR DESCRIPTION
This commit introduces the following syntax:

  - `m.[:(ty) k]` for `(m.[k] :~ ty)`
  - `m.[:(ty) k <- v]` for `m.[k <- (v :~ ty)]`
  - `m.[:(ty) k] <- k` for `m.[k] <- (v :~ ty)`

This helps disambiguate the selection of getters and setters using the type of the map's values.