### PR TITLE
stdlib: in Field, do not erase the unit predicate

### DIFF
--- a/theories/algebra/Ring.ec
+++ b/theories/algebra/Ring.ec
@@ -795,7 +795,7 @@ end IDomain.
 (* -------------------------------------------------------------------- *)
 abstract theory Field.
 
-  clone include IDomain with pred unit (x : t) <- x <> zeror.
+  clone include IDomain with pred unit (x : t) <= x <> zeror.
 
   lemma mulfV (x : t): x <> zeror => x * (invr x) = oner.
   proof. by apply/mulrV. qed.


### PR DESCRIPTION
This allows using a Field instance in place of a Ring.