### PR TITLE
Keyword `global` for cloning theories

### DIFF
--- a/src/ecLexer.mll
+++ b/src/ecLexer.mll
@@ -181,6 +181,7 @@
     "export"      , EXPORT     ;        (* KW: global *)
     "include"     , INCLUDE    ;        (* KW: global *)
     "local"       , LOCAL      ;        (* KW: global *)
+    "global"      , GLOBAL     ;        (* KW: global *)
     "declare"     , DECLARE    ;        (* KW: global *)
     "hint"        , HINT       ;        (* KW: global *)
     "module"      , MODULE     ;        (* KW: global *)

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -114,15 +114,13 @@
             fp_args = []; }) info
 
   (* ------------------------------------------------------------------ *)
-  let locality_as_local (lc : locality located) =
+  let locality_as_local (lc : EcTypes.locality located) =
     match unloc lc with
     | `Global  -> `Global
     | `Local   -> `Local
     | `Declare -> parse_error (loc lc)
                    (Some "cannot mark with 'declare' this kind of objects ")
 
-  let bool_as_local b =
-    if b then `Local else `Global
   (* ------------------------------------------------------------------ *)
   type prover =
     [ `Exclude | `Include | `Only] * psymbol
@@ -443,6 +441,7 @@
 %token FWDS
 %token GEN
 %token GLOB
+%token GLOBAL
 %token GOAL
 %token HAT
 %token HAVE
@@ -657,6 +656,7 @@ _lident:
 | CHECK      { "check"      }
 | EDIT       { "edit"       }
 | FIX        { "fix"        }
+| GLOBAL     { "global"     }
 
 | x=RING  { match x with `Eq -> "ringeq"  | `Raw -> "ring"  }
 | x=FIELD { match x with `Eq -> "fieldeq" | `Raw -> "field" }
@@ -3497,8 +3497,13 @@ tactic_dump:
 (* -------------------------------------------------------------------- *)
 (* Theory cloning                                                       *)
 
+%inline local_type:
+ | (* empty *) { None }
+ | GLOBAL      { Some `Global }
+ | LOCAL       { Some `Local }
+
 theory_clone:
-| local=is_local CLONE options=clone_opts?
+| local=local_type CLONE options=clone_opts?
     ip=clone_import? x=uqident y=prefix(AS, uident)? cw=clone_with?
     c=or3(clone_proof, clone_rename, clone_clear)*
 

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -4,6 +4,7 @@ open EcMaps
 open EcSymbols
 open EcLocation
 open EcUtils
+open EcTypes
 
 (* -------------------------------------------------------------------- *)
 exception ParseError of EcLocation.t * string option
@@ -96,11 +97,6 @@ and 'a rfield = {
   rf_tvi   : ptyannot option;
   rf_value : 'a;
 }
-
-(* -------------------------------------------------------------------- *)
-type is_local = [ `Local | `Global]
-
-type locality = [`Declare | `Local | `Global]
 
 (* -------------------------------------------------------------------- *)
 type pmodule_type = pqsymbol
@@ -1157,7 +1153,7 @@ type theory_cloning = {
   pthc_rnm    : theory_renaming list;
   pthc_opts   : theory_cloning_options;
   pthc_clears : theory_cloning_clear list;
-  pthc_local  : is_local;
+  pthc_local  : is_local option;
   pthc_import : [`Export | `Import | `Include] option;
 }
 

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -3496,7 +3496,8 @@ let rec pp_theory ppe (fmt : Format.formatter) (path, cth) =
     | `Concrete -> "theory"
   in
 
-  Format.fprintf fmt "@[<v>%a%s %s.@,  @[<v>%a@]@,end %s.@]"
+  Format.fprintf fmt "@[<v>%a%a%s %s.@,  @[<v>%a@]@,end %s.@]"
+    pp_locality cth.cth_loca
     pp_clone cth.EcTheory.cth_source
     thkw basename
     (pp_list "@,@," (pp_th_item ppe path)) cth.cth_items

--- a/src/ecSection.mli
+++ b/src/ecSection.mli
@@ -13,7 +13,7 @@ val env : scenv -> env
 
 val initial : env -> scenv
 
-val add_item     : theory_item -> scenv -> scenv
+val add_item     : ?override_locality:EcTypes.is_local option -> theory_item -> scenv -> scenv
 val add_decl_mod : EcIdent.t -> mty_mr -> scenv -> scenv
 
 val enter_section : EcSymbols.symbol option -> scenv -> scenv

--- a/src/ecTheoryReplay.mli
+++ b/src/ecTheoryReplay.mli
@@ -19,7 +19,7 @@ type 'a ovrenv = {
   ovre_prefix   : (symbol list) EcUtils.pair;
   ovre_glproof  : (ptactic_core option * evtags option) list;
   ovre_abstract : bool;
-  ovre_local    : EcTypes.is_local;
+  ovre_local    : EcTypes.is_local option;
   ovre_hooks    : 'a ovrhooks;
 }
 
@@ -33,8 +33,8 @@ and 'a ovrhooks = {
 
 (* -------------------------------------------------------------------- *)
 val replay : 'a ovrhooks
-  -> abstract:bool -> local:is_local -> incl:bool
+  -> abstract:bool -> override_locality:EcTypes.is_local option -> incl:bool
   -> clears:Sp.t -> renames:(renaming list)
   -> opath:path -> npath:path -> evclone
-  -> 'a -> symbol * theory_item list
+  -> 'a -> symbol * theory_item list * EcTypes.is_local
   ->  axclone list * 'a

--- a/tests/global_cloning.ec
+++ b/tests/global_cloning.ec
@@ -1,0 +1,34 @@
+type t.
+
+section.
+
+theory A.
+  local theory B.
+    local op o1 : t.
+    (* local with or without keyword because theory is local *)
+    op o2 : t.
+  end B.
+  local op o1 : t.
+  op o2 : t.
+end A.
+
+(* this makes all fields from [B] global again *)
+global clone A.B as B'.
+
+(* This clone inherits [local] and thus disappears at section end *)
+clone A.B as FinalTheory.
+
+end section.
+
+(* [FinalTheory] was local so its name is available *)
+theory FinalTheory.
+  clone include A.
+
+  (* idem for [o1] *)
+  op o1 = o2.
+
+  (* idem for B *)
+  clone import B' as B with
+          (* [o1] is visible *)
+	  op o1 <= o2.
+end FinalTheory.


### PR DESCRIPTION
This pull request adds a `global` keyword that ensures that
```
global clone A as Ab ...
```
gives public visibility to newly-cloned items from theory `A`. This might be useful in patterns like
```
local clone A as Ab.
global clone Ab.some.interesting.subtheory as B with ...
```
in order to reexport only specific parts of interest from a given theory `A`. It does not change the standard behaviour
that `clone A as B` preserves the visibility of `A` for items of `B`. Commit df336f872dcb62b571ece9c6670bcb4e41828932 provides an information message when this happens when cloning a local theory (with `clone` and not `local clone`), and also informs on the existence of the `global` keyword.

This also addresses issue #747, because it gives the right visibility to the new _theory_ itself, and not only its items; which properly clears the theory and escapes the assertion failure.

This has been tested on the standard library successfully but was not otherwise submitted to more tests; I will of course try to fix errors if they arise.