### PR TITLE
Making program logic formulas memory-agnostic

### DIFF
--- a/examples/FundamentalLemma.ec
+++ b/examples/FundamentalLemma.ec
@@ -44,6 +44,6 @@ apply (ler_trans (max Pr[G1.main() @ &m: A (glob Mem) res /\ F (glob Mem) res]
                       Pr[G2.main() @ &m: B (glob Mem) res /\ F (glob Mem) res])).
 + smt(ge0_mu).
 have -> //: forall (x y x' y':real), x <= x' => y <= y' => max x y <= max x' y' by smt().
-+ by rewrite -(Pr_split G1 Mem F A &m) andbC; smt(ge0_mu).
-by rewrite -(Pr_split G2 Mem F B &m) andbC; smt(ge0_mu).
++ by rewrite -(Pr_split G1 Mem F A &m); smt(ge0_mu).  
+by rewrite -(Pr_split G2 Mem F B &m); smt(ge0_mu).
 qed.

--- a/examples/hashed_elgamal_generic.ec
+++ b/examples/hashed_elgamal_generic.ec
@@ -260,7 +260,12 @@ section.
     by rewrite dt_ll DBool.dbool_ll.
   + by move=> H H_o_ll; proc; auto; call (guess_ll H _)=> //; auto=> />.
   + by move=> _; apply: dbits_ll.
-  by rewrite !eqT.
+  apply iffLR.
+  congr; 2:congr.
+  + byequiv (: ={glob OnBound.G0(D, LRO), arg} ==>
+               ={glob OnBound.G0(D, LRO), res}) => />; 1:sim.
+  byequiv (: ={glob OnBound.G1(D, LRO), arg} ==>
+             ={glob OnBound.G1(D, LRO), res}) => />; 1:sim.
   qed.
 
   local module G1' = {

--- a/src/ecAst.mli
+++ b/src/ecAst.mli
@@ -201,79 +201,211 @@ and f_node =
 
   | Fpr of pr (* hr *)
 
+(* We use the alert system for privacy because we want to 
+   permit access in *some* instances, and the other fields are fine *)
+(* This is to ensure that memory bindings are carried along with the invariants *)
 and eagerF = {
+  eg_ml : memory;
+  eg_mr : memory;
   eg_pr : form;
+  [@alert priv_pl "Use the accessor function `eg_pr` instead of the field"]
   eg_sl : stmt;  (* No local program variables *)
   eg_fl : EcPath.xpath;
   eg_fr : EcPath.xpath;
   eg_sr : stmt;  (* No local program variables *)
   eg_po : form
+  [@alert priv_pl "Use the accessor function `es_po` instead of the field"]
 }
 
 and equivF = {
+  ef_ml : memory;
+  ef_mr : memory;
   ef_pr : form;
+  [@alert priv_pl "Use the accessor function `ef_pr` instead of the field"]
   ef_fl : EcPath.xpath;
   ef_fr : EcPath.xpath;
   ef_po : form;
+  [@alert priv_pl "Use the accessor function `ef_po` instead of the field"]
 }
 
 and equivS = {
   es_ml  : memenv;
   es_mr  : memenv;
   es_pr  : form;
+  [@alert priv_pl "Use the accessor function `es_pr` instead of the field"]
   es_sl  : stmt;
   es_sr  : stmt;
-  es_po  : form; }
+  es_po  : form;
+  [@alert priv_pl "Use the accessor function `es_po` instead of the field"]
+}
 
 and sHoareF = {
+  hf_m : memory;
   hf_pr : form;
+  [@alert priv_pl "Use the accessor function `hf_pr` instead of the field"]
   hf_f  : EcPath.xpath;
   hf_po : form;
+  [@alert priv_pl "Use the accessor function `hf_pr` instead of the field"]
 }
 
 and sHoareS = {
   hs_m  : memenv;
   hs_pr : form;
+  [@alert priv_pl "Use the accessor function `hs_pr` instead of the field"]
   hs_s  : stmt;
-  hs_po : form; }
+  hs_po : form;
+  [@alert priv_pl "Use the accessor function `hs_po` instead of the field"]
+}
 
 
 and eHoareF = {
+  ehf_m  : memory;
   ehf_pr  : form;
+  [@alert priv_pl "Use the accessor function `ehf_pr` instead of the field"]
   ehf_f   : EcPath.xpath;
   ehf_po  : form;
+  [@alert priv_pl "Use the accessor function `ehf_po` instead of the field"]
 }
 
 and eHoareS = {
   ehs_m   : memenv;
   ehs_pr  : form;
+  [@alert priv_pl "Use the accessor function `ehs_pr` instead of the field"]
   ehs_s   : stmt;
   ehs_po  : form;
+  [@alert priv_pl "Use the accessor function `ehs_po` instead of the field"]
 }
 
 and bdHoareF = {
+  bhf_m   : memory;
   bhf_pr  : form;
+  [@alert priv_pl "Use the accessor function `bhf_pr` instead of the field"]
   bhf_f   : EcPath.xpath;
   bhf_po  : form;
+  [@alert priv_pl "Use the accessor function `bhf_po` instead of the field"]
   bhf_cmp : hoarecmp;
   bhf_bd  : form;
+  [@alert priv_pl "Use the accessor function `bhf_bd` instead of the field"]
 }
 
 and bdHoareS = {
   bhs_m   : memenv;
   bhs_pr  : form;
+  [@alert priv_pl "Use the accessor function `bhs_pr` instead of the field"]
   bhs_s   : stmt;
   bhs_po  : form;
+  [@alert priv_pl "Use the accessor function `bhs_po` instead of the field"]
   bhs_cmp : hoarecmp;
   bhs_bd  : form;
+  [@alert priv_pl "Use the accessor function `bhs_bd` instead of the field"]
+}
+
+and ss_inv = {
+  m   : memory;
+  inv : form;
 }
 
 and pr = {
   pr_mem   : memory;
   pr_fun   : EcPath.xpath;
   pr_args  : form;
-  pr_event : form;
+  pr_event : ss_inv;
 }
+
+(* -------------------------------------------------------------------- *)
+
+val map_ss_inv : ?m:memory -> (form list -> form) -> ss_inv list -> ss_inv
+val map_ss_inv1 : (form -> form) -> ss_inv -> ss_inv
+val map_ss_inv2 : (form -> form -> form) -> ss_inv -> ss_inv -> ss_inv
+val map_ss_inv3 : (form -> form -> form -> form) -> ss_inv -> ss_inv -> ss_inv -> ss_inv
+
+val map_ss_inv_destr2 : (form -> form * form) -> ss_inv -> ss_inv * ss_inv
+val map_ss_inv_destr3 : (form -> form * form * form) -> ss_inv -> ss_inv * ss_inv * ss_inv
+
+type ts_inv = {
+  ml  : memory;
+  mr  : memory;
+  inv : form;
+}
+
+val map_ts_inv : ?ml:memory -> ?mr:memory -> (form list -> form) -> ts_inv list -> ts_inv
+val map_ts_inv1 : (form -> form) -> ts_inv -> ts_inv
+val map_ts_inv2 : (form -> form -> form) -> ts_inv -> ts_inv -> ts_inv
+val map_ts_inv3 : (form -> form -> form -> form) -> ts_inv -> ts_inv -> ts_inv -> ts_inv
+
+val map_ts_inv_left : (ss_inv list -> ss_inv) -> ts_inv list -> ts_inv
+val map_ts_inv_left1 : (ss_inv -> ss_inv) -> ts_inv -> ts_inv
+val map_ts_inv_left2 : (ss_inv -> ss_inv -> ss_inv) -> ts_inv -> ts_inv -> ts_inv
+val map_ts_inv_left3 : (ss_inv -> ss_inv -> ss_inv -> ss_inv) -> 
+    ts_inv -> ts_inv -> ts_inv -> ts_inv
+
+val map_ts_inv_right : (ss_inv list -> ss_inv) -> ts_inv list -> ts_inv
+val map_ts_inv_right1 : (ss_inv -> ss_inv) -> ts_inv -> ts_inv
+val map_ts_inv_right2 : (ss_inv -> ss_inv -> ss_inv) -> ts_inv -> ts_inv -> ts_inv
+val map_ts_inv_right3 : (ss_inv -> ss_inv -> ss_inv -> ss_inv) -> 
+    ts_inv -> ts_inv -> ts_inv -> ts_inv
+
+val map_ts_inv_destr2 : (form -> form * form) -> ts_inv -> ts_inv * ts_inv
+val map_ts_inv_destr3 : (form -> form * form * form) -> ts_inv -> ts_inv * ts_inv * ts_inv
+
+val ts_inv_lower_left : (ss_inv list -> form) -> ts_inv list -> ss_inv
+val ts_inv_lower_left1 : (ss_inv -> form) -> ts_inv -> ss_inv
+val ts_inv_lower_left2 : (ss_inv -> ss_inv -> form) -> ts_inv -> ts_inv -> ss_inv
+val ts_inv_lower_left3 : (ss_inv -> ss_inv -> ss_inv -> form) -> 
+    ts_inv -> ts_inv -> ts_inv -> ss_inv
+
+val ts_inv_lower_right : (ss_inv list -> form) -> ts_inv list -> ss_inv
+val ts_inv_lower_right1 : (ss_inv -> form) -> ts_inv -> ss_inv
+val ts_inv_lower_right2 : (ss_inv -> ss_inv -> form) -> ts_inv -> ts_inv -> ss_inv
+val ts_inv_lower_right3 : (ss_inv -> ss_inv -> ss_inv -> form) -> 
+    ts_inv -> ts_inv -> ts_inv -> ss_inv
+
+(* -------------------------------------------------------------------- *)
+
+type inv =
+  | Inv_ss of ss_inv
+  | Inv_ts of ts_inv
+
+val inv_of_inv : inv -> form
+
+val lift_ss_inv : (ss_inv -> 'a) -> inv -> 'a
+val lift_ss_inv2 : (ss_inv -> ss_inv -> 'a) -> inv -> inv -> 'a
+val lift_ss_inv3 : (ss_inv -> ss_inv -> ss_inv -> 'a) -> inv -> inv -> inv -> 'a
+val lift_ts_inv : (ts_inv -> 'a) -> inv -> 'a
+val lift_ts_inv2 : (ts_inv -> ts_inv -> 'a) -> inv -> inv -> 'a
+val lift_inv_adapter : (form -> 'a) -> inv -> 'a
+val lift_inv_adapter2 : (form -> form -> 'a) -> inv -> inv -> 'a
+
+val ss_inv_generalize_left : ss_inv -> memory -> ts_inv
+val ss_inv_generalize_right : ss_inv -> memory -> ts_inv
+
+val map_inv : (form list -> form) -> inv list -> inv
+val map_inv1 : (form -> form) -> inv -> inv
+val map_inv2 : (form -> form -> form) -> inv -> inv -> inv
+val map_inv3 : (form -> form -> form -> form) -> inv -> inv -> inv -> inv
+
+val eg_pr : eagerF -> ts_inv
+val eg_po : eagerF -> ts_inv
+val ef_pr : equivF -> ts_inv
+val ef_po : equivF -> ts_inv
+val es_pr : equivS -> ts_inv
+val es_po : equivS -> ts_inv
+val hf_pr : sHoareF -> ss_inv
+val hf_po : sHoareF -> ss_inv
+val hs_pr : sHoareS -> ss_inv
+val hs_po : sHoareS -> ss_inv
+val ehf_pr : eHoareF -> ss_inv
+val ehf_po : eHoareF -> ss_inv
+val ehs_pr : eHoareS -> ss_inv
+val ehs_po : eHoareS -> ss_inv
+val bhf_pr : bdHoareF -> ss_inv
+val bhf_po : bdHoareF -> ss_inv
+val bhf_bd : bdHoareF -> ss_inv
+val bhs_pr : bdHoareS -> ss_inv
+val bhs_po : bdHoareS -> ss_inv
+val bhs_bd : bdHoareS -> ss_inv
+
+(* -------------------------------------------------------------------- *)
 
 type 'a equality = 'a -> 'a -> bool
 type 'a hash = 'a -> int
@@ -419,14 +551,6 @@ val eg_hash   : eagerF hash
 
 val pr_equal  : pr equality
 val pr_hash   : pr hash
-
-(* ----------------------------------------------------------------- *)
-(* Predefined memories                                               *)
-(* ----------------------------------------------------------------- *)
-
-val mhr    : memory
-val mleft  : memory
-val mright : memory
 
 (* ----------------------------------------------------------------- *)
 (* Hashconsing                                                       *)

--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -9,11 +9,6 @@ open EcCoreModules
 open EcMemory
 
 (* -------------------------------------------------------------------- *)
-val mhr    : memory
-val mleft  : memory
-val mright : memory
-
-(* -------------------------------------------------------------------- *)
 type quantif = EcAst.quantif
 
 type hoarecmp = EcAst.hoarecmp
@@ -92,10 +87,10 @@ val kind_of_gty: gty -> [`Form | `Mem | `Mod]
 
 (* soft-constructors - common leaves *)
 val f_local : EcIdent.t -> EcTypes.ty -> form
-val f_pvar  : EcTypes.prog_var -> EcTypes.ty -> memory -> form
-val f_pvarg : EcTypes.ty -> memory -> form
-val f_pvloc : variable -> memory -> form
-val f_glob  : EcIdent.t -> memory -> form
+val f_pvar  : EcTypes.prog_var -> EcTypes.ty -> memory -> ss_inv
+val f_pvarg : EcTypes.ty -> memory -> ss_inv
+val f_pvloc : variable -> memory -> ss_inv
+val f_glob  : EcIdent.t -> memory -> ss_inv
 
 (* soft-constructors - common formulas constructors *)
 val f_op     : path -> EcTypes.ty list -> EcTypes.ty -> form
@@ -113,43 +108,30 @@ val f_lambda : bindings -> form -> form
 
 val f_forall_mems : (EcIdent.t * memtype) list -> form -> form
 
-(* soft-constructors - hoare *)
-val f_hoareF_r : sHoareF -> form
-val f_hoareS_r : sHoareS -> form
+val f_hoareF : ss_inv -> xpath -> ss_inv -> form
+val f_hoareS : memtype -> ss_inv -> stmt -> ss_inv -> form
 
-val f_hoareF : form -> xpath -> form -> form
-val f_hoareS : memenv -> form -> stmt -> form -> form
+val f_eHoareF : ss_inv -> xpath -> ss_inv -> form
+val f_eHoareS : memtype -> ss_inv -> EcCoreModules.stmt -> ss_inv -> form
 
-(* soft-constructors - expected hoare *)
-val f_eHoareF_r : eHoareF -> form
-val f_eHoareS_r : eHoareS -> form
-
-val f_eHoareF : form -> xpath -> form -> form
-val f_eHoareS : memenv -> form -> EcCoreModules.stmt -> form -> form
+(* soft-constructors - eager *)
 
 (* soft-constructors - bd hoare *)
 val hoarecmp_opp : hoarecmp -> hoarecmp
 
-val f_bdHoareF_r : bdHoareF -> form
-val f_bdHoareS_r : bdHoareS -> form
-
-val f_bdHoareF : form -> xpath -> form -> hoarecmp -> form -> form
-val f_bdHoareS : memenv -> form -> stmt -> form -> hoarecmp -> form -> form
+val f_bdHoareF : ss_inv -> xpath -> ss_inv -> hoarecmp -> ss_inv -> form
+val f_bdHoareS : memtype -> ss_inv -> stmt -> ss_inv -> hoarecmp -> ss_inv -> form
 
 (* soft-constructors - equiv *)
-val f_equivS : memenv -> memenv -> form -> stmt -> stmt -> form -> form
-val f_equivF : form -> xpath -> xpath -> form -> form
-
-val f_equivS_r : equivS -> form
-val f_equivF_r : equivF -> form
+val f_equivF : ts_inv -> xpath -> xpath -> ts_inv -> form
+val f_equivS : memtype -> memtype -> ts_inv -> stmt -> stmt -> ts_inv -> form
 
 (* soft-constructors - eager *)
-val f_eagerF_r : eagerF -> form
-val f_eagerF   : form -> stmt -> xpath -> xpath -> stmt -> form -> form
+val f_eagerF : ts_inv -> stmt -> xpath -> xpath -> stmt -> ts_inv -> form
 
 (* soft-constructors - Pr *)
 val f_pr_r : pr -> form
-val f_pr   : memory -> xpath -> form -> form -> form
+val f_pr   : memory -> xpath -> form -> ss_inv -> form
 
 (* soft-constructors - unit *)
 val f_tt : form
@@ -325,12 +307,17 @@ val split_fun  : form -> bindings * form
 val split_args : form -> form * form list
 
 (* -------------------------------------------------------------------- *)
-val form_of_expr : EcMemory.memory -> EcTypes.expr -> form
+val form_of_expr : EcTypes.expr -> form
+val ss_inv_of_expr : EcMemory.memory -> EcTypes.expr -> ss_inv
 
 (* -------------------------------------------------------------------- *)
 exception CannotTranslate
 
-val expr_of_form : EcMemory.memory -> form -> EcTypes.expr
+val expr_of_ss_inv : ss_inv -> EcTypes.expr
+val expr_of_form : form -> EcTypes.expr
+
+(* -------------------------------------------------------------------- *)
+(* A predicate on memory: λ mem. -> pred *)
 
 (* -------------------------------------------------------------------- *)
 (* A predicate on memory: λ mem. -> pred *)

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -167,6 +167,11 @@ end = struct
     }
 end
 
+type actmem = [
+  | `SS of EcMemory.memory
+  | `TS of EcMemory.memory * EcMemory.memory
+]
+
 (* -------------------------------------------------------------------- *)
 type preenv = {
   env_top      : EcPath.path option;
@@ -176,7 +181,7 @@ type preenv = {
   env_comps    : mc Mip.t;
   env_locals   : (EcIdent.t * EcTypes.ty) MMsym.t;
   env_memories : EcMemory.memtype Mmem.t;
-  env_actmem   : EcMemory.memory option;
+  env_actmem   : actmem option;
   env_abs_st   : EcModules.abs_uses Mid.t;
   env_tci      : ((ty_params * ty) * tcinstance) list;
   env_tc       : TC.graph;
@@ -1255,18 +1260,43 @@ module Memory = struct
     try Some (Mmem.bysym me env.env_memories)
     with Not_found -> None
 
-  let set_active (me : memory) (env : env) =
+  let set_active_ss (me : memory) (env : env) =
     match byid me env with
     | None   -> raise (MEError (UnknownMemory (`Memory me)))
-    | Some _ -> { env with env_actmem = Some me }
+    | Some _ -> { env with env_actmem = Some (`SS me) }
 
-  let get_active (env : env) =
-    env.env_actmem
-
-  let current (env : env) =
+  let get_active_ss (env : env) =
     match env.env_actmem with
-    | None    -> None
-    | Some me -> byid me env
+    | Some (`SS me) -> Some me
+    | _             -> None
+
+  let current_ss (env : env) =
+    match env.env_actmem with
+    | Some (`SS me) -> byid me env
+    | _             -> None
+
+
+  let set_active_ts (ml: memory) (mr: memory) (env : env) =
+    match byid ml env, byid mr env with
+    | None, _ -> raise (MEError (UnknownMemory (`Memory ml)))
+    | _, None -> raise (MEError (UnknownMemory (`Memory mr)))
+    | Some _, Some _ ->
+        { env with env_actmem = Some (`TS (ml, mr)) }
+
+  let get_active_ts (env : env) =
+    match env.env_actmem with
+    | Some (`TS (ml, mr)) -> Some (ml, mr)
+    | _                   -> None
+
+  let current_ts (env : env) =
+    match env.env_actmem with
+    | Some (`TS (ml, mr)) -> begin
+        match byid ml env, byid mr env with
+        | Some mel, Some mer -> Some (mel, mer)
+        | _ -> None
+    end
+    | _ -> None
+
 
   let update (me: EcMemory.memenv) (env : env) =
     { env with env_memories = Mmem.add (fst me) (snd me) env.env_memories; }
@@ -1281,9 +1311,13 @@ module Memory = struct
       (fun env m -> push m env)
       env memenvs
 
-  let push_active memenv env =
-    set_active (EcMemory.memory memenv)
+  let push_active_ss memenv env =
+    set_active_ss (EcMemory.memory memenv)
       (push memenv env)
+
+  let push_active_ts mel mer env =
+    set_active_ts (EcMemory.memory mel) (EcMemory.memory mer)
+      (push mer (push mel env))
 
 end
 
@@ -1659,64 +1693,61 @@ module Fun = struct
       let locals = List.map ovar_of_var fd.f_locals in
       (fun_.f_sig,fd), adds_in_memenv mem locals
 
-  let inv_memory side =
-    let id    = if side = `Left then EcCoreFol.mleft else EcCoreFol.mright in
-    EcMemory.abstract id
+  let inv_memenv ml mr env =
+    Memory.push_active_ts (EcMemory.abstract ml) (EcMemory.abstract mr) env
 
-  let inv_memenv env =
-    Memory.push_all [inv_memory `Left; inv_memory `Rigth] env
-
-  let inv_memenv1 env =
-    let mem  = EcMemory.abstract EcCoreFol.mhr in
-    Memory.push_active mem env
+  let inv_memenv1 m env =
+    let mem  = EcMemory.abstract m in
+    Memory.push_active_ss mem env
 
   let prF_memenv m path env =
     let fun_ = by_xpath path env in
     actmem_post m fun_
 
-  let prF path env =
-    let post = prF_memenv EcCoreFol.mhr path env in
-    Memory.push_active post env
+  let prF m path env =
+    let post = prF_memenv m path env in
+    Memory.push_active_ss post env
 
-  let hoareF_memenv path env =
+  (* FIXME: This does not use the memory identifier except to return it *)
+  let hoareF_memenv mem path env =
     let (ip, _) = oget (ipath_of_xpath path) in
     let fun_ = snd (oget (by_ipath ip env)) in
-    let pre  = actmem_pre EcCoreFol.mhr fun_ in
-    let post = actmem_post EcCoreFol.mhr fun_ in
+    let pre  = actmem_pre mem fun_ in
+    let post = actmem_post mem fun_ in
     pre, post
 
-  let hoareF path env =
-    let pre, post = hoareF_memenv path env in
-    Memory.push_active pre env, Memory.push_active post env
+  let hoareF mem path env =
+    let pre, post = hoareF_memenv mem path env in
+    Memory.push_active_ss pre env, Memory.push_active_ss post env
 
-  let hoareS path env =
+  let hoareS mem path env =
     let fun_ = by_xpath path env in
-    let fd, memenv = actmem_body EcCoreFol.mhr fun_ in
-    memenv, fd, Memory.push_active memenv env
+    let fd, memenv = actmem_body mem fun_ in
+    memenv, fd, Memory.push_active_ss memenv env
 
-  let equivF_memenv path1 path2 env =
+  let equivF_memenv ml mr path1 path2 env =
     let (ip1, _) = oget (ipath_of_xpath path1) in
     let (ip2, _) = oget (ipath_of_xpath path2) in
 
     let fun1 = snd (oget (by_ipath ip1 env)) in
     let fun2 = snd (oget (by_ipath ip2 env)) in
-    let pre1 = actmem_pre EcCoreFol.mleft fun1 in
-    let pre2 = actmem_pre EcCoreFol.mright fun2 in
-    let post1 = actmem_post EcCoreFol.mleft fun1 in
-    let post2 = actmem_post EcCoreFol.mright fun2 in
+    let pre1 = actmem_pre ml fun1 in
+    let pre2 = actmem_pre mr fun2 in
+    let post1 = actmem_post ml fun1 in
+    let post2 = actmem_post mr fun2 in
     (pre1,pre2), (post1,post2)
 
-  let equivF path1 path2 env =
-    let (pre1,pre2),(post1,post2) = equivF_memenv path1 path2 env in
-    Memory.push_all [pre1; pre2] env,
-    Memory.push_all [post1; post2] env
+  let equivF ml mr path1 path2 env =
+    let (prel,prer),(postl,postr) = equivF_memenv ml mr path1 path2 env in
+    Memory.push_active_ts prel prer env,
+    Memory.push_active_ts postl postr env
 
-  let equivS path1 path2 env =
+  let equivS ml mr path1 path2 env =
     let fun1 = by_xpath path1 env in
     let fun2 = by_xpath path2 env in
-    let fd1, mem1 = actmem_body EcCoreFol.mleft fun1 in
-    let fd2, mem2 = actmem_body EcCoreFol.mright fun2 in
-    mem1, fd1, mem2, fd2, Memory.push_all [mem1; mem2] env
+    let fd1, mem1 = actmem_body ml fun1 in
+    let fd2, mem2 = actmem_body mr fun2 in
+    mem1, fd1, mem2, fd2, Memory.push_active_ts mem1 mem2 env
 end
 
 (* -------------------------------------------------------------------- *)
@@ -2426,13 +2457,13 @@ module NormMp = struct
     let globs = List.map (fun id -> f_glob id m) globs in
     let pv = List.map (fun (xp, ty) -> f_pvar (pv_glob xp) ty m) pv in
 
-    f_tuple (globs @ pv)
+    map_ss_inv ~m f_tuple (globs @ pv)
 
   let norm_glob env m mp = globals env m mp
 
   let norm_tglob env mp =
-    let g = (norm_glob env mhr mp) in
-    g.f_ty
+    let g = (norm_glob env (EcIdent.create "&dummy_shouldnotleak") mp) in
+    g.inv.f_ty
 
   let is_abstract_fun f env =
     let f = norm_xfun env f in
@@ -3558,26 +3589,29 @@ module LDecl = struct
   let fresh_ids hyps s = snd (fresh_ids (tohyps hyps) s)
 
   (* ------------------------------------------------------------------ *)
-  let push_active m lenv =
-    { lenv with le_env = Memory.push_active m lenv.le_env }
+  let push_active_ss m lenv =
+    { lenv with le_env = Memory.push_active_ss m lenv.le_env }
+
+  let push_active_ts ml mr lenv =
+    { lenv with le_env = Memory.push_active_ts ml mr lenv.le_env }
 
   let push_all l lenv =
     { lenv with le_env = Memory.push_all l lenv.le_env }
 
-  let hoareF xp lenv =
-     let env1, env2 = Fun.hoareF xp lenv.le_env in
+  let hoareF mem xp lenv =
+     let env1, env2 = Fun.hoareF mem xp lenv.le_env in
     { lenv with le_env = env1}, {lenv with le_env = env2 }
 
-  let equivF xp1 xp2 lenv =
-    let env1, env2 = Fun.equivF xp1 xp2 lenv.le_env in
+  let equivF ml mr xp1 xp2 lenv =
+    let env1, env2 = Fun.equivF ml mr xp1 xp2 lenv.le_env in
     { lenv with le_env = env1}, {lenv with le_env = env2 }
 
-  let inv_memenv lenv =
-    { lenv with le_env = Fun.inv_memenv lenv.le_env }
+  let inv_memenv ml mr lenv =
+    { lenv with le_env = Fun.inv_memenv ml mr lenv.le_env }
 
-  let inv_memenv1 lenv =
-    { lenv with le_env = Fun.inv_memenv1 lenv.le_env }
+  let inv_memenv1 m lenv =
+    { lenv with le_env = Fun.inv_memenv1 m lenv.le_env }
 end
 
 
-let pp_debug_form = ref (fun _env _fmt _f -> assert false)
+let pp_debug_form = ref (fun _env _f -> assert false)

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -64,16 +64,20 @@ type meerror =
 exception MEError of meerror
 
 module Memory : sig
-  val all         : env -> memenv list
-  val set_active  : memory -> env -> env
-  val get_active  : env -> memory option
+  val all           : env -> memenv list
+  val set_active_ss : memory -> env -> env
+  val get_active_ss : env -> memory option
+  val set_active_ts : memory -> memory -> env -> env
+  val get_active_ts : env -> (memory * memory) option
 
-  val byid        : memory -> env -> memenv option
-  val lookup      : symbol -> env -> memenv option
-  val current     : env -> memenv option
-  val push        : memenv -> env -> env
-  val push_all    : memenv list -> env -> env
-  val push_active : memenv -> env -> env
+  val byid          : memory -> env -> memenv option
+  val lookup        : symbol -> env -> memenv option
+  val current_ss    : env -> memenv option
+  val current_ts    : env -> (memenv * memenv) option
+  val push          : memenv -> env -> env
+  val push_all      : memenv list -> env -> env
+  val push_active_ss: memenv -> env -> env
+  val push_active_ts: memenv -> memenv -> env -> env
 end
 
 (* -------------------------------------------------------------------- *)
@@ -93,29 +97,27 @@ module Fun : sig
   val add   : xpath -> env -> env
 
   (* ------------------------------------------------------------------ *)
-  val prF_memenv : EcMemory.memory -> xpath -> env -> memenv
+  val prF_memenv : memory -> xpath -> env -> memenv
 
-  val prF : xpath -> env -> env
+  val prF : memory -> xpath -> env -> env
 
-  val hoareF_memenv : xpath -> env -> memenv * memenv
+  val hoareF_memenv : memory -> xpath -> env -> memenv * memenv
 
-  val hoareF : xpath -> env -> env * env
+  val hoareF : memory -> xpath -> env -> env * env
 
-  val hoareS : xpath -> env -> memenv * (funsig * function_def) * env
+  val hoareS : memory -> xpath -> env -> memenv * (funsig * function_def) * env
 
   val actmem_body :  memory -> function_ -> (funsig * function_def) * memenv
   val actmem_post :  memory -> function_ -> memenv
 
-  val inv_memory : [`Left|`Right] -> memenv
+  val inv_memenv : memory -> memory -> env -> env
 
-  val inv_memenv : env -> env
-
-  val equivF_memenv : xpath -> xpath -> env ->
+  val equivF_memenv : memory -> memory -> xpath -> xpath -> env ->
     (memenv * memenv) * (memenv * memenv)
 
-  val equivF : xpath -> xpath -> env -> env * env
+  val equivF : memory -> memory -> xpath -> xpath -> env -> env * env
 
-  val equivS : xpath -> xpath -> env ->
+  val equivS : memory -> memory -> xpath -> xpath -> env ->
     memenv * (funsig * function_def) * memenv * (funsig * function_def) * env
 end
 
@@ -246,7 +248,7 @@ module NormMp : sig
 
   val flatten_use : use -> EcIdent.t list * (xpath * ty) list
 
-  val norm_glob     : env -> EcMemory.memory -> mpath -> form
+  val norm_glob     : env -> EcMemory.memory -> mpath -> ss_inv
   val norm_tglob    : env -> mpath -> EcTypes.ty
 
   val is_abstract_fun : xpath -> env -> bool
@@ -502,14 +504,15 @@ module LDecl : sig
 
   val clear : ?leniant:bool -> EcIdent.Sid.t -> hyps -> hyps
 
-  val push_all    : memenv list -> hyps -> hyps
-  val push_active : memenv -> hyps -> hyps
+  val push_all       : memenv list -> hyps -> hyps
+  val push_active_ss : memenv -> hyps -> hyps
+  val push_active_ts : memenv -> memenv -> hyps -> hyps
 
-  val hoareF : xpath -> hyps -> hyps * hyps
-  val equivF : xpath -> xpath -> hyps -> hyps * hyps
+  val hoareF : memory -> xpath -> hyps -> hyps * hyps
+  val equivF : memory -> memory -> xpath -> xpath -> hyps -> hyps * hyps
 
-  val inv_memenv  : hyps -> hyps
-  val inv_memenv1 : hyps -> hyps
+  val inv_memenv  : memory -> memory -> hyps -> hyps
+  val inv_memenv1 : memory -> hyps -> hyps
 end
 
-val pp_debug_form : (env -> Format.formatter -> form -> unit) ref
+val pp_debug_form : (env -> form -> unit) ref

--- a/src/ecFol.mli
+++ b/src/ecFol.mli
@@ -1,8 +1,7 @@
 (* -------------------------------------------------------------------- *)
 open EcBigInt
 open EcPath
-open EcTypes
-open EcMemory
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 include module type of struct include EcCoreFol end
@@ -20,15 +19,30 @@ val f_eqparams:
   -> EcTypes.ty -> ovariable list -> memory
   -> form
 
+val ts_inv_eqparams:
+     EcTypes.ty -> ovariable list -> memory
+  -> EcTypes.ty -> ovariable list -> memory
+  -> ts_inv
+
 val f_eqres:
      EcTypes.ty -> memory
   -> EcTypes.ty -> memory
   -> form
 
+val ts_inv_eqres:
+     EcTypes.ty -> memory
+  -> EcTypes.ty -> memory
+  -> ts_inv
+
 val f_eqglob:
      mpath -> memory
   -> mpath -> memory
   -> form
+
+val ts_inv_eqglob:
+     mpath -> memory
+  -> mpath -> memory
+  -> ts_inv
 
 (* soft-constructors - ordering *)
 val f_int_le  : form -> form -> form
@@ -93,7 +107,7 @@ val f_dmap : ty -> ty -> form -> form -> form
 (* common functions *)
 val f_identity : ?name:EcSymbols.symbol -> EcTypes.ty -> form
 
-val split_sided : memory -> form -> form option
+val split_sided : memory -> ts_inv -> ss_inv option
 val one_sided_vs : memory -> form -> form list
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -1725,8 +1725,8 @@ let process_generalize1 ?(doeq = false) pattern (tc : tcenv1) =
               let newconcl =
                 concl |> FPosition.map ptnpos (fun f ->
                   match f.f_node with
-                  | Fglob (a, _) -> f_glob a m'
-                  | Fpvar (p, _) -> f_pvar p f.f_ty m'
+                  | Fglob (a, _) -> (f_glob a m').inv
+                  | Fpvar (p, _) -> (f_pvar p f.f_ty m').inv
                   | Fpr   pr     -> f_pr_r { pr with pr_mem = m' }
                   | _            -> assert false
                 ) in

--- a/src/ecHiTacticals.ml
+++ b/src/ecHiTacticals.ml
@@ -6,6 +6,7 @@ open EcParsetree
 open EcCoreGoal
 open EcCoreGoal.FApi
 open EcHiGoal
+open EcAst
 
 module TTC = EcProofTyping
 
@@ -81,7 +82,7 @@ and process1_case (_ : ttenv) (doeq, opts, gp) (tc : tcenv1) =
     match (FApi.tc1_goal tc).f_node with
     | FbdHoareS _ | FhoareS _ | FeHoareS _ when not opts.cod_ambient ->
         let _, fp = TTC.tc1_process_Xhl_formula tc (form_of_gp ()) in
-        EcPhlCase.t_hl_case fp tc
+        EcPhlCase.t_hl_case (Inv_ss fp) tc
 
     | FequivS _ when not opts.cod_ambient ->
         let fp = TTC.tc1_process_prhl_formula tc (form_of_gp ()) in

--- a/src/ecLowGoal.mli
+++ b/src/ecLowGoal.mli
@@ -351,3 +351,15 @@ val t_solve :
   -> ?mode:EcMatching.fmoptions
   -> ?depth:int
   -> FApi.backward
+
+val t_debug :
+    ?tag:string (* for distinguishing prints *)
+  -> FApi.backward
+  -> FApi.backward
+  [@@ocaml.alert debug "Debug function, remove uses before merging"]
+
+val pp_tc :tcenv -> unit
+  [@@ocaml.alert debug "Debug function, remove uses before merging"]
+
+val pp_tc1 :tcenv1 -> unit
+  [@@ocaml.alert debug "Debug function, remove uses before merging"]

--- a/src/ecPV.mli
+++ b/src/ecPV.mli
@@ -1,11 +1,8 @@
 (* -------------------------------------------------------------------- *)
 open EcMaps
 open EcPath
-open EcTypes
-open EcModules
-open EcMemory
 open EcEnv
-open EcFol
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 type alias_clash =
@@ -158,9 +155,10 @@ module Mpv2 : sig
   val empty_local : local
   val enter_local: env -> local -> (EcIdent.t * ty) list ->
                    (EcIdent.t * ty) list -> local
-  val to_form : EcIdent.t -> EcIdent.t -> t -> form -> form
-  val of_form : env -> EcIdent.t -> EcIdent.t -> form -> t
-  val needed_eq : env -> EcIdent.t -> EcIdent.t -> form -> t
+  val to_form_ts_inv : t -> ts_inv -> ts_inv
+  val to_form : t -> memory -> memory -> form -> form
+  val of_form : env -> ts_inv -> t
+  val needed_eq : env -> ts_inv -> t
   val union   : t -> t -> t
   val subset   : t -> t -> bool
   val equal    : t -> t -> bool

--- a/src/ecProcSem.ml
+++ b/src/ecProcSem.ml
@@ -82,8 +82,8 @@ let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
      let tyb = body.e_ty in
 
      let aout =
-       let d    = form_of_expr mhr d in
-       let body = form_of_expr mhr body in
+       let d    = form_of_expr d in
+       let body = form_of_expr body in
        let body =
          let arg  = EcIdent.create "arg" in
          let body = f_let lv (f_local arg tya) body in
@@ -93,7 +93,7 @@ let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
        | `Det   -> f_dmap tya tyb d body
        | `Distr -> f_dlet_simpl tya (oget (as_tdistr tyb)) d body
 
-     in (`Distr, expr_of_form mhr aout)
+     in (`Distr, expr_of_form aout)
     end
 
   | Sif (e, bt, bf) ->
@@ -143,7 +143,7 @@ let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
           (cmode, e_let lv (e_if e bt bf) c)
 
        | `Distr, `Det ->
-          let body = form_of_expr mhr (e_if e bt bf) in
+          let body = form_of_expr (e_if e bt bf) in
           let tya  = oget (as_tdistr body.f_ty) in
           let v    = EcIdent.create "v" in
           let vx   = f_local v tya in
@@ -154,12 +154,12 @@ let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
               body
               (f_lambda
                  [v, GTty tya]
-                 (f_let lv vx (form_of_expr mhr c)))
+                 (f_let lv vx (form_of_expr c)))
 
-          in (`Distr, expr_of_form mhr aout)
+          in (`Distr, expr_of_form aout)
 
        | `Distr, `Distr ->
-          let body = form_of_expr mhr (e_if e bt bf) in
+          let body = form_of_expr (e_if e bt bf) in
           let tya  = oget (as_tdistr body.f_ty) in
           let tyb  = oget (as_tdistr c.e_ty) in
           let v    = EcIdent.create "v" in
@@ -171,9 +171,9 @@ let rec translate_i (env : senv) (cont : senv -> mode * expr) (i : instr) =
               body
               (f_lambda
                  [v, GTty tya]
-                 (f_let lv vx (form_of_expr mhr c)))
+                 (f_let lv vx (form_of_expr c)))
 
-          in (`Distr, expr_of_form mhr aout)
+          in (`Distr, expr_of_form aout)
 
      end
 
@@ -346,13 +346,13 @@ and translate_forloop (env : senv) (cont : senv -> mode * expr) (s : stmt) =
        | ids ->
           LTuple ids in
 
-     let niter = form_of_expr mhr (translate_e env bd) in
+     let niter = form_of_expr (translate_e env bd) in
      let niter = f_proj_simpl (f_int_edivz_simpl niter (f_int inc)) 0 tint in
      let rem   = f_proj_simpl (f_int_edivz_simpl niter (f_int inc)) 1 tint in
      let outv  = f_int_add_simpl (f_int_mul_simpl niter (f_int inc)) rem in
 
-     let niter = expr_of_form mhr niter in
-     let outv  = expr_of_form mhr outv in
+     let niter = expr_of_form niter in
+     let outv  = expr_of_form outv in
 
      let mode, aout =
        match mode with
@@ -395,11 +395,11 @@ and translate_forloop (env : senv) (cont : senv -> mode * expr) (s : stmt) =
           let aout =
             ctor
               aty c.e_ty
-              (form_of_expr mhr aout)
+              (form_of_expr aout)
               (f_lambda
                  [(arg, GTty aty)]
-                 (f_let lv (f_local arg aty) (form_of_expr mhr c))) in
-          (`Distr, expr_of_form mhr aout)
+                 (f_let lv (f_local arg aty) (form_of_expr c))) in
+          (`Distr, expr_of_form aout)
 
      in Some (mode, e_let (LSymbol (x, tint)) outv aout)
 

--- a/src/ecProofTyping.mli
+++ b/src/ecProofTyping.mli
@@ -1,14 +1,11 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
 open EcIdent
-open EcTypes
-open EcFol
 open EcDecl
-open EcModules
 open EcEnv
 open EcCoreGoal
-open EcMemory
 open EcMatching.Position
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 type ptnenv = ty Mid.t * EcUnify.unienv
@@ -46,22 +43,21 @@ val tc1_process_exp      : tcenv1 -> [`InProc|`InOp] -> ty option -> pexpr -> ex
 val tc1_process_pattern  : tcenv1 -> pformula -> ptnenv * form
 
 (* Same as previous functions, but for *HL contexts *)
-val tc1_process_Xhl_form     : ?side:side -> tcenv1 -> ty -> pformula -> memenv * form
-val tc1_process_Xhl_formula  : ?side:side -> tcenv1 -> pformula -> memenv * form
-val tc1_process_Xhl_formula_xreal : tcenv1 -> pformula -> memenv * form
+val tc1_process_Xhl_form     : ?side:side -> tcenv1 -> ty -> pformula -> memtype * ss_inv
+val tc1_process_Xhl_formula  : ?side:side -> tcenv1 -> pformula -> memtype * ss_inv
+val tc1_process_Xhl_formula_xreal : tcenv1 -> pformula -> memtype * ss_inv
 
 val tc1_process_Xhl_exp      : tcenv1 -> oside -> ty option -> pexpr -> expr
 
-val tc1_process_prhl_form_opt: tcenv1 -> ty option -> pformula -> form
-val tc1_process_prhl_form    : tcenv1 -> ty -> pformula -> form
-val tc1_process_prhl_formula : tcenv1 -> pformula -> form
-
-val tc1_process_stmt :
-     ?map:EcTyping.ismap -> tcenv1 -> EcMemory.memtype
-  -> pstmt -> stmt
+val tc1_process_prhl_form_opt: tcenv1 -> ty option -> pformula -> ts_inv
+val tc1_process_prhl_form    : tcenv1 -> ty -> pformula -> ts_inv
+val tc1_process_prhl_formula : tcenv1 -> pformula -> ts_inv
 
 val tc1_process_prhl_stmt :
      ?map:EcTyping.ismap -> tcenv1 -> side -> pstmt -> stmt
+
+val tc1_process_Xhl_stmt :
+     ?map:EcTyping.ismap -> tcenv1 -> pstmt -> stmt
 
 val tc1_process_codepos_range : tcenv1 -> oside * pcodepos_range -> codepos_range
 val tc1_process_codepos : tcenv1 -> oside * pcodepos -> codepos

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -1,10 +1,10 @@
 (* -------------------------------------------------------------------- *)
 open EcIdent
 open EcPath
-open EcTypes
 open EcFol
 open EcModules
 open EcEnv
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 exception IncompatibleType of env * (ty * ty)
@@ -35,7 +35,7 @@ module EqTest : sig
   val is_int  : env -> ty -> bool
 end
 
-val is_alpha_eq : LDecl.hyps -> form -> form -> bool
+val is_alpha_eq : ?subst:f_subst -> LDecl.hyps -> form -> form -> bool
 
 (* -------------------------------------------------------------------- *)
 module User : sig
@@ -107,3 +107,6 @@ val check_bindings :
 type xconv = [`Eq | `AlphaEq | `Conv]
 
 val xconv : xconv -> LDecl.hyps -> form -> form -> bool
+
+val ss_inv_alpha_eq : LDecl.hyps -> ss_inv -> ss_inv -> bool
+val ts_inv_alpha_eq : LDecl.hyps -> ts_inv -> ts_inv -> bool

--- a/src/ecSection.ml
+++ b/src/ecSection.ml
@@ -219,66 +219,66 @@ let rec on_form (cb : cb) (f : EcFol.form) =
     | EcAst.Fpr       pr           -> on_pr  cb pr
 
   and on_hf cb hf =
-    on_form cb hf.EcAst.hf_pr;
-    on_form cb hf.EcAst.hf_po;
+    on_form cb (hf_pr hf).inv;
+    on_form cb (hf_po hf).inv;
     on_xp cb hf.EcAst.hf_f
 
   and on_hs cb hs =
-    on_form cb hs.EcAst.hs_pr;
-    on_form cb hs.EcAst.hs_po;
+    on_form cb (hs_pr hs).inv;
+    on_form cb (hs_po hs).inv;
     on_stmt cb hs.EcAst.hs_s;
     on_memenv cb hs.EcAst.hs_m
 
   and on_ef cb ef =
-    on_form cb ef.EcAst.ef_pr;
-    on_form cb ef.EcAst.ef_po;
+    on_form cb (EcAst.ef_pr ef).inv;
+    on_form cb (EcAst.ef_po ef).inv;
     on_xp cb ef.EcAst.ef_fl;
     on_xp cb ef.EcAst.ef_fr
 
   and on_es cb es =
-    on_form cb es.EcAst.es_pr;
-    on_form cb es.EcAst.es_po;
+    on_form cb (EcAst.es_pr es).inv;
+    on_form cb (EcAst.es_po es).inv;
     on_stmt cb es.EcAst.es_sl;
     on_stmt cb es.EcAst.es_sr;
     on_memenv cb es.EcAst.es_ml;
     on_memenv cb es.EcAst.es_mr
 
   and on_eg cb eg =
-    on_form cb eg.EcAst.eg_pr;
-    on_form cb eg.EcAst.eg_po;
+    on_form cb (EcAst.eg_pr eg).inv;
+    on_form cb (EcAst.eg_po eg).inv;
     on_xp cb eg.EcAst.eg_fl;
     on_xp cb eg.EcAst.eg_fr;
     on_stmt cb eg.EcAst.eg_sl;
     on_stmt cb eg.EcAst.eg_sr;
 
   and on_ehf cb hf =
-    on_form cb hf.EcAst.ehf_pr;
-    on_form cb hf.EcAst.ehf_po;
+    on_form cb (EcAst.ehf_pr hf).inv;
+    on_form cb (EcAst.ehf_po hf).inv;
     on_xp cb hf.EcAst.ehf_f
 
   and on_ehs cb hs =
-    on_form cb hs.EcAst.ehs_pr;
-    on_form cb hs.EcAst.ehs_po;
+    on_form cb (EcAst.ehs_pr hs).inv;
+    on_form cb (EcAst.ehs_po hs).inv;
     on_stmt cb hs.EcAst.ehs_s;
     on_memenv cb hs.EcAst.ehs_m
 
   and on_bhf cb bhf =
-    on_form cb bhf.EcAst.bhf_pr;
-    on_form cb bhf.EcAst.bhf_po;
-    on_form cb bhf.EcAst.bhf_bd;
+    on_form cb (EcAst.bhf_pr bhf).inv;
+    on_form cb (EcAst.bhf_po bhf).inv;
+    on_form cb (EcAst.bhf_bd bhf).inv;
     on_xp cb bhf.EcAst.bhf_f
 
   and on_bhs cb bhs =
-    on_form cb bhs.EcAst.bhs_pr;
-    on_form cb bhs.EcAst.bhs_po;
-    on_form cb bhs.EcAst.bhs_bd;
+    on_form cb (EcAst.bhs_pr bhs).inv;
+    on_form cb (EcAst.bhs_po bhs).inv;
+    on_form cb (EcAst.bhs_bd bhs).inv;
     on_stmt cb bhs.EcAst.bhs_s;
     on_memenv cb bhs.EcAst.bhs_m
 
 
   and on_pr cb pr =
     on_xp cb pr.EcAst.pr_fun;
-    List.iter (on_form cb) [pr.EcAst.pr_event; pr.EcAst.pr_args]
+    List.iter (on_form cb) [pr.EcAst.pr_event.inv; pr.EcAst.pr_args]
 
   in
     on_ty cb f.EcAst.f_ty; fornode ()

--- a/src/ecSubst.mli
+++ b/src/ecSubst.mli
@@ -74,7 +74,24 @@ val subst_stmt  : subst -> stmt -> stmt
 val subst_progvar : subst -> prog_var -> prog_var
 val subst_mem : subst -> EcIdent.t -> EcIdent.t
 val subst_flocal : subst -> form -> form
+val subst_ss_inv : subst -> ss_inv -> ss_inv
+val subst_ts_inv : subst -> ts_inv -> ts_inv
+val subst_inv : subst -> inv -> inv
 
 (* -------------------------------------------------------------------- *)
 val open_oper : operator -> ty list -> ty * operator_kind
 val open_tydecl : tydecl -> ty list -> ty_body
+
+(* -------------------------------------------------------------------- *)
+val ss_inv_rebind : ss_inv -> memory -> ss_inv
+val ss_inv_generalize_as_left : ss_inv -> memory -> memory -> ts_inv
+val ss_inv_generalize_as_right : ss_inv -> memory -> memory -> ts_inv
+val f_forall_mems_ss_inv : memenv -> ss_inv -> form
+
+val ts_inv_rebind : ts_inv -> memory -> memory -> ts_inv
+val ts_inv_rebind_left : ts_inv -> memory -> ts_inv
+val ts_inv_rebind_right : ts_inv -> memory -> ts_inv
+val f_forall_mems_ts_inv : memenv -> memenv -> ts_inv -> form
+
+val ss_inv_forall_ml_ts_inv : memenv -> ts_inv -> ss_inv
+val ss_inv_forall_mr_ts_inv : memenv -> ts_inv -> ss_inv

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -124,8 +124,8 @@ let tydecl_compatible env tyd1 tyd2 =
 
 (* -------------------------------------------------------------------- *)
 let expr_compatible exn env s e1 e2 =
-  let f1 = EcFol.form_of_expr EcFol.mhr e1 in
-  let f2 = EcSubst.subst_form s (EcFol.form_of_expr EcFol.mhr e2) in
+  let f1 = EcFol.form_of_expr e1 in
+  let f2 = (EcSubst.subst_form s) (EcFol.form_of_expr e2) in
   error_body exn (EcReduction.is_conv ~ri:ri_compatible (EcEnv.LDecl.init env []) f1 f2)
 
 let get_open_oper exn env p tys =
@@ -533,7 +533,7 @@ and replay_opd (ove : _ ovrenv) (subst, ops, proofs, scope) (import, x, oopd) =
           | `Inline _ ->
               let body =
                 try
-                  EcFol.expr_of_form EcFol.mhr body
+                  EcFol.expr_of_form body
                 with EcFol.CannotTranslate ->
                   clone_error env (CE_InlinedOpIsForm (snd ove.ovre_prefix, x))
               in

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -13,10 +13,6 @@ open EcFol
 open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
-type wp = EcEnv.env -> EcMemory.memenv -> stmt -> EcFol.form -> EcFol.form option
-val  wp : wp option ref
-
-(* -------------------------------------------------------------------- *)
 type opmatch = [
   | `Op   of EcPath.path * EcTypes.ty list
   | `Lc   of EcIdent.t

--- a/src/ecUtils.ml
+++ b/src/ecUtils.ml
@@ -175,6 +175,8 @@ let pair_equal tx ty (x1, y1) (x2, y2) =
 
 let swap (x, y) = (y, x)
 
+let flip f x y = f y x
+
 (* -------------------------------------------------------------------- *)
 module Option = BatOption
 

--- a/src/ecUtils.mli
+++ b/src/ecUtils.mli
@@ -99,6 +99,8 @@ val snd_map : ('b -> 'c) -> 'a * 'b -> 'a * 'c
 
 val swap: 'a * 'b -> 'b * 'a
 
+val flip: ('a -> 'b -> 'c) -> 'b -> 'a -> 'c
+
 (* -------------------------------------------------------------------- *)
 type 'a eq  = 'a -> 'a -> bool
 type 'a cmp = 'a -> 'a -> int

--- a/src/phl/ecPhlApp.mli
+++ b/src/phl/ecPhlApp.mli
@@ -1,16 +1,16 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
 open EcMatching.Position
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_hoare_app   : codepos1 -> form -> backward
-val t_ehoare_app  : codepos1 -> form -> backward
-val t_bdhoare_app : codepos1 -> form tuple6 -> backward
-val t_equiv_app   : codepos1 pair -> form -> backward
-val t_equiv_app_onesided : side -> codepos1 -> form -> form -> backward
+val t_hoare_app   : codepos1 -> ss_inv -> backward
+val t_ehoare_app  : codepos1 -> ss_inv -> backward
+val t_bdhoare_app : codepos1 -> ss_inv tuple6 -> backward
+val t_equiv_app   : codepos1 pair -> ts_inv -> backward
+val t_equiv_app_onesided : side -> codepos1 -> ss_inv -> ss_inv -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_app : app_info -> backward

--- a/src/phl/ecPhlAuto.ml
+++ b/src/phl/ecPhlAuto.ml
@@ -2,6 +2,7 @@
 open EcUtils
 open EcFol
 open EcModules
+open EcAst
 
 open EcCoreGoal
 open EcLowGoal
@@ -18,15 +19,15 @@ let t_exfalso_r tc =
   FApi.t_or
     EcPhlTAuto.t_core_exfalso
     (FApi.t_seqsub
-       (EcPhlConseq.t_conseq f_false post)
+       (EcPhlConseq.t_conseq (map_inv1 (fun _ -> f_false) post) post)
        [t_id; t_trivial; EcPhlTAuto.t_core_exfalso])
     tc
 
 let t_exfalso = FApi.t_low0 "exfalso" t_exfalso_r
 
 (* -------------------------------------------------------------------- *)
-let prnd_info =
-  EcParsetree.PSingleRndParam f_predT
+let prnd_info m =
+  EcParsetree.PSingleRndParam (fun ty -> {m;inv=f_predT ty})
 
 (* -------------------------------------------------------------------- *)
 let t_auto_rnd_hoare_r tc =
@@ -37,7 +38,7 @@ let t_auto_rnd_bdhoare_r tc =
   let hs = tc1_as_bdhoareS tc in
 
   match List.olast hs.bhs_s.s_node with
-  | Some { i_node = Srnd _ } -> EcPhlRnd.t_bdhoare_rnd prnd_info tc
+  | Some { i_node = Srnd _ } -> EcPhlRnd.t_bdhoare_rnd (prnd_info (fst hs.bhs_m)) tc
   | _ -> tc_noauto_error !!tc ()
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlBdHoare.ml
+++ b/src/phl/ecPhlBdHoare.ml
@@ -18,20 +18,20 @@ let t_hoare_bd_hoare tc =
 
   match concl.f_node with
   | FbdHoareF bhf ->
-    if   bhf.bhf_cmp = FHeq && f_equal bhf.bhf_bd f_r0
+    if   bhf.bhf_cmp = FHeq && f_equal (bhf_bd bhf).inv f_r0
     then t_hoare_of_bdhoareF tc
     else
       FApi.t_seqsub
-        (t_bdHoareF_conseq_bd FHeq f_r0)
+        (t_bdHoareF_conseq_bd FHeq {m=bhf.bhf_m; inv=f_r0})
         [FApi.t_try EcPhlAuto.t_pl_trivial; t_hoare_of_bdhoareF]
         tc
 
   | FbdHoareS bhs ->
-    if   bhs.bhs_cmp = FHeq && f_equal bhs.bhs_bd f_r0
+    if   bhs.bhs_cmp = FHeq && f_equal (bhs_bd bhs).inv f_r0
     then t_hoare_of_bdhoareS tc
     else
       FApi.t_seqsub
-        (t_bdHoareS_conseq_bd FHeq f_r0)
+        (t_bdHoareS_conseq_bd FHeq {m=fst bhs.bhs_m; inv=f_r0})
         [FApi.t_try EcPhlAuto.t_pl_trivial; t_hoare_of_bdhoareS]
         tc
 
@@ -42,13 +42,13 @@ let t_hoare_bd_hoare tc =
 
 (* -------------------------------------------------------------------- *)
 type 'a split_t = {
-  as_bdh : proofenv -> form -> 'a * form * hoarecmp * form;
-  mk_bdh : 'a * form * hoarecmp * form -> form;
+  as_bdh : proofenv -> form -> 'a * ss_inv * hoarecmp * ss_inv;
+  mk_bdh : 'a * ss_inv * hoarecmp * ss_inv -> form;
 }
 
 type 'a destr_t = {
-  as_bop : proofenv -> form -> form * form;
-  mk_bop : form -> form -> form;
+  as_bop : proofenv -> ss_inv -> ss_inv * ss_inv;
+  mk_bop : ss_inv -> ss_inv -> ss_inv;
 }
 
 (* -------------------------------------------------------------------- *)
@@ -60,19 +60,19 @@ let t_bdhoare_split_bop sp dt b1 b2 b3 tc =
   let g1 = sp.mk_bdh (bh, a, cmp, b1) in
   let g2 = sp.mk_bdh (bh, b, cmp, b2) in
   let g3 = sp.mk_bdh (bh, dt.mk_bop a b, hoarecmp_opp cmp, b3) in
-  let nb = f_real_sub (f_real_add b1 b2) b3 in
+  let nb = map_ss_inv2 f_real_sub (map_ss_inv2 f_real_add b1 b2) b3 in
 
-  assert (f_equal nb bd);
+  assert (f_equal nb.inv bd.inv);
   FApi.xmutate1 tc `BdHoareSplit [g1; g2; g3]
 
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_split_bop_conseq t_conseq_bd sp dt b1 b2 b3 tc =
   let concl = FApi.tc1_goal tc in
   let _, _, cmp, b = sp.as_bdh !!tc concl in
-  let nb = f_real_sub (f_real_add b1 b2) b3 in
+  let nb = map_ss_inv2 f_real_sub (map_ss_inv2 f_real_add b1 b2) b3 in
   let t_main = t_bdhoare_split_bop sp dt b1 b2 b3 in
 
-  if   f_equal nb b
+  if   f_equal nb.inv b.inv
   then t_main tc
   else FApi.t_seqsub (t_conseq_bd cmp nb) [t_id; t_main] tc
 
@@ -87,10 +87,10 @@ let bdhoare_kind tc =
 let gen_S tactic =
   let as_bdh pf f =
     let bh = pf_as_bdhoareS pf f in
-      (bh, bh.bhs_po, bh.bhs_cmp, bh.bhs_bd)
+      (bh, (bhs_po bh), bh.bhs_cmp, bhs_bd bh)
 
   and mk_bdh (bh, po, cmp, b) =
-    f_bdHoareS_r { bh with bhs_po = po; bhs_cmp = cmp; bhs_bd = b; } in
+    f_bdHoareS (snd bh.bhs_m) (bhs_pr bh) bh.bhs_s po cmp b in
 
   tactic t_bdHoareS_conseq_bd { as_bdh; mk_bdh; }
 
@@ -98,21 +98,24 @@ let gen_S tactic =
 let gen_F tactic =
   let as_bdh pf f =
     let bh = pf_as_bdhoareF pf f in
-      (bh, bh.bhf_po, bh.bhf_cmp, bh.bhf_bd)
+      (bh, (bhf_po bh), bh.bhf_cmp, bhf_bd bh) in
 
-  and mk_bdh (bh, po, cmp, b) =
-    f_bdHoareF bh.bhf_pr bh.bhf_f po cmp b in
+  let mk_bdh (bh, po, cmp, b) =
+    f_bdHoareF (bhf_pr bh) bh.bhf_f po cmp b in
 
   tactic t_bdHoareF_conseq_bd { as_bdh; mk_bdh; }
 
 (* -------------------------------------------------------------------- *)
 let and_dt =
   let destr_and pf f =
-    try  destr_and f
+    try 
+      let f1 = map_ss_inv1 (fun f -> fst (destr_and f)) f in
+      let f2 = map_ss_inv1 (fun f -> snd (destr_and f)) f in
+      (f1, f2)
     with DestrError _ ->
       tc_error pf "the postcondition must be a conjunction"
   in
-    { as_bop = destr_and; mk_bop = f_or; }
+    { as_bop = destr_and; mk_bop = map_ss_inv2 f_or; }
 
 let t_bdhoareS_and = gen_S t_bdhoare_split_bop_conseq and_dt
 let t_bdhoareF_and = gen_F t_bdhoare_split_bop_conseq and_dt
@@ -125,11 +128,14 @@ let t_bdhoare_and b1 b2 b3 tc =
 (* -------------------------------------------------------------------- *)
 let or_dt =
   let destr_or pf f =
-    try  destr_or f
+    try 
+      let f1 = map_ss_inv1 (fun f -> fst (destr_or f)) f in
+      let f2 = map_ss_inv1 (fun f -> snd (destr_or f)) f in
+      (f1, f2)
     with DestrError _ ->
       tc_error pf "the postcondition must be a disjunction"
   in
-    { as_bop = destr_or; mk_bop = f_and; }
+    { as_bop = destr_or; mk_bop = map_ss_inv2 f_and; }
 
 let t_bdhoareS_or = gen_S t_bdhoare_split_bop_conseq or_dt
 let t_bdhoareF_or = gen_F t_bdhoare_split_bop_conseq or_dt
@@ -142,19 +148,20 @@ let t_bdhoare_or b1 b2 b3 tc =
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_split_not split b1 b2 tc =
   let bh, po, cmp, bd = split.as_bdh !!tc (FApi.tc1_goal tc) in
-  let g1 = split.mk_bdh (bh, f_true, cmp, b1) in
-  let g2 = split.mk_bdh (bh, f_not_simpl po, hoarecmp_opp cmp, b2) in
-  let nb = f_real_sub b1 b2 in
+  let g1 = split.mk_bdh (bh, map_ss_inv1 (fun _ -> f_true) po, cmp, b1) in
+  let g2 = split.mk_bdh (bh, map_ss_inv1 f_not_simpl po, hoarecmp_opp cmp, b2) in
+  let nb = map_ss_inv2 f_real_sub b1 b2 in
 
-  assert (f_equal nb bd);
+  assert (f_equal nb.inv bd.inv);
   FApi.xmutate1 tc `BdHoareSplit [g1; g2]
 
 let t_bdhoare_split_not_conseq t_conseq_bd split b1 b2 tc =
+  let hyps = FApi.tc1_hyps tc in
   let _, _, cmp, b = split.as_bdh !!tc (FApi.tc1_goal tc) in
-  let nb = f_real_sub b1 b2 in
+  let nb = map_ss_inv2 f_real_sub b1 b2 in
   let t_main = t_bdhoare_split_not split b1 b2  in
 
-  if   f_equal nb b
+  if EcReduction.ss_inv_alpha_eq hyps nb b
   then t_main tc
   else FApi.t_seqsub (t_conseq_bd cmp nb) [t_id; t_main] tc
 

--- a/src/phl/ecPhlBdHoare.mli
+++ b/src/phl/ecPhlBdHoare.mli
@@ -1,9 +1,9 @@
 (* -------------------------------------------------------------------- *)
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_bdhoare_and    : form -> form -> form -> backward
-val t_bdhoare_or     : form -> form -> form -> backward
-val t_bdhoare_not    : form -> form -> backward
+val t_bdhoare_and    : ss_inv -> ss_inv -> ss_inv -> backward
+val t_bdhoare_or     : ss_inv -> ss_inv -> ss_inv -> backward
+val t_bdhoare_not    : ss_inv -> ss_inv -> backward
 val t_hoare_bd_hoare : backward

--- a/src/phl/ecPhlCall.ml
+++ b/src/phl/ecPhlCall.ml
@@ -7,6 +7,7 @@ open EcModules
 open EcFol
 open EcEnv
 open EcPV
+open EcSubst
 
 open EcCoreGoal
 open EcLowGoal
@@ -16,44 +17,46 @@ module PT  = EcProofTerm
 module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
-let wp_asgn_call env m lv res post =
+let wp_asgn_call ?mc env lv res post =
+  assert (res.m = post.m);
+  let m = post.m in
   match lv with
   | None -> post
   | Some lv ->
-      let lets = lv_subst m lv res in
-      mk_let_of_lv_substs env ([lets], post)
+      let lets = lv_subst m lv res.inv in
+      {m;inv=mk_let_of_lv_substs ?mc env ([lets], post.inv)}
 
 let subst_args_call env m e s =
-  PVM.add env pv_arg m (form_of_expr m e) s
+  PVM.add env pv_arg m (ss_inv_of_expr m e).inv s
 
 (* -------------------------------------------------------------------- *)
 let wp2_call
-  env fpre fpost (lpl,fl,argsl) modil (lpr,fr,argsr) modir ml mr post hyps
+  env fpre fpost (lpl,fl,argsl) modil (lpr,fr,argsr) modir post hyps
 =
+  let ml, mr = post.ml, post.mr in
   let fsigl = (Fun.by_xpath fl env).f_sig in
   let fsigr = (Fun.by_xpath fr env).f_sig in
   (* The wp *)
   let pvresl = pv_res and pvresr = pv_res in
   let vresl = LDecl.fresh_id hyps "result_L" in
   let vresr = LDecl.fresh_id hyps "result_R" in
-  let fresl = f_local vresl fsigl.fs_ret in
-  let fresr = f_local vresr fsigr.fs_ret in
-  let post = wp_asgn_call env ml lpl fresl post in
-  let post = wp_asgn_call env mr lpr fresr post in
+  let fresl = {ml;mr; inv=f_local vresl fsigl.fs_ret} in
+  let fresr = {ml;mr; inv=f_local vresr fsigr.fs_ret} in
+  let post = map_ts_inv_left2 (wp_asgn_call ~mc:(ml,mr) env lpl) fresl post in
+  let post = map_ts_inv_right2 (wp_asgn_call ~mc:(ml,mr) env lpr) fresr post in
   let s    = PVM.empty in
-  let s    = PVM.add env pvresr mr fresr s in
-  let s    = PVM.add env pvresl ml fresl s in
-  let fpost = PVM.subst env s fpost in
-  let post = generalize_mod env mr modir (f_imp_simpl fpost post) in
-  let post = generalize_mod env ml modil post in
-  let post =
-    f_forall_simpl
+  let s    = PVM.add env pvresr mr fresr.inv s in
+  let s    = PVM.add env pvresl ml fresl.inv s in
+  let fpost = map_ts_inv1 (PVM.subst env s) fpost in
+  let post = generalize_mod_ts_inv env modil modir (map_ts_inv2 f_imp_simpl fpost post) in
+  let post = map_ts_inv1
+    (f_forall_simpl
       [(vresl, GTty fsigl.fs_ret);
-       (vresr, GTty fsigr.fs_ret)]
+       (vresr, GTty fsigr.fs_ret)])
       post in
   let spre = subst_args_call env ml (e_tuple argsl) PVM.empty in
   let spre = subst_args_call env mr (e_tuple argsr) spre in
-  f_anda_simpl (PVM.subst env spre fpre) post
+  map_ts_inv2 f_anda_simpl (map_ts_inv1 (PVM.subst env spre) fpre) post
 
 (* -------------------------------------------------------------------- *)
 let t_hoare_call fpre fpost tc =
@@ -64,18 +67,21 @@ let t_hoare_call fpre fpost tc =
   let fsig = (Fun.by_xpath f env).f_sig in
   (* The function satisfies the specification *)
   let f_concl = f_hoareF fpre f fpost in
+  (* substitute memories *)
+  let fpre = (ss_inv_rebind fpre m) in
+  let fpost = (ss_inv_rebind fpost m) in
   (* The wp *)
   let pvres = pv_res in
   let vres = EcIdent.create "result" in
-  let fres = f_local vres fsig.fs_ret in
-  let post = wp_asgn_call env m lp fres hs.hs_po in
-  let fpost = PVM.subst1 env pvres m fres fpost in
+  let fres = {m;inv=f_local vres fsig.fs_ret} in
+  let post = wp_asgn_call env lp fres (hs_po hs) in
+  let fpost = map_ss_inv2 (PVM.subst1 env pvres m) fres fpost in
   let modi = f_write env f in
-  let post = generalize_mod env m modi (f_imp_simpl fpost post) in
-  let post = f_forall_simpl [(vres, GTty fsig.fs_ret)] post in
+  let post = generalize_mod_ss_inv env modi (map_ss_inv2 f_imp_simpl fpost post) in
+  let post = map_ss_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) post in
   let spre = subst_args_call env m (e_tuple args) PVM.empty in
-  let post = f_anda_simpl (PVM.subst env spre fpre) post in
-  let concl = f_hoareS_r { hs with hs_s = s; hs_po=post} in
+  let post = map_ss_inv2 f_anda_simpl (map_ss_inv1 (PVM.subst env spre) fpre) post in
+  let concl = f_hoareS (snd hs.hs_m) (hs_pr hs) s post in
 
   FApi.xmutate1 tc `HlCall [f_concl; concl]
 
@@ -86,6 +92,8 @@ let ehoare_call_pre_post fpre fpost tc =
   let hs = tc1_as_ehoareS tc in
   let (lp,f,args),s = tc1_last_call tc hs.ehs_s in
   let m = EcMemory.memory hs.ehs_m in
+  let fpre = ss_inv_rebind fpre m in
+  let fpost = ss_inv_rebind fpost m in
   (* Ensure that all asigned variables are locals *)
   let all_loc =
     match lp with
@@ -99,17 +107,17 @@ let ehoare_call_pre_post fpre fpost tc =
     match lp with
     | None -> None
     | Some (LvVar (v,ty)) -> Some (f_pvar v ty m)
-    | Some (LvTuple vs) -> Some (f_tuple (List.map (fun (v,ty) -> f_pvar v ty m) vs)) in
+    | Some (LvTuple vs) -> Some (map_ss_inv f_tuple (List.map (fun (v,ty) -> f_pvar v ty m) vs)) in
   let pvres = pv_res in
   let wppost =
-    omap_dfl (fun fres -> PVM.subst1 env pvres m fres fpost) fpost fres in
-  let fv = PV.fv env m wppost in
+    omap_dfl (fun fres -> map_ss_inv2 (PVM.subst1 env pvres m) fres fpost) fpost fres in
+  let fv = PV.fv env m wppost.inv in
   if PV.mem_pv env pv_res fv then
     tc_error !!tc
       "ehoare call core rule: the post condition of the function depend on res but the result is not assigned";
 
   let spre = subst_args_call env m (e_tuple args) PVM.empty in
-  let wppre = PVM.subst env spre fpre in
+  let wppre = map_ss_inv1 (PVM.subst env spre) fpre in
   hyps, env, hs, s, f, wppre, wppost
 
 
@@ -117,17 +125,17 @@ let t_ehoare_call_core fpre fpost tc =
   let hyps, env, hs, s, f, wppre, wppost = ehoare_call_pre_post fpre fpost tc in
   if not (List.is_empty s.s_node) then
     tc_error !!tc  "ehoare call core rule: only single call statements are accepted";
-  if not (EcReduction.is_conv hyps hs.ehs_po wppost) then
-    (let env = EcEnv.Memory.push_active hs.ehs_m env in
+  if not (EcReduction.ss_inv_alpha_eq hyps (ehs_po hs) wppost) then
+    (let env = EcEnv.Memory.push_active_ss hs.ehs_m env in
      let ppe  = EcPrinting.PPEnv.ofenv env in
      tc_error !!tc "ehoare call core rule: wrong post-condition %a instead %a"
-       (EcPrinting.pp_form ppe) hs.ehs_po (EcPrinting.pp_form ppe) wppost);
+       (EcPrinting.pp_form ppe) (ehs_po hs).inv (EcPrinting.pp_form ppe) wppost.inv);
 
-  if not (EcReduction.is_conv hyps hs.ehs_pr wppre) then
-    (let env = EcEnv.Memory.push_active hs.ehs_m env in
+  if not (EcReduction.ss_inv_alpha_eq hyps (ehs_pr hs) wppre) then
+    (let env = EcEnv.Memory.push_active_ss hs.ehs_m env in
      let ppe  = EcPrinting.PPEnv.ofenv env in
      tc_error !!tc "ehoare call core rule: wrong pre-condition %a instead %a"
-       (EcPrinting.pp_form ppe) hs.ehs_pr (EcPrinting.pp_form ppe) wppre);
+       (EcPrinting.pp_form ppe) (ehs_pr hs).inv (EcPrinting.pp_form ppe) wppre.inv);
 
   (* The function satisfies the specification *)
   let f_concl = f_eHoareF fpre f fpost in
@@ -144,7 +152,8 @@ let t_ehoare_call fpre fpost tc =
 let t_ehoare_call_concave f fpre fpost tc =
   let _, _, _, s, _, wppre, wppost = ehoare_call_pre_post fpre fpost tc in
   let tcenv =
-    EcPhlApp.t_ehoare_app (EcMatching.Zipper.cpos (List.length s.s_node)) (f_app_simpl f [wppre] txreal) tc in
+    EcPhlApp.t_ehoare_app (EcMatching.Zipper.cpos (List.length s.s_node)) 
+     (map_ss_inv2 (fun wppre f -> f_app_simpl f [wppre] txreal) wppre f) tc in
   let tcenv = FApi.t_swap_goals 0 1 tcenv in
   let t_call =
     FApi.t_seqsub (EcPhlConseq.t_ehoareS_concave f wppre wppost)
@@ -174,52 +183,55 @@ let t_bdhoare_call fpre fpost opt_bd tc =
   let env = FApi.tc1_env tc in
   let bhs = tc1_as_bdhoareS tc in
   let (lp,f,args),s = tc1_last_call tc bhs.bhs_s in
-  let m = EcMemory.memory bhs.bhs_m in
+  let m =  fpre.m in
   let fsig = (Fun.by_xpath f env).f_sig in
+  let bhs_bd = ss_inv_rebind (bhs_bd bhs) m in
+  let bhs_po = ss_inv_rebind (bhs_po bhs) m in
+  let bhs_pr = ss_inv_rebind (bhs_pr bhs) m in
+
+  (* The function satisfies the specification *)
   let f_concl =
-    bdhoare_call_spec !!tc fpre fpost f bhs.bhs_cmp bhs.bhs_bd opt_bd in
+    bdhoare_call_spec !!tc fpre fpost f bhs.bhs_cmp bhs_bd opt_bd in
 
   (* The wp *)
   let pvres = pv_res in
   let vres = EcIdent.create "result" in
-  let fres = f_local vres fsig.fs_ret in
-  let post = wp_asgn_call env m lp fres bhs.bhs_po in
-  let fpost = PVM.subst1 env pvres m fres fpost in
+  let fres = {m;inv=f_local vres fsig.fs_ret} in
+  let post = wp_asgn_call env lp fres bhs_po in
+  let fpost = map_ss_inv2 (PVM.subst1 env pvres m) fres fpost in
   let modi = f_write env f in
   let post =
     match bhs.bhs_cmp with
-    | FHle -> f_imp_simpl   post fpost
-    | FHge -> f_imp_simpl  fpost  post
+    | FHle -> map_ss_inv2 f_imp_simpl   post fpost
+    | FHge -> map_ss_inv2 f_imp_simpl  fpost  post
 
-    | FHeq when f_equal bhs.bhs_bd f_r0 ->
-        f_imp_simpl post fpost
+    | FHeq when f_equal bhs_bd.inv f_r0 ->
+        map_ss_inv2 f_imp_simpl post fpost
 
-    | FHeq when f_equal bhs.bhs_bd f_r1 ->
-        f_imp_simpl  fpost post
+    | FHeq when f_equal bhs_bd.inv f_r1 ->
+        map_ss_inv2 f_imp_simpl  fpost post
 
-    | FHeq -> f_iff_simpl fpost  post in
+    | FHeq -> map_ss_inv2 f_iff_simpl fpost  post in
 
-  let post = generalize_mod env m modi post in
-  let post = f_forall_simpl [(vres, GTty fsig.fs_ret)] post in
+  let post = generalize_mod_ss_inv env modi post in
+  let post = map_ss_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) post in
   let spre = subst_args_call env m (e_tuple args) PVM.empty in
-  let post = f_anda_simpl (PVM.subst env spre fpre) post in
+  let post = map_ss_inv2 f_anda_simpl (map_ss_inv1 (PVM.subst env spre) fpre) post in
 
   (* most of the above code is duplicated from t_hoare_call *)
-  let concl = match bhs.bhs_cmp, opt_bd with
+  let concl = 
+    let _,mt = bhs.bhs_m in
+    match bhs.bhs_cmp, opt_bd with
     | FHle, None ->
-        f_hoareS bhs.bhs_m bhs.bhs_pr s post
+        f_hoareS mt bhs_pr s post
     | FHeq, Some bd ->
-        f_bdHoareS_r { bhs with
-          bhs_s = s; bhs_po = post; bhs_bd = f_real_div bhs.bhs_bd bd; }
+        f_bdHoareS mt bhs_pr s post bhs.bhs_cmp (map_ss_inv2 f_real_div bhs_bd bd)
     | FHeq, None ->
-        f_bdHoareS_r { bhs with
-          bhs_s = s; bhs_po = post; bhs_bd = f_r1; }
+        f_bdHoareS mt bhs_pr s post bhs.bhs_cmp {m;inv=f_r1}
     | FHge, Some bd ->
-        f_bdHoareS_r { bhs with
-          bhs_s = s; bhs_po = post; bhs_bd = f_real_div bhs.bhs_bd bd; }
+        f_bdHoareS mt bhs_pr s post bhs.bhs_cmp (map_ss_inv2 f_real_div bhs_bd bd)
     | FHge, None ->
-        f_bdHoareS_r { bhs with
-          bhs_s = s; bhs_po = post; bhs_cmp = FHeq; bhs_bd = f_r1; }
+        f_bdHoareS mt bhs_pr s post FHeq {m;inv=f_r1}
     | _, _ -> assert false
   in
 
@@ -229,10 +241,12 @@ let t_bdhoare_call fpre fpost opt_bd tc =
 let t_equiv_call fpre fpost tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
   let es = tc1_as_equivS tc in
+  let ml, mr = fst es.es_ml, fst es.es_mr in
+  let fpre = ts_inv_rebind fpre ml mr in
+  let fpost = ts_inv_rebind fpost ml mr in
+
   let (lpl,fl,argsl),sl = tc1_last_call tc es.es_sl in
   let (lpr,fr,argsr),sr = tc1_last_call tc es.es_sr in
-  let ml = EcMemory.memory es.es_ml in
-  let mr = EcMemory.memory es.es_mr in
   (* The functions satisfy their specification *)
   let f_concl = f_equivF fpre fl fr fpost in
   let modil = f_write env fl in
@@ -241,10 +255,10 @@ let t_equiv_call fpre fpost tc =
   let post =
     wp2_call env fpre fpost
       (lpl,fl,argsl) modil (lpr,fr,argsr) modir
-      ml mr es.es_po hyps
+      (es_po es) hyps
   in
   let concl =
-    f_equivS_r { es with es_sl = sl; es_sr = sr; es_po = post; } in
+    f_equivS (snd es.es_ml) (snd es.es_mr) (es_pr es) sl sr post in
 
   FApi.xmutate1 tc `HlCall [f_concl; concl]
 
@@ -252,40 +266,50 @@ let t_equiv_call fpre fpost tc =
 let t_equiv_call1 side fpre fpost tc =
   let env = FApi.tc1_env tc in
   let equiv = tc1_as_equivS tc in
+  let ml, mr = fst equiv.es_ml, fst equiv.es_mr in
+  let mtl, mtr = snd equiv.es_ml, snd equiv.es_mr in
 
   let (me, stmt) =
     match side with
     | `Left  -> (EcMemory.memory equiv.es_ml, equiv.es_sl)
     | `Right -> (EcMemory.memory equiv.es_mr, equiv.es_sr)
   in
+  let wp_asgn_call_side env lv = sideif side
+    (map_ts_inv_left2 (wp_asgn_call ~mc:(ml,mr) env lv))
+    (map_ts_inv_right2 (wp_asgn_call ~mc:(ml,mr) env lv))
+  in
+  let generalize_mod_side = sideif side
+    generalize_mod_left generalize_mod_right in
+  let ss_inv_generalize_other_side inv = sideif side
+    (ss_inv_generalize_right inv mr) (ss_inv_generalize_left inv ml) in
 
   let (lp, f, args), fstmt = tc1_last_call tc stmt in
   let fsig = (Fun.by_xpath f env).f_sig in
 
   (* The function satisfies its specification *)
-  let fconcl = f_bdHoareF fpre f fpost FHeq f_r1 in
+  let fconcl = f_bdHoareF fpre f fpost FHeq {m=fpost.m; inv=f_r1} in
 
   (* WP *)
   let pvres  = pv_res in
   let vres   = LDecl.fresh_id (FApi.tc1_hyps tc) "result" in
-  let fres   = f_local vres fsig.fs_ret in
-  let post   = wp_asgn_call env me lp fres equiv.es_po in
-  let subst  = PVM.add env pvres me fres PVM.empty in
-  let msubst = Fsubst.f_bind_mem Fsubst.f_subst_id EcFol.mhr me in
-  let fpost  = PVM.subst env subst (Fsubst.f_subst msubst fpost) in
+  let fres   = {ml;mr;inv=f_local vres fsig.fs_ret} in
+  let post   = wp_asgn_call_side env lp fres (es_po equiv) in
+  let subst  = PVM.add env pvres me fres.inv PVM.empty in
+  let fpost  = ss_inv_generalize_other_side (ss_inv_rebind fpost me) in
+  let fpre   = ss_inv_generalize_other_side (ss_inv_rebind fpre me) in
+  let fpost  = map_ts_inv1 (PVM.subst env subst) fpost in
   let modi   = f_write env f in
-  let post   = f_imp_simpl fpost post in
-  let post   = generalize_mod env me modi post in
-  let post   = f_forall_simpl [(vres, GTty fsig.fs_ret)] post in
+  let post   = map_ts_inv2 f_imp_simpl fpost post in
+  let post   = generalize_mod_side env modi post in
+  let post   = map_ts_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) post in
   let spre   = PVM.empty in
   let spre   = subst_args_call env me (e_tuple args) spre in
   let post   =
-    f_anda_simpl (PVM.subst env spre (Fsubst.f_subst msubst fpre)) post in
+    map_ts_inv2 f_anda_simpl (map_ts_inv1 (PVM.subst env spre) fpre) post in
   let concl  =
     match side with
-    | `Left  -> { equiv with es_sl = fstmt; es_po = post; }
-    | `Right -> { equiv with es_sr = fstmt; es_po = post; } in
-  let concl  = f_equivS_r concl in
+    | `Left  -> f_equivS mtl mtr (es_pr equiv) fstmt equiv.es_sr post
+    | `Right -> f_equivS mtl mtr (es_pr equiv) equiv.es_sl fstmt post in
 
   FApi.xmutate1 tc `HlCall [fconcl; concl]
 
@@ -308,19 +332,19 @@ let t_call side ax tc =
       let (_, f, _), _ = tc1_last_call tc hs.hs_s in
       if not (EcEnv.NormMp.x_equal env hf.hf_f f) then
         call_error env tc hf.hf_f f;
-      t_hoare_call hf.hf_pr hf.hf_po tc
+      t_hoare_call (hf_pr hf) (hf_po hf) tc
 
   | FeHoareF hf, FeHoareS hs ->
       let (_, f, _), _ = tc1_last_call tc hs.ehs_s in
       if not (EcEnv.NormMp.x_equal env hf.ehf_f f) then
         call_error env tc hf.ehf_f f;
-      t_ehoare_call hf.ehf_pr hf.ehf_po tc
+      t_ehoare_call (ehf_pr hf) (ehf_po hf) tc
 
   | FbdHoareF hf, FbdHoareS hs ->
       let (_, f, _), _ = tc1_last_call tc hs.bhs_s in
       if not (EcEnv.NormMp.x_equal env hf.bhf_f f) then
         call_error env tc hf.bhf_f f;
-      t_bdhoare_call hf.bhf_pr hf.bhf_po None tc
+      t_bdhoare_call (bhf_pr hf) (bhf_po hf) None tc
 
   | FequivF ef, FequivS es ->
       let (_, fl, _), _ = tc1_last_call tc es.es_sl in
@@ -336,7 +360,7 @@ let t_call side ax tc =
               (EcPrinting.pp_funname ppe) ef.ef_fr
               (EcPrinting.pp_funname ppe) fl
               (EcPrinting.pp_funname ppe) fr);
-      t_equiv_call ef.ef_pr ef.ef_po tc
+      t_equiv_call (ef_pr ef) (ef_po ef) tc
 
   | FbdHoareF hf, FequivS _ ->
       let side =
@@ -344,25 +368,26 @@ let t_call side ax tc =
         | None -> tc_error !!tc "call: a side {1|2} should be provided"
         | Some side -> side
       in
-        t_equiv_call1 side hf.bhf_pr hf.bhf_po tc
+        t_equiv_call1 side (bhf_pr hf) (bhf_po hf) tc
 
   | _, _ -> tc_error !!tc "call: invalid goal shape"
 
 (* -------------------------------------------------------------------- *)
 let mk_inv_spec (_pf : proofenv) env inv fl fr =
+  let ml, mr = inv.ml, inv.mr in
   match NormMp.is_abstract_fun fl env with
   | true ->
     let (topl, _, _, sigl),
       (topr, _, _  , sigr) = EcLowPhlGoal.abstract_info2 env fl fr in
-    let eqglob = f_eqglob topl mleft topr mright in
+    let eqglob = ts_inv_eqglob topl ml topr mr in
     let lpre = [eqglob;inv] in
     let eq_params =
-      f_eqparams
-        sigl.fs_arg sigl.fs_anames mleft
-        sigr.fs_arg sigr.fs_anames mright in
-    let eq_res = f_eqres sigl.fs_ret mleft sigr.fs_ret mright in
-    let pre    = f_ands (eq_params::lpre) in
-    let post   = f_ands [eq_res; eqglob; inv] in
+      ts_inv_eqparams
+        sigl.fs_arg sigl.fs_anames ml
+        sigr.fs_arg sigr.fs_anames mr in
+    let eq_res = ts_inv_eqres sigl.fs_ret ml sigr.fs_ret mr in
+    let pre    = map_ts_inv f_ands (eq_params::lpre) in
+    let post   = map_ts_inv f_ands [eq_res; eqglob; inv] in
       f_equivF pre fl fr post
 
   | false ->
@@ -376,33 +401,42 @@ let mk_inv_spec (_pf : proofenv) env inv fl fr =
 
       if not testty then raise EqObsInError;
       let eq_params =
-        f_eqparams
-          sigl.fs_arg sigl.fs_anames mleft
-          sigr.fs_arg sigr.fs_anames mright in
-      let eq_res = f_eqres sigl.fs_ret mleft sigr.fs_ret mright in
-      let pre = f_and eq_params inv in
-      let post = f_and eq_res inv in
+        ts_inv_eqparams
+          sigl.fs_arg sigl.fs_anames ml
+          sigr.fs_arg sigr.fs_anames mr in
+      let eq_res = ts_inv_eqres sigl.fs_ret ml sigr.fs_ret mr in
+      let pre = map_ts_inv2 f_and eq_params inv in
+      let post = map_ts_inv2 f_and eq_res inv in
         f_equivF pre fl fr post
 
 let process_call side info tc =
-  let process_spec tc side =
+  let process_spec tc side pre post =
     let (hyps, concl) = FApi.tc1_flat tc in
       match concl.f_node, side with
       | FhoareS hs, None ->
           let (_,f,_) = fst (tc1_last_call tc hs.hs_s) in
-          let penv, qenv = LDecl.hoareF f hyps in
-          (penv, qenv, tbool, fun pre post -> f_hoareF pre f post)
+          let m = (EcIdent.create "&hr") in
+          let penv, qenv = LDecl.hoareF m f hyps in
+          let pre  = TTC.pf_process_form !!tc penv tbool pre  in
+          let post = TTC.pf_process_form !!tc qenv tbool post in    
+          f_hoareF {m;inv=pre} f {m;inv=post}
 
       | FbdHoareS bhs, None ->
           let (_,f,_) = fst (tc1_last_call tc bhs.bhs_s) in
-          let penv, qenv = LDecl.hoareF f hyps in
-          (penv, qenv, tbool, fun pre post ->
-            bdhoare_call_spec !!tc pre post f bhs.bhs_cmp bhs.bhs_bd None)
+          let m = (EcIdent.create "&hr") in
+          let penv, qenv = LDecl.hoareF m f hyps in
+          let pre  = TTC.pf_process_form !!tc penv tbool pre  in
+          let post = TTC.pf_process_form !!tc qenv tbool post in
+          let bd = ss_inv_rebind (bhs_bd bhs) m in
+          bdhoare_call_spec !!tc {m;inv=pre} {m;inv=post} f bhs.bhs_cmp bd None
 
       | FeHoareS hs, None ->
           let (_,f,_) = fst (tc1_last_call tc hs.ehs_s) in
-          let penv, qenv = LDecl.hoareF f hyps in
-          (penv, qenv, txreal, fun pre post -> f_eHoareF pre f post)
+          let m = (EcIdent.create "&hr") in
+          let penv, qenv = LDecl.hoareF m f hyps in
+          let pre  = TTC.pf_process_form !!tc penv txreal pre  in
+          let post = TTC.pf_process_form !!tc qenv txreal post in   
+          f_eHoareF {m;inv=pre} f {m;inv=post}
 
       | FbdHoareS _, Some _
       | FhoareS  _, Some _ ->
@@ -411,44 +445,67 @@ let process_call side info tc =
       | FequivS es, None ->
           let (_,fl,_) = fst (tc1_last_call tc es.es_sl) in
           let (_,fr,_) = fst (tc1_last_call tc es.es_sr) in
-          let penv, qenv = LDecl.equivF fl fr hyps in
-          (penv, qenv, tbool, fun pre post -> f_equivF pre fl fr post)
+          let (ml, mr) = (EcIdent.create "&1", EcIdent.create "&2") in
+          let penv, qenv = LDecl.equivF ml mr fl fr hyps in
+          let pre  = TTC.pf_process_form !!tc penv tbool pre  in
+          let post = TTC.pf_process_form !!tc qenv tbool post in  
+          f_equivF {ml;mr;inv=pre} fl fr {ml;mr;inv=post}
 
       | FequivS es, Some side ->
           let fstmt = sideif side es.es_sl es.es_sr in
+          let m = sideif side (EcIdent.create "&1") (EcIdent.create "&2") in
           let (_,f,_) = fst (tc1_last_call tc fstmt) in
-          let penv, qenv = LDecl.hoareF f hyps in
-          (penv, qenv, tbool, fun pre post -> f_bdHoareF pre f post FHeq f_r1)
+          let penv, qenv = LDecl.hoareF m f hyps in
+          let pre  = TTC.pf_process_form !!tc penv tbool pre  in
+          let post = TTC.pf_process_form !!tc qenv tbool post in
+          f_bdHoareF {m;inv=pre} f {m;inv=post} FHeq {m;inv=f_r1}
 
       | _ -> tc_error !!tc "the conclusion is not a hoare or an equiv" in
 
-  let process_inv tc side =
+  let process_inv tc side inv =
     if not (is_none side) then
       tc_error !!tc "cannot specify side for call with invariants";
 
     let hyps, concl = FApi.tc1_flat tc in
     match concl.f_node with
     | FhoareS hs ->
+        let m = fst hs.hs_m in
         let (_,f,_) = fst (tc1_last_call tc hs.hs_s) in
-        let penv = LDecl.inv_memenv1 hyps in
-        (penv, tbool, fun inv -> f_hoareF inv f inv)
+        let me = EcMemory.abstract m in
+        let hyps = LDecl.push_active_ss me hyps in
+        let inv = TTC.pf_process_form !!tc hyps tbool inv in
+        let inv = {m; inv} in
+        (f_hoareF inv f inv, Inv_ss inv)
 
     | FeHoareS hs ->
+        let m = fst hs.ehs_m in
         let (_,f,_) = fst (tc1_last_call tc hs.ehs_s) in
-        let penv = LDecl.inv_memenv1 hyps in
-        (penv, txreal, fun inv -> f_eHoareF inv f inv)
+        let me = EcMemory.abstract m in
+        let hyps = LDecl.push_active_ss me hyps in
+        let inv = TTC.pf_process_form !!tc hyps txreal inv in
+        let inv = {m; inv} in
+        (f_eHoareF inv f inv, Inv_ss inv)
 
     | FbdHoareS bhs ->
+      let m = fst bhs.bhs_m in
       let (_,f,_) = fst (tc1_last_call tc bhs.bhs_s) in
-      let penv = LDecl.inv_memenv1 hyps in
-      (penv, tbool, fun inv -> bdhoare_call_spec !!tc inv inv f bhs.bhs_cmp bhs.bhs_bd None)
+      let me = EcMemory.abstract m in
+      let hyps = LDecl.push_active_ss me hyps in
+      let inv = TTC.pf_process_form !!tc hyps tbool inv in
+      let inv = {m; inv} in
+      let f = bdhoare_call_spec !!tc inv inv f bhs.bhs_cmp (bhs_bd bhs) None in
+      (f, Inv_ss inv)
 
     | FequivS es ->
+      let ml, mr = fst es.es_ml, fst es.es_mr in
       let (_,fl,_) = fst (tc1_last_call tc es.es_sl) in
       let (_,fr,_) = fst (tc1_last_call tc es.es_sr) in
-      let penv = LDecl.inv_memenv hyps in
+      let mel, mer = EcMemory.abstract ml, EcMemory.abstract mr in
+      let hyps = LDecl.push_active_ts mel mer hyps in
       let env  = LDecl.toenv hyps in
-      (penv, tbool, fun inv -> mk_inv_spec !!tc env inv fl fr)
+      let inv = TTC.pf_process_form !!tc hyps tbool inv in
+      let inv = {ml;mr; inv} in
+      (mk_inv_spec !!tc env inv fl fr, Inv_ts inv)
 
     | _ -> tc_error !!tc "the conclusion is not a hoare or an equiv" in
 
@@ -458,21 +515,24 @@ let process_call side info tc =
     let env, _, concl = FApi.tc1_eflat tc in
       match concl.f_node with
       | FequivS es ->
+        let ml, mr = fst es.es_ml, fst es.es_mr in
         let (_,fl,_) = fst (tc1_last_call tc es.es_sl) in
         let (_,fr,_) = fst (tc1_last_call tc es.es_sr) in
         let bad,invP,invQ = EcPhlFun.process_fun_upto_info info tc in
+        let bad2 = ss_inv_generalize_as_right bad ml mr in
+        let invP = ts_inv_rebind invP ml mr in
+        let invQ = ts_inv_rebind invQ ml mr in
         let (topl,fl,_,sigl),
             (topr,fr,_  ,sigr) = EcLowPhlGoal.abstract_info2 env fl fr in
-        let bad2 = Fsubst.f_subst_mem mhr mright bad in
-        let eqglob = f_eqglob topl mleft topr mright in
+        let eqglob = ts_inv_eqglob topl ml topr mr in
         let lpre = [eqglob;invP] in
         let eq_params =
-          f_eqparams
-            sigl.fs_arg sigl.fs_anames mleft
-            sigr.fs_arg sigr.fs_anames mright in
-        let eq_res = f_eqres sigl.fs_ret mleft sigr.fs_ret mright in
-        let pre    = f_if_simpl bad2 invQ (f_ands (eq_params::lpre)) in
-        let post   = f_if_simpl bad2 invQ (f_ands [eq_res;eqglob;invP]) in
+          ts_inv_eqparams
+            sigl.fs_arg sigl.fs_anames ml
+            sigr.fs_arg sigr.fs_anames mr in
+        let eq_res = ts_inv_eqres sigl.fs_ret ml sigr.fs_ret mr in
+        let pre    = map_ts_inv3 f_if_simpl bad2 invQ (map_ts_inv f_ands (eq_params::lpre)) in
+        let post   = map_ts_inv3 f_if_simpl bad2 invQ (map_ts_inv f_ands [eq_res;eqglob;invP]) in
         (bad,invP,invQ, f_equivF pre fl fr post)
 
     | _ -> tc_error !!tc "the conclusion is not an equiv" in
@@ -482,17 +542,12 @@ let process_call side info tc =
   let process_cut tc info =
     match info with
     | CI_spec (pre, post) ->
-      let penv,qenv,ty,fmake = process_spec tc side in
-      let pre  = TTC.pf_process_form !!tc penv ty pre  in
-      let post = TTC.pf_process_form !!tc qenv ty post in
-      fmake pre post
-
+      process_spec tc side pre post
     | CI_inv inv ->
-      let hyps, ty, fmake = process_inv tc side in
-      let inv = TTC.pf_process_form !!tc hyps ty inv in
+      let f, inv = process_inv tc side inv in
       subtactic := (fun tc ->
         FApi.t_firsts t_trivial 2 (EcPhlFun.t_fun inv tc));
-      fmake inv
+      f
 
     | CI_upto info ->
       let bad, p, q, form = process_upto tc side info in
@@ -532,28 +587,26 @@ let process_call_concave (fc, info) tc =
     let (hyps, concl) = FApi.tc1_flat tc in
     match concl.f_node  with
     | FeHoareS hs ->
-      let env = LDecl.push_active hs.ehs_m hyps in
-      TTC.pf_process_form !!tc env (tfun txreal txreal) fc
+      let env = LDecl.push_active_ss hs.ehs_m hyps in
+      {m=fst hs.ehs_m;inv=TTC.pf_process_form !!tc env (tfun txreal txreal) fc}
 
     | _ -> tc_error !!tc "the conclusion is not a ehoare" in
 
   let process_spec tc =
-    let (hyps, concl) = FApi.tc1_flat tc in
+    let _, concl = FApi.tc1_flat tc in
       match concl.f_node  with
       | FeHoareS hs ->
           let (_,f,_) = fst (tc1_last_call tc hs.ehs_s) in
-          let penv, qenv = LDecl.hoareF f hyps in
-          (penv, qenv, txreal, fun pre post -> f_eHoareF pre f post)
+          (txreal, fun pre post -> f_eHoareF pre f post)
 
       | _ -> tc_error !!tc "the conclusion is not a ehoare" in
 
   let process_inv tc =
-      let hyps, concl = FApi.tc1_flat tc in
+      let _, concl = FApi.tc1_flat tc in
     match concl.f_node with
     | FeHoareS hs ->
         let (_,f,_) = fst (tc1_last_call tc hs.ehs_s) in
-        let penv = LDecl.inv_memenv1 hyps in
-        (penv, txreal, fun inv -> f_eHoareF inv f inv)
+        (txreal, fun inv -> f_eHoareF inv f inv)
 
     | _ -> tc_error !!tc "the conclusion is not a ehoare" in
 
@@ -562,16 +615,16 @@ let process_call_concave (fc, info) tc =
   let process_cut tc info =
     match info with
     | CI_spec (pre, post) ->
-      let penv,qenv,ty,fmake = process_spec tc in
-      let pre  = TTC.pf_process_form !!tc penv ty pre  in
-      let post = TTC.pf_process_form !!tc qenv ty post in
+      let ty,fmake = process_spec tc in
+      let _, pre = TTC.tc1_process_Xhl_form tc ty pre in
+      let _, post = TTC.tc1_process_Xhl_form tc ty post in
       fmake pre post
 
     | CI_inv inv ->
-      let env, ty, fmake = process_inv tc in
-      let inv = TTC.pf_process_form !!tc env ty inv in
+      let ty, fmake = process_inv tc in
+      let _, inv = TTC.tc1_process_Xhl_form tc ty inv in
       subtactic := (fun tc ->
-        FApi.t_firsts t_trivial 2 (EcPhlFun.t_fun inv tc));
+        FApi.t_firsts t_trivial 2 (EcPhlFun.t_fun (Inv_ss inv) tc));
       fmake inv
 
     | _ ->
@@ -601,7 +654,7 @@ let process_call_concave (fc, info) tc =
       let (_, f, _), _ = tc1_last_call tc hs.ehs_s in
       if not (EcEnv.NormMp.x_equal env hf.ehf_f f) then
         call_error env tc hf.ehf_f f;
-      t_ehoare_call_concave fc hf.ehf_pr hf.ehf_po tc
+      t_ehoare_call_concave fc (ehf_pr hf) (ehf_po hf) tc
     | _, _ -> tc_error !!tc "call: invalid goal shape" in
 
   FApi.t_seqsub

--- a/src/phl/ecPhlCall.mli
+++ b/src/phl/ecPhlCall.mli
@@ -1,22 +1,22 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 val wp2_call :
-     EcEnv.env -> form -> form
+     EcEnv.env -> ts_inv -> ts_inv
   -> EcModules.lvalue option * EcPath.xpath * EcTypes.expr list
   -> EcPV.PV.t
   -> EcModules.lvalue option * EcPath.xpath * EcTypes.expr list
   -> EcPV.PV.t
-  -> EcMemory.memory -> EcMemory.memory -> form
-  -> EcEnv.LDecl.hyps -> form
+  -> ts_inv
+  -> EcEnv.LDecl.hyps -> ts_inv
 
-val t_hoare_call   : form -> form -> backward
-val t_bdhoare_call : form -> form -> form option -> backward
-val t_equiv_call   : form -> form -> backward
-val t_equiv_call1  : side -> form -> form -> backward
+val t_hoare_call   : ss_inv -> ss_inv -> backward
+val t_bdhoare_call : ss_inv -> ss_inv -> ss_inv option -> backward
+val t_equiv_call   : ts_inv -> ts_inv -> backward
+val t_equiv_call1  : side -> ss_inv -> ss_inv -> backward
 val t_call         : oside -> form -> backward
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlCase.ml
+++ b/src/phl/ecPhlCase.ml
@@ -2,39 +2,43 @@
 open EcFol
 open EcCoreGoal
 open EcLowPhlGoal
+open EcAst
 
 (* --------------------------------------------------------------------- *)
 let t_hoare_case_r ?(simplify = true) f tc =
   let fand = if simplify then f_and_simpl else f_and in
   let hs = tc1_as_hoareS tc in
-  let concl1 = f_hoareS_r { hs with hs_pr = fand hs.hs_pr f } in
-  let concl2 = f_hoareS_r { hs with hs_pr = fand hs.hs_pr (f_not f) } in
+  let mt = snd hs.hs_m in
+  let concl1 = f_hoareS mt (map_ss_inv2 fand (hs_pr hs) f) hs.hs_s (hs_po hs) in
+  let concl2 = f_hoareS mt (map_ss_inv2 fand (hs_pr hs) (map_ss_inv1 f_not f)) hs.hs_s (hs_po hs) in
   FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
 
 (* --------------------------------------------------------------------- *)
 let t_ehoare_case_r ?(simplify = true) f tc =
   let _ = simplify in
   let hs = tc1_as_ehoareS tc in
-  let concl1 = f_eHoareS_r { hs with ehs_pr = f_interp_ehoare_form f hs.ehs_pr } in
-  let concl2 = f_eHoareS_r { hs with ehs_pr = f_interp_ehoare_form (f_not f) hs.ehs_pr} in
+  let mt = snd hs.ehs_m in
+  let concl1 = f_eHoareS mt (map_ss_inv2 f_interp_ehoare_form f (ehs_pr hs)) hs.ehs_s (ehs_po hs) in
+  let concl2 = f_eHoareS mt (map_ss_inv2 f_interp_ehoare_form (map_ss_inv1 f_not f) (ehs_pr hs)) hs.ehs_s (ehs_po hs) in
   FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
 
 (* --------------------------------------------------------------------- *)
 let t_bdhoare_case_r ?(simplify = true) f tc =
   let fand = if simplify then f_and_simpl else f_and in
   let bhs = tc1_as_bdhoareS tc in
-  let concl1 = f_bdHoareS_r
-    { bhs with bhs_pr = fand bhs.bhs_pr f } in
-  let concl2 = f_bdHoareS_r
-    { bhs with bhs_pr = fand bhs.bhs_pr (f_not f) } in
+  let mt = snd bhs.bhs_m in
+  let concl1 = f_bdHoareS mt (map_ss_inv2 fand (bhs_pr bhs) f) bhs.bhs_s (bhs_po bhs) bhs.bhs_cmp (bhs_bd bhs) in
+  let concl2 = f_bdHoareS mt
+    (map_ss_inv2 fand (bhs_pr bhs) (map_ss_inv1 f_not f)) bhs.bhs_s (bhs_po bhs) bhs.bhs_cmp (bhs_bd bhs) in
   FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
 
 (* --------------------------------------------------------------------- *)
 let t_equiv_case_r ?(simplify = true) f tc =
   let fand = if simplify then f_and_simpl else f_and in
   let es = tc1_as_equivS tc in
-  let concl1 = f_equivS_r { es with es_pr = fand es.es_pr f } in
-  let concl2 = f_equivS_r { es with es_pr = fand es.es_pr (f_not f) } in
+  let mtl, mtr = snd es.es_ml, snd es.es_mr in
+  let concl1 = f_equivS mtl mtr (map_ts_inv2 fand (es_pr es) f) es.es_sl es.es_sr (es_po es) in
+  let concl2 = f_equivS mtl mtr (map_ts_inv2 fand (es_pr es) (map_ts_inv1 f_not f)) es.es_sl es.es_sr (es_po es) in
   FApi.xmutate1 tc (`HlCase f) [concl1; concl2]
 
 (* --------------------------------------------------------------------- *)
@@ -52,12 +56,23 @@ let t_equiv_case ?simplify =
 
 (* --------------------------------------------------------------------- *)
 let t_hl_case_r ?simplify f tc =
-  t_hS_or_bhS_or_eS
-    ~th:(t_hoare_case ?simplify f)
-    ~teh:(t_ehoare_case ?simplify f)
-    ~tbh:(t_bdhoare_case ?simplify f)
-    ~te:(t_equiv_case ?simplify f)
-    tc
+  match f with
+  | Inv_ss f ->
+    t_hS_or_bhS_or_eS
+      ~th:(t_hoare_case ?simplify f)
+      ~teh:(t_ehoare_case ?simplify f)
+      ~tbh:(t_bdhoare_case ?simplify f)
+      ~te:(fun _ -> tc_error !!tc "expecting a two sided formula")
+      tc
+  | Inv_ts f ->
+    let err _ =
+      tc_error !!tc "expecting a one sided formula" in
+    t_hS_or_bhS_or_eS
+      ~th:err
+      ~teh:err
+      ~tbh:err
+      ~te:(t_equiv_case ?simplify f)
+      tc
 
 (* -------------------------------------------------------------------- *)
 let t_hl_case ?simplify = FApi.t_low1 "hl-case" (t_hl_case_r ?simplify)

--- a/src/phl/ecPhlCase.mli
+++ b/src/phl/ecPhlCase.mli
@@ -1,10 +1,10 @@
 (* -------------------------------------------------------------------- *)
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_hoare_case   : ?simplify:bool -> form -> backward
-val t_bdhoare_case : ?simplify:bool -> form -> backward
-val t_equiv_case   : ?simplify:bool -> form -> backward
+val t_hoare_case   : ?simplify:bool -> ss_inv -> backward
+val t_bdhoare_case : ?simplify:bool -> ss_inv -> backward
+val t_equiv_case   : ?simplify:bool -> ts_inv -> backward
 
-val t_hl_case : ?simplify:bool -> form -> backward
+val t_hl_case : ?simplify:bool -> inv -> backward

--- a/src/phl/ecPhlCodeTx.ml
+++ b/src/phl/ecPhlCodeTx.ml
@@ -72,8 +72,8 @@ let t_kill_r side cpos olen tc =
             "code writes variables (%a) used by the post-condition"
             pp_of_name x
     end;
-
-    let kslconcl = EcFol.f_bdHoareS me f_true (stmt ks) f_true FHeq f_r1 in
+    let (m, mt) = me in
+    let kslconcl = EcFol.f_bdHoareS mt {m;inv=f_true} (stmt ks) {m;inv=f_true} FHeq {m;inv=f_r1} in
       (me, { zpr with Zpr.z_tail = tl; }, [kslconcl])
   in
 
@@ -155,23 +155,24 @@ let set_match_stmt (id : symbol) ((ue, mev, ptn) : _ * _ * form) =
 
     try
       let ptev = EcProofTerm.ptenv pe hyps (ue, mev) in
-      let e = form_of_expr (fst me) e in
-      let subf, occmode = EcProofTerm.pf_find_occurence_lazy ptev ~ptn e in
+      let e = ss_inv_of_expr (fst me) e in
+      let subf, occmode = EcProofTerm.pf_find_occurence_lazy ptev ~ptn e.inv in
+      let subf = {m=e.m; inv= subf} in
 
       assert (EcProofTerm.can_concretize ptev);
 
       let cpos =
         EcMatching.FPosition.select_form
           ~xconv:`AlphaEq ~keyed:occmode.k_keyed
-          hyps None subf e in
+          hyps None subf.inv e.inv in
 
-      let v = { ov_name = Some id; ov_type = subf.f_ty } in
+      let v = { ov_name = Some id; ov_type = subf.inv.f_ty } in
       let (me, id) = EcMemory.bind_fresh v me in
       let pv = pv_loc (oget id.ov_name) in
-      let e = EcMatching.FPosition.map cpos (fun _ -> f_pvar pv (subf.f_ty) (fst me)) e in
+      let e = map_ss_inv2 (fun pv -> EcMatching.FPosition.map cpos (fun _ -> pv)) (f_pvar pv (subf.inv.f_ty) (fst me)) e  in
 
-      let i1 = i_asgn (LvVar (pv, subf.f_ty), expr_of_form (fst me) subf) in
-      let i2 = mk (expr_of_form (fst me) e) in
+      let i1 = i_asgn (LvVar (pv, subf.inv.f_ty), expr_of_ss_inv subf) in
+      let i2 = mk (expr_of_ss_inv e) in
 
       (me, { z with z_tail = i1 :: i2 :: is }, [])
 
@@ -189,9 +190,9 @@ let cfold_stmt ?(simplify = true) (pf, hyps) (me : memenv) (olen : int option) (
 
   let simplify : expr -> expr =
     if simplify then (fun e ->
-      let e = form_of_expr (fst me) e in
-      let e = EcReduction.simplify EcReduction.nodelta hyps e in
-      let e = expr_of_form (fst me) e in
+      let e = ss_inv_of_expr (fst me) e in
+      let e = map_ss_inv1 (EcReduction.simplify EcReduction.nodelta hyps) e in
+      let e = expr_of_ss_inv e in
       e
     ) else identity in
 
@@ -360,7 +361,7 @@ let process_set (side, cpos, fresh, id, e) tc =
 let process_set_match (side, cpos, id, pattern) tc =
   let cpos = EcProofTyping.tc1_process_codepos tc (side, cpos) in
   let me, _ = tc1_get_stmt side tc in
-  let hyps = LDecl.push_active me (FApi.tc1_hyps tc) in
+  let hyps = LDecl.push_active_ss me (FApi.tc1_hyps tc) in
   let ue  = EcProofTyping.unienv_of_hyps hyps in
   let ptnmap = ref Mid.empty in
   let pattern = EcTyping.trans_pattern (LDecl.toenv hyps) ptnmap ue pattern in
@@ -395,27 +396,27 @@ let process_weakmem (side, id, params) tc =
   let h =
     match f.f_node with
     | FhoareS hs ->
-      let me = bind hs.hs_m in
-      f_hoareS_r { hs with hs_m = me }
+      let _, mt = bind hs.hs_m in
+      f_hoareS mt (hs_pr hs) hs.hs_s (hs_po hs)
 
     | FeHoareS hs ->
-      let me = bind hs.ehs_m in
-      f_eHoareS_r { hs with ehs_m = me }
+      let _, mt = bind hs.ehs_m in
+      f_eHoareS mt (ehs_pr hs) hs.ehs_s (ehs_po hs)
 
     | FbdHoareS hs ->
-      let me = bind hs.bhs_m in
-      f_bdHoareS_r { hs with bhs_m = me }
+      let _, mt = bind hs.bhs_m in
+      f_bdHoareS mt (bhs_pr hs) hs.bhs_s (bhs_po hs) hs.bhs_cmp (bhs_bd hs)
 
     | FequivS es ->
-      let do_side side es =
-        let es_ml, es_mr = if side = `Left then bind es.es_ml, es.es_mr else es.es_ml, bind es.es_mr in
-        {es with es_ml; es_mr}
+      let do_side side (ml, mr) =
+        let es_ml, es_mr = if side = `Left then bind ml, mr else ml, bind mr in
+        (es_ml, es_mr)
       in
-      let es =
+      let ((_, mtl), (_, mtr)) =
         match side with
-        | None -> do_side `Left (do_side `Right es)
-        | Some side -> do_side side es in
-      f_equivS_r es
+        | None -> do_side `Left (do_side `Right (es.es_ml, es.es_mr))
+        | Some side -> do_side side (es.es_ml, es.es_mr) in
+      f_equivS mtl mtr (es_pr es) es.es_sl es.es_sr (es_po es)
 
     | _ ->
       tc_error ~loc:id.pl_loc !!tc

--- a/src/phl/ecPhlCond.ml
+++ b/src/phl/ecPhlCond.ml
@@ -3,6 +3,7 @@ open EcUtils
 open EcTypes
 open EcFol
 open EcEnv
+open EcAst
 
 open EcCoreGoal
 open EcLowGoal
@@ -47,25 +48,26 @@ end
 let t_hoare_cond tc =
   let hs = tc1_as_hoareS tc in
   let (e,_,_) = fst (tc1_first_if tc hs.hs_s) in
-  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory hs.hs_m) e) tc
+  LowInternal.t_gen_cond None (Inv_ss (ss_inv_of_expr (EcMemory.memory hs.hs_m) e)) tc
 
 (* -------------------------------------------------------------------- *)
 let t_ehoare_cond tc =
   let hs = tc1_as_ehoareS tc in
   let (e,_,_) = fst (tc1_first_if tc hs.ehs_s) in
   LowInternal.t_gen_cond ~t_finalize:LowInternal.t_finalize_ehoare
-    None (form_of_expr (EcMemory.memory hs.ehs_m) e) tc
+    None (Inv_ss (ss_inv_of_expr (EcMemory.memory hs.ehs_m) e)) tc
 
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_cond tc =
   let bhs = tc1_as_bdhoareS tc in
   let (e,_,_) = fst (tc1_first_if tc bhs.bhs_s) in
-  LowInternal.t_gen_cond None (form_of_expr (EcMemory.memory bhs.bhs_m) e) tc
+  LowInternal.t_gen_cond None (Inv_ss (ss_inv_of_expr (EcMemory.memory bhs.bhs_m) e)) tc
 
 (* -------------------------------------------------------------------- *)
 let rec t_equiv_cond side tc =
   let hyps = FApi.tc1_hyps tc in
   let es   = tc1_as_equivS tc in
+  let ml, mr = fst es.es_ml, fst es.es_mr in
 
   match side with
   | Some s ->
@@ -73,21 +75,20 @@ let rec t_equiv_cond side tc =
         match s with
         | `Left ->
           let (e,_,_) = fst (tc1_first_if tc es.es_sl) in
-          form_of_expr (EcMemory.memory es.es_ml) e
+          ss_inv_generalize_right (ss_inv_of_expr ml e) mr
         | `Right ->
           let (e,_,_) = fst (tc1_first_if tc es.es_sr) in
-          form_of_expr (EcMemory.memory es.es_mr) e
-      in LowInternal.t_gen_cond side e tc
+          ss_inv_generalize_left (ss_inv_of_expr mr e) ml
+      in LowInternal.t_gen_cond side (Inv_ts e) tc
 
   | None ->
       let el,_,_ = fst (tc1_first_if tc es.es_sl) in
       let er,_,_ = fst (tc1_first_if tc es.es_sr) in
-      let el     = form_of_expr (EcMemory.memory es.es_ml) el in
-      let er     = form_of_expr (EcMemory.memory es.es_mr) er in
+      let el     = ss_inv_generalize_right (ss_inv_of_expr ml el) mr in
+      let er     = ss_inv_generalize_left (ss_inv_of_expr mr er) ml in
       let fiff   =
-        f_forall_mems
-          [es.es_ml;es.es_mr]
-          (f_imp es.es_pr (f_iff el er)) in
+        EcSubst.f_forall_mems_ts_inv es.es_ml es.es_mr
+          (map_ts_inv2 f_imp (es_pr es) (map_ts_inv2 f_iff el er)) in
 
       let fresh = ["hiff";"&m1";"&m2";"h";"h";"h"] in
       let fresh = LDecl.fresh_ids hyps fresh in
@@ -131,7 +132,17 @@ end = struct
     let (e, _), _ = tc1_first_match tc st in
     let _, indt, _ = oget (EcEnv.Ty.get_top_decl e.e_ty env) in
     let indt = oget (EcDecl.tydecl_as_datatype indt) in
-    let f = form_of_expr (EcMemory.memory me) e in
+    let f = 
+      let f = ss_inv_of_expr (EcMemory.memory me) e in
+      let pre = tc1_get_pre tc in
+      match pre, side with
+      | Inv_ts {mr}, Some `Left ->
+        Inv_ts (ss_inv_generalize_right f mr)
+      | Inv_ts {ml}, Some `Right ->
+        Inv_ts (ss_inv_generalize_left f ml)
+      | Inv_ss _, _ ->
+        Inv_ss f
+      | Inv_ts _, None -> tc_error !!tc "expecting a side" in
 
     let onsub (i : int) (tc : tcenv1) =
       let cname, cargs = List.nth indt.tydt_ctors i in
@@ -200,9 +211,12 @@ end = struct
 
         let pre = oget (EcLowPhlGoal.get_pre (FApi.tc1_goal tc)) in
         let post = oget (EcLowPhlGoal.get_post (FApi.tc1_goal tc)) in
-        let eq, _, pre = destr_and3 pre in
+
+        let pre = map_inv1 (fun pre -> 
+          let eq, _, pre = destr_and3 pre in
+          f_and eq pre) pre in
         tc
-          |> EcPhlConseq.t_conseq (f_and eq pre) post
+          |> EcPhlConseq.t_conseq pre post
           @+ [discharge_pre; discharge_post; EcLowGoal.t_clears names]
       in
 
@@ -238,6 +252,7 @@ let t_equiv_match_same_constr tc =
   let hyps = FApi.tc1_hyps tc in
   let env  = LDecl.toenv hyps in
   let es   = tc1_as_equivS tc in
+  let ml, mr = fst es.es_ml, fst es.es_mr in
 
   let (el, bsl), sl = tc1_first_match tc es.es_sl in
   let (er, bsr), sr = tc1_first_match tc es.es_sr in
@@ -249,44 +264,45 @@ let t_equiv_match_same_constr tc =
     tc_error !!tc "match statements on different inductive types";
 
   let dt = oget (EcDecl.tydecl_as_datatype dt) in
-  let fl = form_of_expr (EcMemory.memory es.es_ml) el in
-  let fr = form_of_expr (EcMemory.memory es.es_mr) er in
+  let fl = ss_inv_generalize_right (ss_inv_of_expr ml el) mr in
+  let fr = ss_inv_generalize_left (ss_inv_of_expr mr er) ml in
 
   let get_eqv_cond ((c, _), ((cl, _), (cr, _))) =
     let bhl  = List.map (fst_map EcIdent.fresh) cl in
     let bhr  = List.map (fst_map EcIdent.fresh) cr in
     let cop  = EcPath.pqoname (EcPath.prefix pl) c in
-    let copl = f_op cop tyl (toarrow (List.snd cl) fl.f_ty) in
-    let copr = f_op cop tyr (toarrow (List.snd cr) fr.f_ty) in
+    let copl = f_op cop tyl (toarrow (List.snd cl) fl.inv.f_ty) in
+    let copr = f_op cop tyr (toarrow (List.snd cr) fr.inv.f_ty) in
 
-    let lhs = f_eq fl (f_app copl (List.map (curry f_local) bhl) fl.f_ty) in
-    let lhs = f_exists (List.map (snd_map gtty) bhl) lhs in
+    let lhs = map_ts_inv1 (fun fl -> f_eq fl (f_app copl (List.map (curry f_local) bhl) fl.f_ty)) fl in
+    let lhs = map_ts_inv1 (f_exists (List.map (snd_map gtty) bhl)) lhs in
 
-    let rhs = f_eq fr (f_app copr (List.map (curry f_local) bhr) fr.f_ty) in
-    let rhs = f_exists (List.map (snd_map gtty) bhr) rhs in
+    let rhs = map_ts_inv1 (fun fr -> f_eq fr (f_app copr (List.map (curry f_local) bhr) fr.f_ty)) fr in
+    let rhs = map_ts_inv1 (f_exists (List.map (snd_map gtty) bhr)) rhs in
 
-    f_forall_mems [es.es_ml; es.es_mr] (f_imp_simpl es.es_pr (f_iff lhs rhs)) in
+    EcSubst.f_forall_mems_ts_inv es.es_ml es.es_mr 
+      (map_ts_inv2 f_imp_simpl (es_pr es) (map_ts_inv2 f_iff lhs rhs)) in
 
   let get_eqv_goal ((c, _), ((cl, bl), (cr, br))) =
     let sb      = Fsubst.f_subst_id in
     let sb, bhl = add_elocals sb cl in
     let sb, bhr = add_elocals sb cr in
     let cop     = EcPath.pqoname (EcPath.prefix pl) c in
-    let copl    = f_op cop tyl (toarrow (List.snd cl) fl.f_ty) in
-    let copr    = f_op cop tyr (toarrow (List.snd cr) fr.f_ty) in
-    let pre     = f_ands_simpl
-      [ f_eq fl (f_app copl (List.map (curry f_local) bhl) fl.f_ty);
-        f_eq fr (f_app copr (List.map (curry f_local) bhr) fr.f_ty) ]
-      es.es_pr in
+    let copl    = f_op cop tyl (toarrow (List.snd cl) fl.inv.f_ty) in
+    let copr    = f_op cop tyr (toarrow (List.snd cr) fr.inv.f_ty) in
+    let f_ands_simpl' f = f_ands_simpl (List.tl f) (List.hd f) in
+    let pre     = map_ts_inv f_ands_simpl'
+      [es_pr es; map_ts_inv1 (fun fl -> f_eq fl (f_app copl (List.map (curry f_local) bhl) fl.f_ty)) fl;
+        map_ts_inv1 (fun fr -> f_eq fr (f_app copr (List.map (curry f_local) bhr) fr.f_ty)) fr ]
+       in
 
     f_forall
       ( (List.map (snd_map gtty) bhl) @
         (List.map (snd_map gtty) bhr) )
-      ( f_equivS_r
-          { es with
-              es_sl = EcModules.stmt ((s_subst sb bl).s_node @ sl.s_node);
-              es_sr = EcModules.stmt ((s_subst sb br).s_node @ sr.s_node);
-              es_pr = pre; } )
+      ( f_equivS (snd es.es_ml) (snd es.es_mr) pre 
+        (EcModules.stmt ((s_subst sb bl).s_node @ sl.s_node)) 
+        (EcModules.stmt ((s_subst sb br).s_node @ sr.s_node))
+        (es_po es))
 
   in
 
@@ -303,6 +319,7 @@ let t_equiv_match_eq tc =
   let hyps = FApi.tc1_hyps tc in
   let env  = LDecl.toenv hyps in
   let es   = tc1_as_equivS tc in
+  let ml, mr = fst es.es_ml, fst es.es_mr in
 
   let (el, bsl), sl = tc1_first_match tc es.es_sl in
   let (er, bsr), sr = tc1_first_match tc es.es_sr in
@@ -317,12 +334,12 @@ let t_equiv_match_eq tc =
     tc_error !!tc "synced match requires matches on the same type";
 
   let dt = oget (EcDecl.tydecl_as_datatype dt) in
-  let fl = form_of_expr (EcMemory.memory es.es_ml) el in
-  let fr = form_of_expr (EcMemory.memory es.es_mr) er in
+  let fl = ss_inv_generalize_right (ss_inv_of_expr ml el) mr in
+  let fr = ss_inv_generalize_left (ss_inv_of_expr mr er) ml in
 
   let eqv_cond =
-    f_forall_mems [es.es_ml; es.es_mr]
-      (f_imp_simpl es.es_pr (f_eq fl fr)) in
+    EcSubst.f_forall_mems_ts_inv es.es_ml es.es_mr
+      (map_ts_inv2 f_imp_simpl (es_pr es) (map_ts_inv2 f_eq fl fr)) in
 
   let get_eqv_goal ((c, _), ((cl, bl), (cr, br))) =
     let sb     = f_subst_init () in
@@ -335,20 +352,19 @@ let t_equiv_match_eq tc =
         sb cl cr in
 
     let cop    = EcPath.pqoname (EcPath.prefix pl) c in
-    let copl   = f_op cop tyl (toarrow (List.snd cl) fl.f_ty) in
-    let copr   = f_op cop tyr (toarrow (List.snd cr) fr.f_ty) in
-    let pre    = f_ands_simpl
-      [ f_eq fl (f_app copl (List.map (curry f_local) bh) fl.f_ty);
-        f_eq fr (f_app copr (List.map (curry f_local) bh) fr.f_ty) ]
-      es.es_pr in
+    let copl   = f_op cop tyl (toarrow (List.snd cl) fl.inv.f_ty) in
+    let copr   = f_op cop tyr (toarrow (List.snd cr) fr.inv.f_ty) in
+    let f_ands_simpl' f = f_ands_simpl (List.tl f) (List.hd f) in
+    let pre    = map_ts_inv f_ands_simpl'
+      [ es_pr es; map_ts_inv1 (fun fl -> f_eq fl (f_app copl (List.map (curry f_local) bh) fl.f_ty)) fl;
+        map_ts_inv1 (fun fr -> f_eq fr (f_app copr (List.map (curry f_local) bh) fr.f_ty)) fr ] in
 
     f_forall
       (List.map (snd_map gtty) bh)
-      (f_equivS_r
-         { es with
-             es_sl = EcModules.stmt ((s_subst sb bl).s_node @ sl.s_node);
-             es_sr = EcModules.stmt ((s_subst sb br).s_node @ sr.s_node);
-             es_pr = pre; } )
+      (f_equivS (snd es.es_ml) (snd es.es_mr) pre
+        (EcModules.stmt ((s_subst sb bl).s_node @ sl.s_node))
+        (EcModules.stmt ((s_subst sb br).s_node @ sr.s_node))
+        (es_po es))
 
   in
 

--- a/src/phl/ecPhlConseq.ml
+++ b/src/phl/ecPhlConseq.ml
@@ -7,6 +7,8 @@ open EcModules
 open EcFol
 open EcEnv
 open EcPV
+open EcSubst
+open EcReduction
 
 open EcCoreGoal
 open EcLowGoal
@@ -16,9 +18,11 @@ module PT  = EcProofTerm
 module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
-let conseq_cond pre post spre spost =
-  f_imp pre spre, f_imp spost post
+let conseq_cond_ss pre post spre spost =
+  map_ss_inv2 f_imp pre spre, map_ss_inv2 f_imp spost post
 
+let conseq_cond_ts pre post spre spost =
+  map_ts_inv2 f_imp pre spre, map_ts_inv2 f_imp spost post
 
 (*
 { sF } c { sf }  sF <= F  f <= sf
@@ -26,15 +30,21 @@ let conseq_cond pre post spre spost =
 { F } c { f }
  *)
 let conseq_econd pre post spre spost =
-  f_xreal_le spre pre, f_xreal_le post spost
+  let spre = ss_inv_rebind spre pre.m in
+  let spost = ss_inv_rebind spost post.m in
+  map_ss_inv2 f_xreal_le spre pre, map_ss_inv2 f_xreal_le post spost
 
 let bd_goal_r fcmp fbd cmp bd =
   match fcmp, cmp with
-  | FHle, (FHle | FHeq) -> Some (f_real_le bd fbd)
-  | FHge, (FHge | FHeq) -> Some (f_real_le fbd bd)
-  | FHeq, FHeq          -> Some (f_eq bd fbd)
-  | FHeq, FHge          -> Some (f_and (f_eq fbd f_r1) (f_eq bd f_r1))
-  | FHeq, FHle          -> Some (f_and (f_eq fbd f_r0) (f_eq bd f_r0))
+  | FHle, (FHle | FHeq) -> Some (map_ss_inv2 f_real_le bd fbd)
+  | FHge, (FHge | FHeq) -> Some (map_ss_inv2 f_real_le fbd bd)
+  | FHeq, FHeq          -> Some (map_ss_inv2 f_eq bd fbd)
+  | FHeq, FHge          -> Some (map_ss_inv2 f_and 
+          (map_ss_inv1 ((EcUtils.flip f_eq) f_r1) fbd) 
+          (map_ss_inv1 ((EcUtils.flip f_eq) f_r1) bd))
+  | FHeq, FHle          -> Some (map_ss_inv2 f_and 
+          (map_ss_inv1 ((EcUtils.flip f_eq) f_r0) fbd) 
+          (map_ss_inv1 ((EcUtils.flip f_eq) f_r0) bd))
   | _   , _             -> None
 
 let bd_goal tc fcmp fbd cmp bd =
@@ -43,39 +53,43 @@ let bd_goal tc fcmp fbd cmp bd =
     let ppe = EcPrinting.PPEnv.ofenv (FApi.tc1_env tc) in
     tc_error !!tc
       "do not know how to change phoare[...]%s %a into phoare[...]%s %a"
-      (EcPrinting.string_of_hcmp fcmp) (EcPrinting.pp_form ppe) fbd
-      (EcPrinting.string_of_hcmp cmp) (EcPrinting.pp_form ppe) bd
+      (EcPrinting.string_of_hcmp fcmp) (EcPrinting.pp_form ppe) fbd.inv
+      (EcPrinting.string_of_hcmp cmp) (EcPrinting.pp_form ppe) bd.inv
   | Some fp -> fp
 
 (* -------------------------------------------------------------------- *)
 let t_hoareF_conseq pre post tc =
   let env = FApi.tc1_env tc in
   let hf  = tc1_as_hoareF tc in
-  let mpr,mpo = EcEnv.Fun.hoareF_memenv hf.hf_f env in
-  let cond1, cond2 = conseq_cond hf.hf_pr hf.hf_po pre post in
-  let concl1 = f_forall_mems [mpr] cond1 in
-  let concl2 = f_forall_mems [mpo] cond2 in
+  let pre = ss_inv_rebind pre hf.hf_m in
+  let post = ss_inv_rebind post hf.hf_m in
+  let mpr,mpo = EcEnv.Fun.hoareF_memenv hf.hf_m hf.hf_f env in
+  let cond1, cond2 = conseq_cond_ss (hf_pr hf) (hf_po hf) pre post in
+  let concl1 = f_forall_mems_ss_inv mpr cond1 in
+  let concl2 = f_forall_mems_ss_inv mpo cond2 in
   let concl3 = f_hoareF pre hf.hf_f post in
   FApi.xmutate1 tc `Conseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_hoareS_conseq pre post tc =
   let hs = tc1_as_hoareS tc in
-  let cond1, cond2 = conseq_cond hs.hs_pr hs.hs_po pre post in
-  let concl1 = f_forall_mems [hs.hs_m] cond1 in
-  let concl2 = f_forall_mems [hs.hs_m] cond2 in
-  let concl3 = f_hoareS_r { hs with hs_pr = pre; hs_po = post } in
+  let pre = ss_inv_rebind pre (fst hs.hs_m) in
+  let post = ss_inv_rebind post (fst hs.hs_m) in
+  let cond1, cond2 = conseq_cond_ss (hs_pr hs) (hs_po hs) pre post in
+  let concl1 = f_forall_mems_ss_inv hs.hs_m cond1 in
+  let concl2 = f_forall_mems_ss_inv hs.hs_m cond2 in
+  let concl3 = f_hoareS (snd hs.hs_m) pre hs.hs_s post in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_ehoareF_conseq pre post tc =
   let env = FApi.tc1_env tc in
   let hf  = tc1_as_ehoareF tc in
-  let mpr,mpo = EcEnv.Fun.hoareF_memenv hf.ehf_f env in
+  let mpr,mpo = EcEnv.Fun.hoareF_memenv hf.ehf_m hf.ehf_f env in
   let cond1, cond2 =
-    conseq_econd hf.ehf_pr hf.ehf_po pre post in
-  let concl1 = f_forall_mems [mpr] cond1 in
-  let concl2 = f_forall_mems [mpo] cond2 in
+    conseq_econd (ehf_pr hf) (ehf_po hf) pre post in
+  let concl1 = f_forall_mems_ss_inv mpr cond1 in
+  let concl2 = f_forall_mems_ss_inv mpo cond2 in
   let concl3 = f_eHoareF pre hf.ehf_f post in
   FApi.xmutate1 tc `Conseq [concl1; concl2; concl3]
 
@@ -83,59 +97,70 @@ let t_ehoareF_conseq pre post tc =
 let t_ehoareS_conseq pre post tc =
   let hs = tc1_as_ehoareS tc in
   let cond1, cond2 =
-    conseq_econd hs.ehs_pr hs.ehs_po pre post in
-  let concl1 = f_forall_mems [hs.ehs_m] cond1 in
-  let concl2 = f_forall_mems [hs.ehs_m] cond2 in
-  let concl3 = f_eHoareS_r { hs with ehs_pr = pre; ehs_po = post; } in
+    conseq_econd (ehs_pr hs) (ehs_po hs) pre post in
+  let concl1 = f_forall_mems_ss_inv hs.ehs_m cond1 in
+  let concl2 = f_forall_mems_ss_inv hs.ehs_m cond2 in
+  let concl3 = f_eHoareS (snd hs.ehs_m) pre hs.ehs_s post in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
+
 let bdHoare_conseq_conds cmp pr po new_pr new_po =
-  let cond1, cond2 = conseq_cond pr po new_pr new_po in
+  let cond1, cond2 = conseq_cond_ss pr po new_pr new_po in
   let cond2 = match cmp with
-    | FHle -> f_imp po new_po
-    | FHeq -> f_iff po new_po
+    | FHle -> map_ss_inv2 f_imp po new_po
+    | FHeq -> map_ss_inv2 f_iff po new_po
     | FHge -> cond2
   in
   cond1, cond2
 
+(* -------------------------------------------------------------------- *)
+
 let t_bdHoareF_conseq pre post tc =
   let env = FApi.tc1_env tc in
   let bhf = tc1_as_bdhoareF tc in
-  let mpr,mpo = EcEnv.Fun.hoareF_memenv bhf.bhf_f env in
+  let mpr,mpo = EcEnv.Fun.hoareF_memenv bhf.bhf_m bhf.bhf_f env in
+  let pre = ss_inv_rebind pre bhf.bhf_m in
+  let post = ss_inv_rebind post bhf.bhf_m in
   let cond1, cond2 =
-    bdHoare_conseq_conds bhf.bhf_cmp bhf.bhf_pr bhf.bhf_po pre post in
-  let concl1 = f_forall_mems [mpr] cond1 in
-  let concl2 = f_forall_mems [mpo] cond2 in
-  let concl3 = f_bdHoareF pre bhf.bhf_f post bhf.bhf_cmp bhf.bhf_bd in
+    bdHoare_conseq_conds bhf.bhf_cmp (bhf_pr bhf) (bhf_po bhf) pre post in
+  let concl1 = f_forall_mems_ss_inv mpr cond1 in
+  let concl2 = f_forall_mems_ss_inv mpo cond2 in
+  let concl3 = f_bdHoareF pre bhf.bhf_f post bhf.bhf_cmp (bhf_bd bhf) in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_bdHoareS_conseq pre post tc =
   let bhs = tc1_as_bdhoareS tc in
+  let pre = ss_inv_rebind pre (fst bhs.bhs_m) in
+  let post = ss_inv_rebind post (fst bhs.bhs_m) in
   let cond1, cond2 =
-    bdHoare_conseq_conds bhs.bhs_cmp bhs.bhs_pr bhs.bhs_po pre post in
-  let concl1 = f_forall_mems [bhs.bhs_m] cond1 in
-  let concl2 = f_forall_mems [bhs.bhs_m] cond2 in
-  let concl3 = f_bdHoareS_r { bhs with bhs_pr = pre; bhs_po = post } in
+    bdHoare_conseq_conds bhs.bhs_cmp (bhs_pr bhs) (bhs_po bhs) pre post in
+  let concl1 = f_forall_mems_ss_inv bhs.bhs_m cond1 in
+  let concl2 = f_forall_mems_ss_inv bhs.bhs_m cond2 in
+  let concl3 = f_bdHoareS (snd bhs.bhs_m) pre bhs.bhs_s post bhs.bhs_cmp (bhs_bd bhs) in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_bdHoareF_conseq_bd cmp bd tc =
   let env = FApi.tc1_env tc in
   let bhf = tc1_as_bdhoareF tc in
-  let mpr,_ = EcEnv.Fun.hoareF_memenv bhf.bhf_f env in
-  let bd_goal =  bd_goal tc bhf.bhf_cmp bhf.bhf_bd cmp bd in
-  let concl = f_bdHoareF bhf.bhf_pr bhf.bhf_f bhf.bhf_po cmp bd in
-  let bd_goal = f_forall_mems [mpr] (f_imp bhf.bhf_pr bd_goal) in
+  let bd = ss_inv_rebind bd bhf.bhf_m in
+  let mpr,_ = EcEnv.Fun.hoareF_memenv bhf.bhf_m bhf.bhf_f env in
+  let bd_goal =  bd_goal tc bhf.bhf_cmp (bhf_bd bhf) cmp bd in
+  let concl = f_bdHoareF (bhf_pr bhf) bhf.bhf_f (bhf_po bhf) cmp bd in
+  let goal = map_ss_inv2 f_imp (bhf_pr bhf) bd_goal in
+  let bd_goal = f_forall_mems_ss_inv mpr goal in
   FApi.xmutate1 tc `HlConseq [bd_goal; concl]
 
 (* -------------------------------------------------------------------- *)
 let t_bdHoareS_conseq_bd cmp bd tc =
   let bhs = tc1_as_bdhoareS tc in
-  let bd_goal = bd_goal tc bhs.bhs_cmp bhs.bhs_bd cmp bd in
-  let concl = f_bdHoareS bhs.bhs_m bhs.bhs_pr bhs.bhs_s bhs.bhs_po cmp bd in
-  let bd_goal = f_forall_mems [bhs.bhs_m] (f_imp bhs.bhs_pr bd_goal) in
+  let bd = ss_inv_rebind bd (fst bhs.bhs_m) in
+  let bd_goal = bd_goal tc bhs.bhs_cmp (bhs_bd bhs) cmp bd in
+  let concl = f_bdHoareS (snd bhs.bhs_m) (bhs_pr bhs) bhs.bhs_s (bhs_po bhs) cmp bd in
+  let imp = map_ss_inv2 f_imp (bhs_pr bhs) bd_goal in
+  let bd_goal = f_forall_mems_ss_inv bhs.bhs_m imp in
   FApi.xmutate1 tc `HlConseq [bd_goal; concl]
 
 (* -------------------------------------------------------------------- *)
@@ -143,10 +168,12 @@ let t_equivF_conseq pre post tc =
   let env = FApi.tc1_env tc in
   let ef  = tc1_as_equivF tc in
   let (mprl,mprr), (mpol,mpor) =
-    EcEnv.Fun.equivF_memenv ef.ef_fl ef.ef_fr env in
-  let cond1, cond2 = conseq_cond ef.ef_pr ef.ef_po pre post in
-  let concl1 = f_forall_mems [mprl;mprr] cond1 in
-  let concl2 = f_forall_mems [mpol;mpor] cond2 in
+    EcEnv.Fun.equivF_memenv ef.ef_ml ef.ef_mr ef.ef_fl ef.ef_fr env in
+  let pre = ts_inv_rebind pre ef.ef_ml ef.ef_mr in
+  let post = ts_inv_rebind post ef.ef_ml ef.ef_mr in
+  let cond1, cond2 = conseq_cond_ts (ef_pr ef) (ef_po ef) pre post in
+  let concl1 = f_forall_mems_ts_inv mprl mprr cond1 in
+  let concl2 = f_forall_mems_ts_inv mpol mpor cond2 in
   let concl3 = f_equivF pre ef.ef_fl ef.ef_fr post in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
@@ -155,34 +182,38 @@ let t_eagerF_conseq pre post tc =
   let env = FApi.tc1_env tc in
   let eg = tc1_as_eagerF tc in
   let (mprl,mprr), (mpol,mpor) =
-    EcEnv.Fun.equivF_memenv eg.eg_fl eg.eg_fr env in
-  let cond1, cond2 = conseq_cond eg.eg_pr eg.eg_po pre post in
-  let concl1 = f_forall_mems [mprl;mprr] cond1 in
-  let concl2 = f_forall_mems [mpol;mpor] cond2 in
+    EcEnv.Fun.equivF_memenv eg.eg_ml eg.eg_mr eg.eg_fl eg.eg_fr env in
+  let pre = ts_inv_rebind pre eg.eg_ml eg.eg_mr in
+  let post = ts_inv_rebind post eg.eg_ml eg.eg_mr in
+  let cond1, cond2 = conseq_cond_ts (eg_pr eg) (eg_po eg) pre post in
+  let concl1 = f_forall_mems_ts_inv mprl mprr cond1 in
+  let concl2 = f_forall_mems_ts_inv mpol mpor cond2 in
   let concl3 = f_eagerF pre eg.eg_sl eg.eg_fl eg.eg_fr eg.eg_sr post in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_equivS_conseq pre post tc =
   let es = tc1_as_equivS tc in
-  let cond1, cond2 = conseq_cond es.es_pr es.es_po pre post in
-  let concl1 = f_forall_mems [es.es_ml;es.es_mr] cond1 in
-  let concl2 = f_forall_mems [es.es_ml;es.es_mr] cond2 in
-  let concl3 = f_equivS_r { es with es_pr = pre; es_po = post } in
+  let pre = ts_inv_rebind pre (fst es.es_ml) (fst es.es_mr) in
+  let post = ts_inv_rebind post (fst es.es_ml) (fst es.es_mr) in
+  let cond1, cond2 = conseq_cond_ts (es_pr es) (es_po es) pre post in
+  let concl1 = f_forall_mems_ts_inv es.es_ml es.es_mr cond1 in
+  let concl2 = f_forall_mems_ts_inv es.es_ml es.es_mr cond2 in
+  let concl3 = f_equivS (snd es.es_ml) (snd es.es_mr) pre es.es_sl es.es_sr post in
   FApi.xmutate1 tc `HlConseq [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_conseq pre post tc =
-  match (FApi.tc1_goal tc).f_node with
-  | FhoareF _   -> t_hoareF_conseq pre post tc
-  | FhoareS _   -> t_hoareS_conseq pre post tc
-  | FbdHoareF _ -> t_bdHoareF_conseq pre post tc
-  | FbdHoareS _ -> t_bdHoareS_conseq pre post tc
-  | FeHoareF _  -> t_ehoareF_conseq pre post tc
-  | FeHoareS _  -> t_ehoareS_conseq pre post tc
-  | FequivF _   -> t_equivF_conseq pre post tc
-  | FequivS _   -> t_equivS_conseq pre post tc
-  | FeagerF _   -> t_eagerF_conseq pre post tc
+  match (FApi.tc1_goal tc).f_node, pre, post with
+  | FhoareF _,   Inv_ss pre, Inv_ss post -> t_hoareF_conseq pre post tc
+  | FhoareS _,   Inv_ss pre, Inv_ss post -> t_hoareS_conseq pre post tc
+  | FbdHoareF _, Inv_ss pre, Inv_ss post -> t_bdHoareF_conseq pre post tc
+  | FbdHoareS _, Inv_ss pre, Inv_ss post -> t_bdHoareS_conseq pre post tc
+  | FeHoareF _ , Inv_ss pre, Inv_ss post -> t_ehoareF_conseq pre post tc
+  | FeHoareS _ , Inv_ss pre, Inv_ss post -> t_ehoareS_conseq pre post tc
+  | FequivF _  , Inv_ts pre, Inv_ts post -> t_equivF_conseq pre post tc
+  | FequivS _  , Inv_ts pre, Inv_ts post -> t_equivS_conseq pre post tc
+  | FeagerF _  , Inv_ts pre, Inv_ts post -> t_eagerF_conseq pre post tc
   | _           -> tc_error_noXhl !!tc
 
 (* -------------------------------------------------------------------- *)
@@ -191,11 +222,11 @@ let mk_bind_glob env m (id,_) x = id, NormMp.norm_glob env m x
 let mk_bind_pvars m (bd1,bd2) = List.map2 (mk_bind_pvar m) bd1 bd2
 let mk_bind_globs env m (bd1,bd2) = List.map2 (mk_bind_glob env m) bd1 bd2
 
-let cond_equivF_notmod ?(mk_other=false) tc cond =
+let cond_equivF_notmod ?(mk_other=false) tc (cond: ts_inv) =
   let (env, hyps, _) = FApi.tc1_eflat tc in
   let ef = tc1_as_equivF tc in
   let fl, fr = ef.ef_fl, ef.ef_fr in
-  let (mprl,mprr),(mpol,mpor) = Fun.equivF_memenv fl fr env in
+  let (mprl,mprr),(mpol,mpor) = Fun.equivF_memenv ef.ef_ml ef.ef_mr fl fr env in
   let fsigl = (Fun.by_xpath fl env).f_sig in
   let fsigr = (Fun.by_xpath fr env).f_sig in
   let pvresl = pv_res and pvresr = pv_res in
@@ -204,18 +235,19 @@ let cond_equivF_notmod ?(mk_other=false) tc cond =
   let fresl = f_local vresl fsigl.fs_ret in
   let fresr = f_local vresr fsigr.fs_ret in
   let ml, mr = fst mpol, fst mpor in
+  assert (ml = cond.ml && mr = cond.mr);
   let s = PVM.add env pvresl ml fresl (PVM.add env pvresr mr fresr PVM.empty) in
-  let cond = PVM.subst env s cond in
+  let cond = map_ts_inv1 (PVM.subst env s) cond in
   let modil, modir = f_write env fl, f_write env fr in
-  let cond, bdgr, bder = generalize_mod_ env mr modir cond in
-  let cond, bdgl, bdel = generalize_mod_ env ml modil cond in
+  let cond, bdgr, bder = generalize_mod_right_ env modir cond in
+  let cond, bdgl, bdel = generalize_mod_left_ env modil cond in
   let cond =
-    f_forall_simpl
+    map_ts_inv1 (f_forall_simpl
       [(vresl, GTty fsigl.fs_ret);
-       (vresr, GTty fsigr.fs_ret)]
+       (vresr, GTty fsigr.fs_ret)])
       cond in
   assert (fst mprl = ml && fst mprr = mr);
-  let cond = f_forall_mems [mprl; mprr] (f_imp ef.ef_pr cond) in
+  let cond = f_forall_mems_ts_inv mprl mprr (map_ts_inv2 f_imp (ef_pr ef) cond) in
   let bmem = [ml;mr] in
   let bother =
     if mk_other then
@@ -228,8 +260,9 @@ let cond_equivF_notmod ?(mk_other=false) tc cond =
 
 let t_equivF_notmod post tc =
   let ef = tc1_as_equivF tc in
-  let cond1, _, _ = cond_equivF_notmod tc (f_imp post ef.ef_po) in
-  let cond2 = f_equivF_r {ef with ef_po = post } in
+  let post = ts_inv_rebind post ef.ef_ml ef.ef_mr in
+  let cond1, _, _ = cond_equivF_notmod tc (map_ts_inv2 f_imp post (ef_po ef)) in
+  let cond2 = f_equivF (ef_pr ef) ef.ef_fl ef.ef_fr post in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
@@ -238,10 +271,11 @@ let cond_equivS_notmod ?(mk_other=false) tc cond =
   let es = tc1_as_equivS tc in
   let sl, sr = es.es_sl, es.es_sr in
   let ml, mr = fst es.es_ml, fst es.es_mr in
+  assert (ml = cond.ml && mr = cond.mr);
   let modil, modir = s_write env sl, s_write env sr in
-  let cond, bdgr, bder = generalize_mod_ env mr modir cond in
-  let cond, bdgl, bdel = generalize_mod_ env ml modil cond in
-  let cond = f_forall_mems [es.es_ml; es.es_mr] (f_imp es.es_pr cond) in
+  let cond, bdgr, bder = generalize_mod_right_ env modir cond in
+  let cond, bdgl, bdel = generalize_mod_left_ env modil cond in
+  let cond = f_forall_mems_ts_inv es.es_ml es.es_mr (map_ts_inv2 f_imp (es_pr es) cond) in
   let bmem = [ml;mr] in
   let bother =
     if mk_other then
@@ -252,28 +286,28 @@ let cond_equivS_notmod ?(mk_other=false) tc cond =
 
 let t_equivS_notmod post tc =
   let es = tc1_as_equivS tc in
-  let cond1,_,_ = cond_equivS_notmod tc (f_imp post es.es_po) in
-  let cond2 = f_equivS_r {es with es_po = post} in
+  let post = ts_inv_rebind post (fst es.es_ml) (fst es.es_mr) in
+  let cond1,_,_ = cond_equivS_notmod tc (map_ts_inv2 f_imp post (es_po es)) in
+  let cond2 = f_equivS (snd es.es_ml) (snd es.es_mr) (es_pr es) es.es_sl es.es_sr post in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
-let cond_hoareF_notmod ?(mk_other=false) tc cond =
+let cond_hoareF_notmod ?(mk_other=false) tc (cond: ss_inv) =
   let (env, hyps, _) = FApi.tc1_eflat tc in
   let hf = tc1_as_hoareF tc in
   let f = hf.hf_f in
-  let mpr,mpo = Fun.hoareF_memenv f env in
+  let mpr,mpo = Fun.hoareF_memenv hf.hf_m f env in
   let fsig = (Fun.by_xpath f env).f_sig in
   let pvres = pv_res in
   let vres = LDecl.fresh_id hyps "result" in
   let fres = f_local vres fsig.fs_ret in
   let m    = fst mpo in
   let s = PVM.add env pvres m fres PVM.empty in
-  let cond = PVM.subst env s cond in
+  let cond = map_ss_inv1 (PVM.subst env s) cond in
   let modi = f_write env f in
-  let cond,bdg,bde = generalize_mod_ env m modi cond in
-  let cond = f_forall_simpl [(vres, GTty fsig.fs_ret)] cond in
-  assert (fst mpr = m);
-  let cond = f_forall_mems [mpr] (f_imp hf.hf_pr cond) in
+  let cond,bdg,bde = generalize_mod_ env modi cond in
+  let cond = map_ss_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) cond in
+  let cond = f_forall_mems_ss_inv mpr (map_ss_inv2 f_imp (hf_pr hf) cond) in
   let bmem = [m] in
   let bother =
     if mk_other then
@@ -282,10 +316,11 @@ let cond_hoareF_notmod ?(mk_other=false) tc cond =
     else [] in
   cond, bmem, bother
 
-let t_hoareF_notmod post tc =
+let t_hoareF_notmod (post: ss_inv) tc =
   let hf = tc1_as_hoareF tc in
-  let cond1, _, _ = cond_hoareF_notmod tc (f_imp post hf.hf_po) in
-  let cond2 = f_hoareF_r { hf with hf_po = post } in
+  let post = ss_inv_rebind post hf.hf_m in
+  let cond1, _, _ = cond_hoareF_notmod tc (map_ss_inv2 f_imp post (hf_po hf)) in
+  let cond2 = f_hoareF (hf_pr hf) hf.hf_f post in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
@@ -295,8 +330,8 @@ let cond_hoareS_notmod ?(mk_other=false) tc cond =
   let s = hs.hs_s in
   let m = fst hs.hs_m in
   let modi = s_write env s in
-  let cond, bdg, bde = generalize_mod_ env m modi cond in
-  let cond = f_forall_mems [hs.hs_m] (f_imp hs.hs_pr cond) in
+  let cond, bdg, bde = generalize_mod_ env modi cond in
+  let cond = f_forall_mems_ss_inv hs.hs_m (map_ss_inv2 f_imp (hs_pr hs) cond) in
   let bmem = [m] in
   let bother =
     if mk_other then
@@ -306,28 +341,29 @@ let cond_hoareS_notmod ?(mk_other=false) tc cond =
 
 let t_hoareS_notmod post tc =
   let hs = tc1_as_hoareS tc in
-  let cond1, _, _ = cond_hoareS_notmod tc (f_imp post hs.hs_po) in
-  let cond2 = f_hoareS_r {hs with hs_po = post} in
+  let post = ss_inv_rebind post (fst hs.hs_m) in
+  let cond1, _, _ = cond_hoareS_notmod tc (map_ss_inv2 f_imp post (hs_po hs)) in
+  let cond2 = f_hoareS (snd hs.hs_m) (hs_pr hs) hs.hs_s post in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
-let cond_bdHoareF_notmod ?(mk_other=false) tc cond =
+let cond_bdHoareF_notmod ?(mk_other=false) tc (cond: ss_inv) =
   let (env, hyps, _) = FApi.tc1_eflat tc in
   let hf = tc1_as_bdhoareF tc in
   let f = hf.bhf_f in
-  let mpr,mpo = Fun.hoareF_memenv f env in
+  let mpr,mpo = Fun.hoareF_memenv hf.bhf_m f env in
   let fsig = (Fun.by_xpath f env).f_sig in
   let pvres = pv_res in
   let vres = LDecl.fresh_id hyps "result" in
   let fres = f_local vres fsig.fs_ret in
   let m    = fst mpo in
   let s = PVM.add env pvres m fres PVM.empty in
-  let cond = PVM.subst env s cond in
+  let cond = map_ss_inv1 (PVM.subst env s) cond in
   let modi = f_write env f in
-  let cond, bdg, bde = generalize_mod_ env m modi cond in
-  let cond = f_forall_simpl [(vres, GTty fsig.fs_ret)] cond in
+  let cond, bdg, bde = generalize_mod_ env modi cond in
+  let cond = map_ss_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) cond in
   assert (fst mpr = m);
-  let cond = f_forall_mems [mpr] (f_imp hf.bhf_pr cond) in
+  let cond = f_forall_mems_ss_inv mpr (map_ss_inv2 f_imp (bhf_pr hf) cond) in
   let bmem = [m] in
   let bother =
     if mk_other then
@@ -339,21 +375,22 @@ let cond_bdHoareF_notmod ?(mk_other=false) tc cond =
 
 let t_bdHoareF_notmod post tc =
   let hf = tc1_as_bdhoareF tc in
+  let post = ss_inv_rebind post hf.bhf_m in
   let _, cond =
-    bdHoare_conseq_conds hf.bhf_cmp hf.bhf_pr hf.bhf_po hf.bhf_pr post in
+    bdHoare_conseq_conds hf.bhf_cmp (bhf_pr hf) (bhf_po hf) (bhf_pr hf) post in
   let cond1, _, _ = cond_bdHoareF_notmod tc cond in
-  let cond2 = f_bdHoareF_r {hf with bhf_po = post} in
+  let cond2 = f_bdHoareF (bhf_pr hf) hf.bhf_f post hf.bhf_cmp (bhf_bd hf) in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
-let cond_bdHoareS_notmod ?(mk_other=false) tc cond =
+let cond_bdHoareS_notmod ?(mk_other=false) tc (cond: ss_inv) =
   let env = FApi.tc1_env tc in
   let hs = tc1_as_bdhoareS tc in
   let s = hs.bhs_s in
   let m = fst hs.bhs_m in
   let modi = s_write env s in
-  let cond, bdg, bde = generalize_mod_ env m modi cond in
-  let cond = f_forall_mems [hs.bhs_m] (f_imp hs.bhs_pr cond) in
+  let cond, bdg, bde = generalize_mod_ env modi cond in
+  let cond = f_forall_mems_ss_inv hs.bhs_m (map_ss_inv2 f_imp (bhs_pr hs) cond) in
   let bmem = [m] in
   let bother =
     if mk_other then
@@ -363,10 +400,11 @@ let cond_bdHoareS_notmod ?(mk_other=false) tc cond =
 
 let t_bdHoareS_notmod post tc =
   let hs = tc1_as_bdhoareS tc in
+  let post = ss_inv_rebind post (fst hs.bhs_m) in
   let _, cond =
-    bdHoare_conseq_conds hs.bhs_cmp hs.bhs_pr hs.bhs_po hs.bhs_pr post in
+    bdHoare_conseq_conds hs.bhs_cmp (bhs_pr hs) (bhs_po hs) (bhs_pr hs) post in
   let cond1, _, _ = cond_bdHoareS_notmod tc cond in
-  let cond2 = f_bdHoareS_r {hs with bhs_po = post} in
+  let cond2 = f_bdHoareS (snd hs.bhs_m) (bhs_pr hs) hs.bhs_s post hs.bhs_cmp (bhs_bd hs) in
   FApi.xmutate1 tc `HlNotmod [cond1; cond2]
 
 (* -------------------------------------------------------------------- *)
@@ -379,9 +417,27 @@ let gen_conseq_nm tnm tc pre post =
     FApi.t_swap_goals 0 1 gs
   )
 
-let t_hoareF_conseq_nm   = gen_conseq_nm t_hoareF_notmod   t_hoareF_conseq
+let gen_conseq_nm_ss tnm tc (pre: ss_inv) (post: ss_inv) =
+    FApi.t_internal ~info:"generic-conseq-nm" (fun g ->
+      let gs =
+        (tnm post @+
+          [ t_id;
+            tc pre post @+ [t_id; t_trivial; t_id] ]) g in
+      FApi.t_swap_goals 0 1 gs
+    )
+
+let gen_conseq_nm_ts tnm tc (pre: ts_inv) (post: ts_inv) =
+  FApi.t_internal ~info:"generic-conseq-nm" (fun g ->
+    let gs =
+      (tnm post @+
+        [ t_id;
+          tc pre post @+ [t_id; t_trivial; t_id] ]) g in
+    FApi.t_swap_goals 0 1 gs
+  )
+
+let t_hoareF_conseq_nm   = gen_conseq_nm_ss t_hoareF_notmod   t_hoareF_conseq
 let t_hoareS_conseq_nm   = gen_conseq_nm t_hoareS_notmod   t_hoareS_conseq
-let t_equivF_conseq_nm   = gen_conseq_nm t_equivF_notmod   t_equivF_conseq
+let t_equivF_conseq_nm   = gen_conseq_nm_ts t_equivF_notmod   t_equivF_conseq
 let t_equivS_conseq_nm   = gen_conseq_nm t_equivS_notmod   t_equivS_conseq
 let t_bdHoareF_conseq_nm = gen_conseq_nm t_bdHoareF_notmod t_bdHoareF_conseq
 let t_bdHoareS_conseq_nm = gen_conseq_nm t_bdHoareS_notmod t_bdHoareS_conseq
@@ -394,33 +450,35 @@ let t_bdHoareS_conseq_nm = gen_conseq_nm t_bdHoareS_notmod t_bdHoareS_conseq
    {f g1} c { f g2 }
 *)
 
-let t_ehoareF_concave fc pre post tc =
+let t_ehoareF_concave (fc: ss_inv) pre post tc =
   let env = FApi.tc1_env tc in
   let hf = tc1_as_ehoareF tc in
   let f = hf.ehf_f in
-  let mpr,mpo = Fun.hoareF_memenv f env in
+  let mpr,mpo = Fun.hoareF_memenv hf.ehf_m f env in
   let fsig = (Fun.by_xpath f env).f_sig in
   let m = fst mpo in
   assert (fst mpr = m && fst mpo = m);
   (* ensure that f only depend of notmod *)
   let modi = f_write env f in
   let modi = PV.add env pv_res fsig.fs_ret modi in
-  let fv = PV.fv env m fc in
+  let fv = PV.fv env m fc.inv in
   let inter = PV.interdep env fv modi in
   if not (PV.is_empty inter) then
     tc_error !!tc "the function should not depend on modified elements: %a"
        (PV.pp env) inter;
 
   let g0 =
-    f_forall_mems [EcMemory.empty_local ~witharg:false m] (f_concave_incr fc) in
+    f_forall_mems_ss_inv (EcMemory.empty_local ~witharg:false m) (map_ss_inv1 f_concave_incr fc) in
 
   let g1 =
-    let cond = f_xreal_le (f_app_simpl fc [pre] txreal) hf.ehf_pr in
-    f_forall_mems [mpr] cond in
+    let cond = map_ss_inv2 (fun pre fc -> f_app_simpl fc [pre] txreal) pre fc in
+    let cond = map_ss_inv2 f_xreal_le cond (ehf_pr hf) in
+    f_forall_mems_ss_inv mpr cond in
 
   let g2 =
-    let cond = f_xreal_le hf.ehf_po (f_app_simpl fc [post] txreal) in
-    f_forall_mems [mpo] cond in
+    let cond = map_ss_inv2 (fun post fc -> f_app_simpl fc [post] txreal) post fc in
+    let cond = map_ss_inv2 f_xreal_le (ehf_po hf) cond in
+    f_forall_mems_ss_inv mpo cond in
 
   let g3 =
     f_eHoareF pre f post in
@@ -428,32 +486,34 @@ let t_ehoareF_concave fc pre post tc =
   FApi.xmutate1 tc `HlConseq [g0; g1; g2; g3]
 
 (* -------------------------------------------------------------------- *)
-let t_ehoareS_concave fc (* xreal -> xreal *) pre post tc =
+let t_ehoareS_concave (fc: ss_inv) (* xreal -> xreal *) pre post tc =
   let env = FApi.tc1_env tc in
   let hs = tc1_as_ehoareS tc in
   let s = hs.ehs_s in
   let m = fst hs.ehs_m in
   (* ensure that f only depend of notmod *)
   let modi = s_write env s in
-  let fv = PV.fv env m fc in
+  let fv = PV.fv env m fc.inv in
   let inter = PV.interdep env fv modi in
   if not (PV.is_empty inter) then
     tc_error !!tc "the function should not depend on modified elements: %a"
        (PV.pp env) inter;
 
   let g0 =
-    f_forall_mems [hs.ehs_m] (f_concave_incr fc) in
+    f_forall_mems_ss_inv hs.ehs_m (map_ss_inv1 f_concave_incr fc) in
 
   let g1 =
-    let cond = f_xreal_le (f_app_simpl fc [pre] txreal) hs.ehs_pr in
-    f_forall_mems [hs.ehs_m] cond in
+    let cond = map_ss_inv2 (fun pre fc -> f_app_simpl fc [pre] txreal) pre fc in
+    let cond = map_ss_inv2 f_xreal_le cond (ehs_pr hs) in
+    f_forall_mems_ss_inv hs.ehs_m cond in
 
   let g2 =
-    let cond = f_xreal_le hs.ehs_po (f_app_simpl fc [post] txreal) in
-    f_forall_mems [hs.ehs_m] cond in
+    let cond = map_ss_inv2 (fun post fc -> f_app_simpl fc [post] txreal) post fc in
+    let cond = map_ss_inv2 f_xreal_le (ehs_po hs) cond in
+    f_forall_mems_ss_inv hs.ehs_m cond in
 
   let g3 =
-    f_eHoareS hs.ehs_m pre s post in
+    f_eHoareS (snd hs.ehs_m) pre s post in
 
   FApi.xmutate1 tc `HlConseq [g0; g1; g2; g3]
 
@@ -475,24 +535,26 @@ let t_ehoareF_conseq_nm pre post tc =
   let (env, hyps, _) = FApi.tc1_eflat tc in
   let hf = tc1_as_ehoareF tc in
   let f = hf.ehf_f in
-  let _mpr,mpo = Fun.hoareF_memenv f env in
+  let _mpr,mpo = Fun.hoareF_memenv hf.ehf_m f env in
   let fsig = (Fun.by_xpath f env).f_sig in
-  let _cond1, cond2 = conseq_econd hf.ehf_pr hf.ehf_po pre post in
+  let _cond1, cond2 = conseq_econd (ehf_pr hf) (ehf_po hf) pre post in
 
   let pvres = pv_res in
   let vres = LDecl.fresh_id hyps "result" in
   let fres = f_local vres fsig.fs_ret in
   let m    = fst mpo in
   let s = PVM.add env pvres m fres PVM.empty in
-  let cond = PVM.subst env s cond2 in
+  let cond = map_ss_inv1 (PVM.subst env s) cond2 in
 
   let modi = f_write env f in
-  let cond,_,_ = generalize_mod_ env m modi cond in
-  let cond = f_forall_simpl [(vres, GTty fsig.fs_ret)] cond in
+  let cond,_,_ = generalize_mod_ env modi cond in
+  let cond = map_ss_inv1 (f_forall_simpl [(vres, GTty fsig.fs_ret)]) cond in
 
   let fc =
     let x = EcIdent.create "x" in
-    f_lambda [x,GTty txreal] (f_interp_ehoare_form cond (f_local x txreal)) in
+    let f_interp_ehoare_form' cond =
+      f_interp_ehoare_form cond (f_local x txreal) in
+    map_ss_inv1 (fun cd -> f_lambda [x,GTty txreal] (f_interp_ehoare_form' cd)) cond in
 
   (t_ehoareF_concave fc pre post @+ t_ehoare_conseq_nm_end) tc
 
@@ -501,14 +563,14 @@ let t_ehoareS_conseq_nm pre post tc =
   let env = FApi.tc1_env tc in
   let hs = tc1_as_ehoareS tc in
   let s = hs.ehs_s in
-  let m = fst hs.ehs_m in
   let modi = s_write env s in
-  let _cond1, cond2 = conseq_econd hs.ehs_pr hs.ehs_po pre post in
-  let cond, _bdg, _bde = generalize_mod_ env m modi cond2 in
-
+  let _cond1, cond2 = conseq_econd (ehs_pr hs) (ehs_po hs) pre post in
+  let cond, _bdg, _bde = generalize_mod_ env modi cond2 in
   let fc =
     let x = EcIdent.create "x" in
-    f_lambda [x,GTty txreal] (f_interp_ehoare_form cond (f_local x txreal)) in
+    let f_interp_ehoare_form' cond =
+      f_interp_ehoare_form cond (f_local x txreal) in
+    map_ss_inv1 (fun cond -> f_lambda [x,GTty txreal] (f_interp_ehoare_form' cond)) cond in
 
   (t_ehoareS_concave fc pre post @+ t_ehoare_conseq_nm_end) tc
 
@@ -521,12 +583,14 @@ let process_concave ((info, fc) : pformula option tuple2 gppterm * pformula) tc 
   let fc =
     match concl.f_node with
     | FeHoareS hs ->
-      let env = LDecl.push_active hs.ehs_m hyps in
-      TTC.pf_process_form !!tc env (tfun txreal txreal) fc
+      let m = fst hs.ehs_m in
+      let env = LDecl.push_active_ss hs.ehs_m hyps in
+      {m; inv=TTC.pf_process_form !!tc env (tfun txreal txreal) fc}
 
     | FeHoareF hf ->
-      let _, env = LDecl.hoareF hf.ehf_f hyps in
-      TTC.pf_process_form !!tc env (tfun txreal txreal) fc
+      let m = hf.ehf_m in
+      let _, env = LDecl.hoareF hf.ehf_m hf.ehf_f hyps in
+      {m; inv=TTC.pf_process_form !!tc env (tfun txreal txreal) fc}
 
     | _ -> tc_error !!tc "conseq concave: not a ehoare judgement"
   in
@@ -535,21 +599,22 @@ let process_concave ((info, fc) : pformula option tuple2 gppterm * pformula) tc 
     let penv, qenv, gpre, gpost, fmake =
       match concl.f_node with
       | FeHoareS hs ->
-        let env = LDecl.push_active hs.ehs_m hyps in
-        let fmake pre post = f_eHoareS_r { hs with ehs_pr = pre; ehs_po = post; } in
-        (env, env, hs.ehs_pr, hs.ehs_po, fmake)
+        let env = LDecl.push_active_ss hs.ehs_m hyps in
+        let fmake pre post = f_eHoareS (snd hs.ehs_m) pre hs.ehs_s post in
+        (env, env, (ehs_pr hs), (ehs_po hs), fmake)
 
       | FeHoareF hf ->
-        let penv, qenv = LDecl.hoareF hf.ehf_f hyps in
+        let penv, qenv = LDecl.hoareF hf.ehf_m hf.ehf_f hyps in
         let fmake pre post =
-          f_eHoareF_r { hf with ehf_pr = pre; ehf_po = post } in
-        (penv, qenv, hf.ehf_pr, hf.ehf_po, fmake)
+          f_eHoareF pre hf.ehf_f post in
+        (penv, qenv, (ehf_pr hf), (ehf_po hf), fmake)
 
       | _ -> tc_error !!tc "conseq concave: not a ehoare judgement"
     in
 
-    let pre   = pre  |> omap (TTC.pf_process_form !!tc penv txreal) |> odfl gpre  in
-    let post  = post |> omap (TTC.pf_process_form !!tc qenv txreal) |> odfl gpost in
+    let pre   = map_ss_inv1 (fun gpre -> pre |> omap (TTC.pf_process_form !!tc penv txreal) |> odfl gpre) gpre  in
+    let post  = map_ss_inv1 (fun gpost -> post |> omap (TTC.pf_process_form !!tc qenv txreal) |> odfl gpost) gpost in
+    
     fmake pre post
 
   in
@@ -563,11 +628,11 @@ let process_concave ((info, fc) : pformula option tuple2 gppterm * pformula) tc 
   match (snd f1).f_node with
   | FeHoareS hs ->
     FApi.t_first t_concave_incr
-        (FApi.t_on1seq 3 (t_ehoareS_concave fc hs.ehs_pr hs.ehs_po) t_apply_r tc)
+        (FApi.t_on1seq 3 (t_ehoareS_concave fc (ehs_pr hs) (ehs_po hs)) t_apply_r tc)
 
   | FeHoareF hf ->
      FApi.t_first t_concave_incr
-       (FApi.t_on1seq 3 (t_ehoareF_concave fc hf.ehf_pr hf.ehf_po) t_apply_r tc)
+       (FApi.t_on1seq 3 (t_ehoareF_concave fc (ehf_pr hf) (ehf_po hf)) t_apply_r tc)
 
   | _ -> tc_error !!tc "conseq concave: not a ehoare judgement"
 
@@ -583,90 +648,105 @@ let process_concave ((info, fc) : pformula option tuple2 gppterm * pformula) tc 
 (* -------------------------------------------------------------------- *)
 let t_hoareS_conseq_bdhoare tc =
   let hs = tc1_as_hoareS tc in
-  let concl1 = f_bdHoareS hs.hs_m hs.hs_pr hs.hs_s hs.hs_po FHeq f_r1 in
+  let f_r1 = {m=fst hs.hs_m; inv=f_r1} in
+  let concl1 = f_bdHoareS (snd hs.hs_m) (hs_pr hs) hs.hs_s (hs_po hs) FHeq f_r1 in
   FApi.xmutate1 tc `HlConseqBd [concl1]
 
 (* -------------------------------------------------------------------- *)
 let t_hoareF_conseq_bdhoare tc =
   let hf = tc1_as_hoareF tc in
-  let concl1 = f_bdHoareF hf.hf_pr hf.hf_f hf.hf_po FHeq f_r1 in
+  let f_r1 = {m=hf.hf_m; inv=f_r1} in
+  let concl1 = f_bdHoareF (hf_pr hf) hf.hf_f (hf_po hf) FHeq f_r1 in
   FApi.xmutate1 tc `HlConseqBd [concl1]
 
 (* -------------------------------------------------------------------- *)
 let t_hoareS_conseq_conj pre post pre' post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let hs = tc1_as_hoareS tc in
-  if not (f_equal hs.hs_pr (f_and pre' pre)) then
-    tc_error !!tc "invalid pre-condition";
-  if not (f_equal hs.hs_po (f_and post' post)) then
-    tc_error !!tc "invalid post-condition";
-  let concl1 = f_hoareS_r { hs with hs_pr = pre; hs_po = post } in
-  let concl2 = f_hoareS_r { hs with hs_pr = pre'; hs_po = post' } in
+  let pre'' = map_ss_inv2 f_and pre' pre in
+  let post'' = map_ss_inv2 f_and post' post in
+  if not (ss_inv_alpha_eq hyps (hs_pr hs) pre'') 
+    then tc_error !!tc "invalid pre-condition";
+  if not (ss_inv_alpha_eq hyps (hs_po hs) post'') 
+    then tc_error !!tc "invalid post-condition";
+  let concl1 = f_hoareS (snd hs.hs_m) pre hs.hs_s post in
+  let concl2 = f_hoareS (snd hs.hs_m) pre' hs.hs_s post' in
   FApi.xmutate1 tc `HlConseqBd [concl1; concl2]
 
 (* -------------------------------------------------------------------- *)
 let t_hoareF_conseq_conj pre post pre' post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let hf = tc1_as_hoareF tc in
-  if not (f_equal hf.hf_pr (f_and pre' pre)) then
-    tc_error !!tc "invalid pre-condition";
-  if not (f_equal hf.hf_po (f_and post' post)) then
-    tc_error !!tc "invalid post-condition";
+  let pre'' = map_ss_inv2 f_and pre' pre in
+  let post'' = map_ss_inv2 f_and post' post in
+  if not (ss_inv_alpha_eq hyps (hf_pr hf) pre'') 
+  then tc_error !!tc "invalid pre-condition";
+  if not (ss_inv_alpha_eq hyps (hf_po hf) post'')
+  then tc_error !!tc "invalid post-condition";
   let concl1 = f_hoareF pre hf.hf_f post in
   let concl2 = f_hoareF pre' hf.hf_f post' in
   FApi.xmutate1 tc `HlConseqBd [concl1; concl2]
 
 (* -------------------------------------------------------------------- *)
 let t_bdHoareS_conseq_conj ~add post post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let hs = tc1_as_bdhoareS tc in
-  let postc = if add then f_and post' post else post' in
-  let posth = if add then post' else f_and post' post in
-  if not (f_equal hs.bhs_po postc) then
+  let postc = if add then map_ss_inv2 f_and post' post else post' in
+  let posth = if add then post' else map_ss_inv2 f_and post' post in
+  if not (ss_inv_alpha_eq hyps (bhs_po hs) postc) then
     tc_error !!tc "invalid post-condition";
-  let concl1 = f_hoareS hs.bhs_m hs.bhs_pr hs.bhs_s post in
-  let concl2 = f_bdHoareS_r { hs with bhs_po = posth } in
+  let concl1 = f_hoareS (snd hs.bhs_m) (bhs_pr hs) hs.bhs_s post in
+  let concl2 = f_bdHoareS (snd hs.bhs_m) (bhs_pr hs) hs.bhs_s posth 
+                 hs.bhs_cmp (bhs_bd hs) in
   FApi.xmutate1 tc `HlConseqBd [concl1; concl2]
 
 (* -------------------------------------------------------------------- *)
 let t_bdHoareF_conseq_conj ~add post post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let hs = tc1_as_bdhoareF tc in
-  let postc = if add then f_and post' post else post' in
-  let posth = if add then post' else f_and post' post in
-  if not (f_equal hs.bhf_po postc) then
+  let post = ss_inv_rebind post hs.bhf_m in
+  let post' = ss_inv_rebind post' hs.bhf_m in
+  let postc = if add then map_ss_inv2 f_and post' post else post' in
+  let posth = if add then post' else map_ss_inv2 f_and post' post in
+  if not (ss_inv_alpha_eq hyps (bhf_po hs) postc) then
     tc_error !!tc "invalid post-condition";
-  let concl1 = f_hoareF hs.bhf_pr hs.bhf_f post in
-  let concl2 = f_bdHoareF_r { hs with bhf_po = posth } in
+  let concl1 = f_hoareF (bhf_pr hs) hs.bhf_f post in
+  let concl2 = f_bdHoareF (bhf_pr hs) hs.bhf_f posth hs.bhf_cmp (bhf_bd hs) in
   FApi.xmutate1 tc `HlConseqBd [concl1; concl2]
 
 (* -------------------------------------------------------------------- *)
 let t_equivS_conseq_conj pre1 post1 pre2 post2 pre' post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let es = tc1_as_equivS tc in
-  let subst1 = Fsubst.f_subst_mem mhr mleft in
-  let subst2 = Fsubst.f_subst_mem mhr mright in
-  let pre1'  = subst1 pre1 in
-  let post1' = subst1 post1 in
-  let pre2'  = subst2 pre2 in
-  let post2' = subst2 post2 in
-  if not (f_equal es.es_pr (f_ands [pre';pre1';pre2'])) then
+  let (ml, mtl), (mr, mtr) = es.es_ml, es.es_mr in
+  let pre1' = ss_inv_generalize_right (ss_inv_rebind pre1 ml) mr in
+  let post1' = ss_inv_generalize_right (ss_inv_rebind post1 ml) mr in
+  let pre2' = ss_inv_generalize_left (ss_inv_rebind pre2 mr) ml in
+  let post2' = ss_inv_generalize_left (ss_inv_rebind post2 mr) ml in
+  if not (ts_inv_alpha_eq hyps (es_pr es) (map_ts_inv f_ands [pre';pre1';pre2'])) then
     tc_error !!tc "invalid pre-condition";
-  if not (f_equal es.es_po (f_ands [post';post1';post2'])) then
+  if not (ts_inv_alpha_eq hyps (es_po es) (map_ts_inv f_ands [post';post1';post2'])) then
     tc_error !!tc "invalid post-condition";
-  let concl1 = f_hoareS (mhr,snd es.es_ml) pre1 es.es_sl post1 in
-  let concl2 = f_hoareS (mhr,snd es.es_mr) pre2 es.es_sr post2 in
-  let concl3 = f_equivS_r {es with es_pr = pre'; es_po = post'} in
+  let concl1 = f_hoareS mtl pre1 es.es_sl post1 in
+  let concl2 = f_hoareS mtr pre2 es.es_sr post2 in
+  let concl3 = f_equivS mtl mtr pre' es.es_sl es.es_sr post' in
   FApi.xmutate1 tc `HlConseqConj [concl1; concl2; concl3]
 
 (* -------------------------------------------------------------------- *)
 let t_equivF_conseq_conj pre1 post1 pre2 post2 pre' post' tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let ef = tc1_as_equivF tc in
-  let subst1 = Fsubst.f_subst_mem mhr mleft in
-  let subst2 = Fsubst.f_subst_mem mhr mright in
-  let pre1'  = subst1 pre1 in
-  let post1' = subst1 post1 in
-  let pre2'  = subst2 pre2 in
-  let post2' = subst2 post2 in
-  if not (f_equal ef.ef_pr (f_ands [pre';pre1';pre2']) ) then
-    tc_error !!tc "invalid pre-condition";
-  if not (f_equal ef.ef_po (f_ands [post';post1';post2'])) then
-    tc_error !!tc "invalid post-condition";
+  let ml, mr = ef.ef_ml, ef.ef_mr in
+  let pre1' = ss_inv_generalize_right (ss_inv_rebind pre1 ml) mr in
+  let post1' = ss_inv_generalize_right (ss_inv_rebind post1 ml) mr in
+  let pre2' = ss_inv_generalize_left (ss_inv_rebind pre2 mr) ml in
+  let post2' = ss_inv_generalize_left (ss_inv_rebind post2 mr) ml in
+  let pre'' = map_ts_inv f_ands [pre'; pre1'; pre2'] in
+  let post'' = map_ts_inv f_ands [post'; post1'; post2'] in
+  if not (ts_inv_alpha_eq hyps (ef_pr ef) pre'') 
+  then tc_error !!tc "invalid pre-condition";
+  if not (ts_inv_alpha_eq hyps (ef_po ef) post'')
+  then tc_error !!tc "invalid post-condition";
   let concl1 = f_hoareF pre1 ef.ef_fl post1 in
   let concl2 = f_hoareF pre2 ef.ef_fr post2 in
   let concl3 = f_equivF pre' ef.ef_fl ef.ef_fr post' in
@@ -674,21 +754,32 @@ let t_equivF_conseq_conj pre1 post1 pre2 post2 pre' post' tc =
 
 (* -------------------------------------------------------------------- *)
 let t_equivS_conseq_bd side pr po tc =
+  let (_, hyps, _) = FApi.tc1_eflat tc in
   let es = tc1_as_equivS tc in
-  let m,s,s' =
+  let ((ml,_), (mr,_)) = es.es_ml, es.es_mr in
+  let m,s,s',prs,pos =
     match side with
-    | `Left  -> es.es_ml, es.es_sl, es.es_sr
-    | `Right -> es.es_mr, es.es_sr, es.es_sl
+    | `Left  ->
+      let pos = ss_inv_generalize_right (ss_inv_rebind po ml) mr in
+      let prs = ss_inv_generalize_right (ss_inv_rebind pr ml) mr in
+      es.es_ml, es.es_sl, es.es_sr, prs, pos
+    | `Right -> 
+      let pos = ss_inv_generalize_left (ss_inv_rebind po mr) ml in
+      let prs = ss_inv_generalize_left (ss_inv_rebind pr mr) ml in
+      es.es_mr, es.es_sr, es.es_sl, prs, pos
   in
   if not (List.is_empty s'.s_node) then begin
     let side = side2str (negside side) in
     tc_error !!tc "%s statement should be empty" side
   end;
-  let subst = Fsubst.f_subst_mem mhr (fst m) in
-  let prs, pos = subst pr, subst po in
-  if not (f_equal prs es.es_pr && f_equal pos es.es_po) then
+  if not (ts_inv_alpha_eq hyps prs (es_pr es)) then
     tc_error !!tc "invalid pre- or post-condition";
-  let g1 = f_bdHoareS (mhr,snd m) pr s po FHeq f_r1 in
+  if not (ts_inv_alpha_eq hyps pos (es_po es)) then
+    tc_error !!tc "invalid pre- or post-condition";
+  let f_r1 = {m=fst m; inv=f_r1} in
+  let pr = ss_inv_rebind pr (fst m) in
+  let po = ss_inv_rebind po (fst m) in
+  let g1 = f_bdHoareS (snd m) pr s po FHeq f_r1 in
   FApi.xmutate1 tc `HlBdEquiv [g1]
 
 (* -------------------------------------------------------------------- *)
@@ -704,20 +795,20 @@ hoare M1 : P1 ==> Q1.
 let transitivity_side_cond hyps prml poml pomr p q p2 q2 p1 q1 =
   let env = LDecl.toenv hyps in
   let cond1 =
-    let fv1 = PV.fv env mright p in
-    let fv2 = PV.fv env mhr p2 in
+    let fv1 = PV.fv env p.mr p.inv in
+    let fv2 = PV.fv env p2.m p2.inv in
     let fv = PV.union fv1 fv2 in
     let elts, glob = PV.ntr_elements fv in
-    let bd, s = generalize_subst env mhr elts glob in
-    let s1 = PVM.of_mpv s mright in
-    let s2 = PVM.of_mpv s mhr in
-    let concl = f_and (PVM.subst env s1 p) (PVM.subst env s2 p2) in
-    let p1 = Fsubst.f_subst_mem mhr mleft p1 in
-    f_forall_mems [prml] (f_imp p1 (f_exists bd concl)) in
+    let bd, s = generalize_subst env p2.m elts glob in
+    let s1 = PVM.of_mpv s p.mr in
+    let s2 = PVM.of_mpv s p2.m in
+    let concl = f_and (PVM.subst env s1 p.inv) (PVM.subst env s2 p2.inv) in
+    let p1 = ss_inv_rebind p1 p.ml in
+    f_forall_mems [prml] (f_imp p1.inv (f_exists bd concl)) in
   let cond2 =
-    let q1 = Fsubst.f_subst_mem mhr mleft q1 in
-    let q2 = Fsubst.f_subst_mem mhr mright q2 in
-    f_forall_mems [poml; pomr] (f_imps [q;q2] q1) in
+    let q1 = ss_inv_generalize_as_left q1 q.ml q.mr in
+    let q2 = ss_inv_generalize_as_right q2 q.ml q.mr in
+    f_forall_mems_ts_inv poml pomr (map_ts_inv3 (fun q q2 q1 -> f_imps [q;q2] q1) q q2 q1) in
   (cond1, cond2)
 
 let t_hoareF_conseq_equiv f2 p q p2 q2 tc =
@@ -725,19 +816,19 @@ let t_hoareF_conseq_equiv f2 p q p2 q2 tc =
   let hf1 = tc1_as_hoareF tc in
   let ef  = f_equivF p hf1.hf_f f2 q in
   let hf2 = f_hoareF p2 f2 q2 in
-  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv hf1.hf_f f2 env in
+  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv p.ml p.mr hf1.hf_f f2 env in
   let (cond1, cond2) =
-    transitivity_side_cond hyps prml poml pomr p q p2 q2 hf1.hf_pr hf1.hf_po in
+    transitivity_side_cond hyps prml poml pomr p q p2 q2 (hf_pr hf1) (hf_po hf1) in
   FApi.xmutate1 tc `HoareFConseqEquiv [cond1; cond2; ef; hf2]
 
 let t_bdHoareF_conseq_equiv f2 p q p2 q2 tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
   let hf1 = tc1_as_bdhoareF tc in
   let ef  = f_equivF p hf1.bhf_f f2 q in
-  let hf2 = f_bdHoareF p2 f2 q2 hf1.bhf_cmp hf1.bhf_bd in
-  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv hf1.bhf_f f2 env in
+  let hf2 = f_bdHoareF p2 f2 q2 hf1.bhf_cmp (bhf_bd hf1) in
+  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv p.ml p.mr hf1.bhf_f f2 env in
   let (cond1, cond2) =
-    transitivity_side_cond hyps prml poml pomr p q p2 q2 hf1.bhf_pr hf1.bhf_po in
+    transitivity_side_cond hyps prml poml pomr p q p2 q2 (bhf_pr hf1) (bhf_po hf1) in
   FApi.xmutate1 tc `BdHoareFConseqEquiv [cond1; cond2; ef; hf2]
 
 
@@ -746,25 +837,27 @@ let t_ehoareF_conseq_equiv f2 p q p2 q2 tc =
   let hf1 = tc1_as_ehoareF tc in
   let ef  = f_equivF p hf1.ehf_f f2 q in
   let hf2 = f_eHoareF p2 f2 q2 in
-  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv hf1.ehf_f f2 env in
-  let p1 = hf1.ehf_pr and q1 = hf1.ehf_po in
+  let (prml, _prmr), (poml, pomr) = Fun.equivF_memenv p.ml p.mr hf1.ehf_f f2 env in
+  let p1 = (ehf_pr hf1) and q1 = (ehf_po hf1) in
   let cond1 =
-    let fv1 = PV.fv env mright p in
-    let fv2 = PV.fv env mhr p2 in
+    let fv1 = PV.fv env p.mr p.inv in
+    let fv2 = PV.fv env p2.m p2.inv in
     let fv = PV.union fv1 fv2 in
     let elts, glob = PV.ntr_elements fv in
-    let bd, s = generalize_subst env mhr elts glob in
-    let s1 = PVM.of_mpv s mright in
-    let s2 = PVM.of_mpv s mhr in
-    let p1 = Fsubst.f_subst_mem mhr mleft p1 in
+    let bd, s = generalize_subst env p2.m elts glob in
+    let s1 = PVM.of_mpv s p.mr in
+    let s2 = PVM.of_mpv s p2.m in
+    let p1 = ss_inv_rebind p1 p.ml in
     let concl =
-     f_or (f_eq p1 f_xreal_inf)
-       (f_and (PVM.subst env s1 p) (f_xreal_le (PVM.subst env s2 p2) p1)) in
+     f_or (f_eq p1.inv f_xreal_inf)
+       (f_and (PVM.subst env s1 p.inv) (f_xreal_le (PVM.subst env s2 p2.inv) p1.inv)) in
     f_forall_mems [prml] (f_exists bd concl) in
   let cond2 =
-    let q1 = Fsubst.f_subst_mem mhr mleft q1 in
-    let q2 = Fsubst.f_subst_mem mhr mright q2 in
-    f_forall_mems [poml; pomr] (f_imp q (f_xreal_le q1 q2)) in
+    let q1 = ss_inv_rebind q1 q.ml in
+    let q1 = ss_inv_generalize_right q1 q.mr in
+    let q2 = ss_inv_rebind q2 q.mr in
+    let q2 = ss_inv_generalize_left q2 q.ml in
+    f_forall_mems_ts_inv poml pomr (map_ts_inv3 (fun q q1 q2 -> f_imp q (f_xreal_le q1 q2)) q q1 q2) in
   FApi.xmutate1 tc `HoareFConseqEquiv [cond1; cond2; ef; hf2]
 
 
@@ -804,7 +897,7 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
   (* hoareS / hoareS / ⊥ / ⊥                                            *)
   | FhoareS _, Some ((_, {f_node = FhoareS hs}) as nf1), None, None ->
     let tac = if notmod then t_hoareS_conseq_nm else t_hoareS_conseq in
-    t_on1 2 (t_apply_r nf1) (tac hs.hs_pr hs.hs_po tc)
+    t_on1 2 (t_apply_r nf1) (tac (hs_pr hs) (hs_po hs) tc)
 
   (* ------------------------------------------------------------------ *)
   (* hoareS / hoareS / hoareS / ⊥                                       *)
@@ -817,9 +910,10 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_hoareS_conseq_nm else t_hoareS_conseq in
 
     t_on1seq 2
-      (tac (f_and hs.hs_pr hs2.hs_pr) (f_and hs.hs_po hs2.hs_po))
+      (tac (map_ss_inv2 f_and (hs_pr hs) (hs_pr hs2)) 
+            (map_ss_inv2 f_and (hs_po hs) (hs_po hs2)))
       (FApi.t_seqsub
-         (t_hoareS_conseq_conj hs2.hs_pr hs2.hs_po hs.hs_pr hs.hs_po)
+         (t_hoareS_conseq_conj (hs_pr hs2) (hs_po hs2) (hs_pr hs) (hs_po hs))
          [t_apply_r nf2; t_apply_r nf1])
       tc
 
@@ -828,35 +922,39 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
   | FhoareS _, Some ((_, {f_node = FbdHoareS hs}) as nf1), None, None ->
     let tac = if notmod then t_bdHoareS_conseq_nm else t_bdHoareS_conseq in
 
-    check_is_detbound `First hs.bhs_bd;
+    check_is_detbound `First (bhs_bd hs).inv;
 
     FApi.t_seq
       t_hoareS_conseq_bdhoare
       (t_on1seq 1
-         (t_bdHoareS_conseq_bd hs.bhs_cmp hs.bhs_bd)
-         (t_on1seq 2 (tac hs.bhs_pr hs.bhs_po) (t_apply_r nf1)))
+         (t_bdHoareS_conseq_bd hs.bhs_cmp (bhs_bd hs))
+         (t_on1seq 2 (tac (bhs_pr hs) (bhs_po hs)) (t_apply_r nf1)))
       tc
 
   (* ------------------------------------------------------------------ *)
   (* hoareF / hoareF / ⊥ / ⊥                                            *)
   | FhoareF _, Some ((_, {f_node = FhoareF hs}) as nf1), None, None ->
     let tac = if notmod then t_hoareF_conseq_nm else t_hoareF_conseq in
-    t_on1 2 (t_apply_r nf1) (tac hs.hf_pr hs.hf_po tc)
+    t_on1 2 (t_apply_r nf1) (tac (hf_pr hs) (hf_po hs) tc)
 
   (* ------------------------------------------------------------------ *)
   (* hoareF / hoareF / hoareF / ⊥                                       *)
   | FhoareF _,
-      Some ((_, {f_node = FhoareF hs}) as nf1),
+      Some ((_, {f_node = FhoareF hf}) as nf1),
       Some((_, f2) as nf2),
       None
     ->
     let hs2 = pf_as_hoareF !!tc f2 in
     let tac = if notmod then t_hoareF_conseq_nm else t_hoareF_conseq in
-
+    let pr1, po1 = hf_pr hf, hf_po hf in
+    let pr2 = ss_inv_rebind (hf_pr hs2) hf.hf_m in
+    let po2 = ss_inv_rebind (hf_po hs2) hf.hf_m in
+    (* check that the pre- and post-conditions are well formed *)
     t_on1seq 2
-      (tac (f_and hs.hf_pr hs2.hf_pr) (f_and hs.hf_po hs2.hf_po))
+      ((tac (map_ss_inv2 f_and pr1 pr2) 
+           (map_ss_inv2 f_and po1 po2)))
       (FApi.t_seqsub
-         (t_hoareF_conseq_conj hs2.hf_pr hs2.hf_po hs.hf_pr hs.hf_po)
+         (t_hoareF_conseq_conj pr2 po2 pr1 po1)
          [t_apply_r nf2; t_apply_r nf1])
       tc
 
@@ -865,13 +963,13 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
   | FhoareF _, Some ((_, {f_node = FbdHoareF hs}) as nf1), None, None ->
     let tac = if notmod then t_bdHoareF_conseq_nm else t_bdHoareF_conseq in
 
-    check_is_detbound `First hs.bhf_bd;
+    check_is_detbound `First (bhf_bd hs).inv;
 
     FApi.t_seq
       t_hoareF_conseq_bdhoare
       (t_on1seq 1
-         (t_bdHoareF_conseq_bd hs.bhf_cmp hs.bhf_bd)
-         (t_on1seq 2 (tac hs.bhf_pr hs.bhf_po) (t_apply_r nf1)))
+         (t_bdHoareF_conseq_bd hs.bhf_cmp (bhf_bd hs))
+         (t_on1seq 2 (tac (bhf_pr hs) (bhf_po hs)) (t_apply_r nf1)))
       tc
   (* ------------------------------------------------------------------ *)
   (* hoareF / equivF / hoareF                                           *)
@@ -879,20 +977,20 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     Some ((_, {f_node = FequivF ef}) as nef), Some((_, f2) as nf2), _ ->
     let hf2 = pf_as_hoareF !!tc f2 in
     FApi.t_seqsub
-      (t_hoareF_conseq_equiv hf2.hf_f ef.ef_pr ef.ef_po hf2.hf_pr hf2.hf_po)
+      (t_hoareF_conseq_equiv hf2.hf_f (ef_pr ef) (ef_po ef) (hf_pr hf2) (hf_po hf2))
       [t_id; t_id; t_apply_r nef; t_apply_r nf2] tc
 
   (* ------------------------------------------------------------------ *)
   (* ehoareS / ehoareS / ⊥ / ⊥                                            *)
   | FeHoareS _, Some ((_, {f_node = FeHoareS hs}) as nf1), None, None ->
     let tac = if notmod then t_ehoareS_conseq_nm else t_ehoareS_conseq in
-    FApi.t_last (t_apply_r nf1) (tac hs.ehs_pr hs.ehs_po tc)
+    FApi.t_last (t_apply_r nf1) (tac (ehs_pr hs) (ehs_po hs) tc)
 
   (* ------------------------------------------------------------------ *)
   (* ehoareF / ehoareF / ⊥ / ⊥                                            *)
   | FeHoareF _, Some ((_, {f_node = FeHoareF hf}) as nf1), None, None ->
     let tac = if notmod then t_ehoareF_conseq_nm else t_ehoareF_conseq in
-    FApi.t_last (t_apply_r nf1) (tac hf.ehf_pr hf.ehf_po tc)
+    FApi.t_last (t_apply_r nf1) (tac (ehf_pr hf) (ehf_po hf) tc)
 
   (* ------------------------------------------------------------------ *)
   (* ehoareF / equivF / ehoareF                                           *)
@@ -900,7 +998,7 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     Some ((_, {f_node = FequivF ef}) as nef), Some((_, f2) as nf2), _ ->
     let hf2 = pf_as_ehoareF !!tc f2 in
     FApi.t_seqsub
-      (t_ehoareF_conseq_equiv hf2.ehf_f ef.ef_pr ef.ef_po hf2.ehf_pr hf2.ehf_po)
+      (t_ehoareF_conseq_equiv hf2.ehf_f (ef_pr ef) (ef_po ef) (ehf_pr hf2) (ehf_po hf2))
       [t_id; t_id; t_apply_r nef; t_apply_r nf2] tc
 
   (* ------------------------------------------------------------------ *)
@@ -909,8 +1007,8 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_bdHoareS_conseq_nm else t_bdHoareS_conseq in
 
     t_on1seq 1
-      (t_bdHoareS_conseq_bd hs.bhs_cmp hs.bhs_bd)
-      (t_on1seq 2 (tac hs.bhs_pr hs.bhs_po) (t_apply_r nf1))
+      (t_bdHoareS_conseq_bd hs.bhs_cmp (bhs_bd hs))
+      (t_on1seq 2 (tac (bhs_pr hs) (bhs_po hs)) (t_apply_r nf1))
       tc
 
   (* ------------------------------------------------------------------ *)
@@ -925,27 +1023,28 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
 
     let m,hi,hh, h0 =
       as_seq4 (LDecl.fresh_ids (FApi.tc1_hyps tc) ["&m";"_";"_";"_"]) in
-    let pre    = f_and hs.bhs_pr hs2.hs_pr in
-    let mpre   = Fsubst.f_subst_mem mhr m pre in
-    let post1  = hs0.bhs_po in
-    let post   = hs.bhs_po in
-    let posta  = f_and post hs2.hs_po in
+    let pre    = map_ss_inv2 f_and (bhs_pr hs) (hs_pr hs2) in
+    (* TODO: dubious *)
+    let mpre   = Fsubst.f_subst_mem pre.m m pre.inv in
+    let post1  = (bhs_po hs0) in
+    let post   = (bhs_po hs) in
+    let posta  = map_ss_inv2 f_and post (hs_po hs2) in
 
-    let concl1 = f_forall_mems [hs0.bhs_m] (f_imp hs0.bhs_pr pre) in
+    let concl1 = f_forall_mems_ss_inv hs0.bhs_m (map_ss_inv2 f_imp (bhs_pr hs0) pre) in
 
     let tc = ( t_cut concl1 @+
         [ t_id;   (* subgoal 1 : pre *)
           t_intro_i hi @!
-          t_cut (f_hoareS_r {hs2 with hs_pr = pre}) @+ [
-            t_hoareS_conseq hs2.hs_pr hs2.hs_po @+
+          t_cut (f_hoareS (snd hs2.hs_m) pre hs2.hs_s (hs_po hs2)) @+ [
+            t_hoareS_conseq (hs_pr hs2) (hs_po hs2) @+
                 [ EcLowGoal.t_trivial;
                   t_mytrivial;
                   t_clear hi (* subgoal 2 : hs2 *)];
             t_intro_i hh @!
-            (t_bdHoareS_conseq_bd hs.bhs_cmp hs.bhs_bd @+ [
+            (t_bdHoareS_conseq_bd hs.bhs_cmp (bhs_bd hs) @+ [
               t_id; (* subgoal 3 : bound *)
-              t_bdHoareS_conseq_conj ~add:false hs2.hs_po post1 @+ [
-                t_hoareS_conseq pre hs2.hs_po @+ [
+              t_bdHoareS_conseq_conj ~add:false (hs_po hs2) post1 @+ [
+                t_hoareS_conseq pre (hs_po hs2) @+ [
                   t_intros_i [m;h0] @! t_cutdef
                     (ptlocal ~args:[pamemory m; palocal h0] hi)
                     mpre @! EcLowGoal.t_trivial;
@@ -954,9 +1053,9 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
                 tac pre posta @+ [
                   t_apply_hyp hi;
                   t_id; (* subgoal 4 : post *)
-                  t_bdHoareS_conseq_conj ~add:true hs2.hs_po post @+ [
+                  t_bdHoareS_conseq_conj ~add:true (hs_po hs2) post @+ [
                     t_apply_hyp hh;
-                    t_bdHoareS_conseq hs.bhs_pr post @+ [
+                    t_bdHoareS_conseq (bhs_pr hs) post @+ [
                       EcLowGoal.t_trivial;
                       t_mytrivial;
                       t_id (* subgoal 5 : bdhoare *)
@@ -980,8 +1079,8 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_bdHoareF_conseq_nm else t_bdHoareF_conseq in
 
     t_on1seq 1
-      (t_bdHoareF_conseq_bd hs.bhf_cmp hs.bhf_bd)
-      (t_on1seq 2 (tac hs.bhf_pr hs.bhf_po) (t_apply_r nf1))
+      (t_bdHoareF_conseq_bd hs.bhf_cmp (bhf_bd hs))
+      (t_on1seq 2 (tac (bhf_pr hs) (bhf_po hs)) (t_apply_r nf1))
       tc
 
   (* ------------------------------------------------------------------ *)
@@ -996,27 +1095,29 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_bdHoareF_conseq_nm else t_bdHoareF_conseq in
     let m,hi,hh, h0 =
       as_seq4 (LDecl.fresh_ids (FApi.tc1_hyps tc) ["&m";"_";"_";"_"]) in
-    let pre    = f_and hs.bhf_pr hs2.hf_pr in
-    let mpre   = Fsubst.f_subst_mem mhr m pre in
-    let post1  = hs0.bhf_po in
-    let post   = hs.bhf_po in
-    let posta  = f_and post hs2.hf_po in
-    let mpr,_ = EcEnv.Fun.hoareF_memenv hs0.bhf_f (FApi.tc1_env tc) in
-    let concl1 = f_forall_mems [mpr] (f_imp hs0.bhf_pr pre) in
+    let hs_pr = ss_inv_rebind (bhf_pr hs) hs2.hf_m in
+    let hs0_pr = ss_inv_rebind (bhf_pr hs0) hs2.hf_m in
+    let pre    = map_ss_inv2 f_and hs_pr (hf_pr hs2) in
+    let mpre   = Fsubst.f_subst_mem pre.m m pre.inv in
+    let post1  = (bhf_po hs0) in
+    let post   = ss_inv_rebind (bhf_po hs) hs2.hf_m in
+    let posta  = map_ss_inv2 f_and post (hf_po hs2) in
+    let mpr,_ = EcEnv.Fun.hoareF_memenv hs0.bhf_m hs0.bhf_f (FApi.tc1_env tc) in
+    let concl1 = f_forall_mems_ss_inv mpr (map_ss_inv2 f_imp hs0_pr pre) in
 
     let tc = ( t_cut concl1 @+
         [ t_id;   (* subgoal 1 : pre *)
           t_intro_i hi @!
-          t_cut (f_hoareF_r {hs2 with hf_pr = pre}) @+ [
-            t_hoareF_conseq hs2.hf_pr hs2.hf_po @+
+          t_cut (f_hoareF pre hs2.hf_f (hf_po hs2)) @+ [
+            t_hoareF_conseq (hf_pr hs2) (hf_po hs2) @+
                 [ EcLowGoal.t_trivial;
                   t_mytrivial;
                   t_clear hi (* subgoal 2 : hs2 *)];
             t_intro_i hh @!
-            (t_bdHoareF_conseq_bd hs.bhf_cmp hs.bhf_bd @+ [
+            (t_bdHoareF_conseq_bd hs.bhf_cmp (bhf_bd hs) @+ [
               t_id; (* subgoal 3 : bound *)
-              t_bdHoareF_conseq_conj ~add:false hs2.hf_po post1 @+ [
-                t_hoareF_conseq pre hs2.hf_po @+ [
+              t_bdHoareF_conseq_conj ~add:false (hf_po hs2) post1 @+ [
+                t_hoareF_conseq pre (hf_po hs2) @+ [
                   t_intros_i [m;h0] @! t_cutdef
                     (ptlocal ~args:[pamemory m; palocal h0] hi)
                     mpre @! EcLowGoal.t_trivial;
@@ -1025,9 +1126,9 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
                 tac pre posta @+ [
                   t_apply_hyp hi;
                   t_id; (* subgoal 4 : post *)
-                  t_bdHoareF_conseq_conj ~add:true hs2.hf_po post @+ [
+                  t_bdHoareF_conseq_conj ~add:true (hf_po hs2) post @+ [
                     t_apply_hyp hh;
-                    t_bdHoareF_conseq hs.bhf_pr post @+ [
+                    t_bdHoareF_conseq (bhf_pr hs) post @+ [
                       EcLowGoal.t_trivial;
                       t_mytrivial;
                       t_id (* subgoal 5 : bdhoare *)
@@ -1046,19 +1147,20 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
       tc
 
   (* ------------------------------------------------------------------ *)
-  (* bdhoareF / equivF / bdhoareF                                           *)
+  (* bdhoareF / equivF / bdhoareF                                       *)
   | FbdHoareF _,
     Some ((_, {f_node = FequivF ef}) as nef), Some((_, f2) as nf2), _ ->
     let hf2 = pf_as_bdhoareF !!tc f2 in
     FApi.t_seqsub
-      (t_bdHoareF_conseq_equiv hf2.bhf_f ef.ef_pr ef.ef_po hf2.bhf_pr hf2.bhf_po)
+      (t_bdHoareF_conseq_equiv hf2.bhf_f (ef_pr ef) (ef_po ef) 
+                                         (bhf_pr hf2) (bhf_po hf2))
       [t_id; t_id; t_apply_r nef; t_apply_r nf2] tc
 
   (* ------------------------------------------------------------------ *)
   (* equivS / equivS / ⊥ / ⊥                                            *)
   | FequivS _, Some ((_, {f_node = FequivS es}) as nf1), None, None ->
     let tac = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
-    t_on1 2 (t_apply_r nf1) (tac es.es_pr es.es_po tc)
+    t_on1 2 (t_apply_r nf1) (tac (es_pr es) (es_po es) tc)
 
   (* ------------------------------------------------------------------ *)
   (* equivS / equivS / hoareS / hoareS  *)
@@ -1067,18 +1169,21 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
       Some ((_, f2) as nf2),
       Some ((_, f3) as nf3)
     ->
-    let subst1 = Fsubst.f_subst_mem mhr mleft  in
-    let subst2 = Fsubst.f_subst_mem mhr mright in
     let hs2    = pf_as_hoareS !!tc f2 in
     let hs3    = pf_as_hoareS !!tc f3 in
-    let pre    = f_ands [es.es_pr; subst1 hs2.hs_pr; subst2 hs3.hs_pr] in
-    let post   = f_ands [es.es_po; subst1 hs2.hs_po; subst2 hs3.hs_po] in
+    let (ml, mr) = (fst es.es_ml, fst es.es_mr) in
+    let hs2_pr = ss_inv_generalize_right (ss_inv_rebind (hs_pr hs2) ml) mr in
+    let hs2_po = ss_inv_generalize_right (ss_inv_rebind (hs_po hs2) ml) mr in
+    let hs3_pr = ss_inv_generalize_left (ss_inv_rebind (hs_pr hs3) mr) ml in
+    let hs3_po = ss_inv_generalize_left (ss_inv_rebind (hs_po hs3) mr) ml in
+    let pre    = map_ts_inv f_ands [es_pr es; hs2_pr; hs3_pr] in
+    let post   = map_ts_inv f_ands [es_po es; hs2_po; hs3_po] in
     let tac    = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
 
     t_on1seq 2 (tac pre post)
       (FApi.t_seqsub
          (t_equivS_conseq_conj
-            hs2.hs_pr hs2.hs_po hs3.hs_pr hs3.hs_po es.es_pr es.es_po)
+            (hs_pr hs2) (hs_po hs2) (hs_pr hs3) (hs_po hs3) (es_pr es) (es_po es))
          [t_apply_r nf2; t_apply_r nf3; t_apply_r nf1])
       tc
 
@@ -1090,7 +1195,7 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
 
     t_on1seq 2
-      (tac es.es_pr es.es_po)
+      (tac (es_pr es) (es_po es))
       (t_hi_conseq notmod None f2 None)
       tc
 
@@ -1102,53 +1207,57 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
     let tac = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
 
     t_on1seq 2
-      (tac es.es_pr es.es_po)
+      (tac (es_pr es) (es_po es))
       (t_hi_conseq notmod None None f3)
       tc
 
   (* ------------------------------------------------------------------ *)
   (* equivS / ? / ? / ⊥                                                 *)
   | FequivS es, Some _, Some _, None ->
-    let f3 = f_hoareS (mhr, snd es.es_mr) f_true es.es_sr f_true in
+    let m = EcIdent.create "&hr" in
+    let f3 = f_hoareS (snd es.es_mr) {m;inv=f_true} es.es_sr {m;inv=f_true} in
     t_hi_conseq notmod f1 f2 (Some (None, f3)) tc
 
   (* ------------------------------------------------------------------ *)
   (* equivS / ? / ⊥ / ?                                                 *)
   | FequivS es, Some _, None, Some _ ->
-    let f2 = f_hoareS (mhr, snd es.es_ml) f_true es.es_sl f_true in
+    let m = EcIdent.create "&hr" in
+    let f2 = f_hoareS (snd es.es_ml) {m;inv=f_true} es.es_sl {m;inv=f_true} in
     t_hi_conseq notmod f1 (Some (None, f2)) f3 tc
 
   (* ------------------------------------------------------------------ *)
   (* equivS / ⊥ / bdhoareS / ⊥                                          *)
-  | FequivS _, None, Some ((_, f2) as nf2), None ->
-    let subst1 = Fsubst.f_subst_mem mhr mleft in
+  | FequivS es, None, Some ((_, f2) as nf2), None ->
     let hs = pf_as_bdhoareS !!tc f2 in
-    let pre, post = subst1 hs.bhs_pr, subst1 hs.bhs_po in
+    let (ml, mr) = (fst es.es_ml, fst es.es_mr) in
+    let pre = ss_inv_generalize_right (ss_inv_rebind (bhs_pr hs) ml) mr in
+    let post = ss_inv_generalize_right (ss_inv_rebind (bhs_po hs) ml) mr in
     let tac = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
 
-    check_is_detbound `Second hs.bhs_bd;
+    check_is_detbound `Second (bhs_bd hs).inv;
 
     t_on1seq 2
      (tac pre post)
      (FApi.t_seq
-        (t_equivS_conseq_bd `Left hs.bhs_pr hs.bhs_po)
+        (t_equivS_conseq_bd `Left (bhs_pr hs) (bhs_po hs))
         (t_apply_r nf2))
      tc
 
   (* ------------------------------------------------------------------ *)
   (* equivS / ⊥ / ⊥ / bdhoareS                                          *)
-  | FequivS _, None, None, Some ((_, f3) as nf3) ->
-    let subst2 = Fsubst.f_subst_mem mhr mright in
+  | FequivS es, None, None, Some ((_, f3) as nf3) ->
     let hs = pf_as_bdhoareS !!tc f3 in
-    let pre, post = subst2 hs.bhs_pr, subst2 hs.bhs_po in
+    let (ml, mr) = (fst es.es_ml, fst es.es_mr) in
+    let pre = ss_inv_generalize_left (ss_inv_rebind (bhs_pr hs) mr) ml in
+    let post = ss_inv_generalize_left (ss_inv_rebind (bhs_po hs) mr) ml in
     let tac = if notmod then t_equivS_conseq_nm else t_equivS_conseq in
 
-    check_is_detbound `Third hs.bhs_bd;
+    check_is_detbound `Third (bhs_bd hs).inv;
 
     t_on1seq 2
       (tac pre post)
       (FApi.t_seq
-         (t_equivS_conseq_bd `Right hs.bhs_pr hs.bhs_po)
+         (t_equivS_conseq_bd `Right (bhs_pr hs) (bhs_po hs))
          (t_apply_r nf3))
       tc
 
@@ -1156,7 +1265,7 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
   (* equivF / equivF / ⊥ / ⊥                                            *)
   | FequivF _, Some ((_, {f_node = FequivF ef}) as nf1), None, None ->
     let tac = if notmod then t_equivF_conseq_nm else t_equivF_conseq in
-    t_on1seq 2 (tac ef.ef_pr ef.ef_po) (t_apply_r nf1) tc
+    t_on1seq 2 (tac (ef_pr ef) (ef_po ef)) (t_apply_r nf1) tc
 
   (* ------------------------------------------------------------------ *)
   (* equivF / equivF / hoareF / hoareF                                  *)
@@ -1165,32 +1274,36 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
       Some ((_, f2) as nf2),
       Some ((_, f3) as nf3)
     ->
-    let subst1 = Fsubst.f_subst_mem mhr mleft in
-    let subst2 = Fsubst.f_subst_mem mhr mright in
     let hs2    = pf_as_hoareF !!tc f2 in
     let hs3    = pf_as_hoareF !!tc f3 in
-    let pre    = f_ands [ef.ef_pr; subst1 hs2.hf_pr; subst2 hs3.hf_pr] in
-    let post   = f_ands [ef.ef_po; subst1 hs2.hf_po; subst2 hs3.hf_po] in
+    let (ml, mr) = (ef.ef_ml, ef.ef_mr) in
+    let hs2_pr = ss_inv_generalize_right (ss_inv_rebind (hf_pr hs2) ml) mr in
+    let hs3_pr = ss_inv_generalize_left (ss_inv_rebind (hf_pr hs3) mr) ml in
+    let pre    = map_ts_inv f_ands [ef_pr ef; hs2_pr; hs3_pr] in
+    let hs2_po = ss_inv_generalize_right (ss_inv_rebind (hf_po hs2) ml) mr in
+    let hs3_po = ss_inv_generalize_left (ss_inv_rebind (hf_po hs3) mr) ml in
+    let post  = map_ts_inv f_ands [ef_po ef; hs2_po; hs3_po] in
     let tac    = if notmod then t_equivF_conseq_nm else t_equivF_conseq in
-
     t_on1seq 2
       (tac pre post)
       (FApi.t_seqsub
          (t_equivF_conseq_conj
-            hs2.hf_pr hs2.hf_po hs3.hf_pr hs3.hf_po ef.ef_pr ef.ef_po)
+            (hf_pr hs2) (hf_po hs2) (hf_pr hs3) (hf_po hs3) (ef_pr ef) (ef_po ef))
          [t_apply_r nf2; t_apply_r nf3; t_apply_r nf1])
       tc
 
   (* ------------------------------------------------------------------ *)
   (* equivF / ? / ? / ⊥                                                 *)
   | FequivF ef, Some _, Some _, None ->
-    let f3 = f_hoareF f_true ef.ef_fr f_true in
+    let m = EcIdent.create "&hr" in
+    let f3 = f_hoareF {m;inv=f_true} ef.ef_fr {m;inv=f_true} in
     t_hi_conseq notmod f1 f2 (Some (None, f3)) tc
 
   (* ------------------------------------------------------------------ *)
   (* equivF / ? / ⊥ / ?                                                 *)
   | FequivF ef, Some _, None, Some _ ->
-    let f2 = f_hoareF f_true ef.ef_fl f_true in
+    let m = EcIdent.create "&hr" in
+    let f2 = f_hoareF {m;inv=f_true} ef.ef_fl {m;inv=f_true} in
     t_hi_conseq notmod f1 (Some (None, f2)) f3 tc
 
   | _ ->
@@ -1217,10 +1330,10 @@ let rec t_hi_conseq notmod f1 f2 f3 tc =
 
 (* -------------------------------------------------------------------- *)
 type processed_conseq_info =
-  | PCI_bd of hoarecmp option * form
+  | PCI_bd of hoarecmp option * ss_inv
 
-let process_info pe hyps = function
-  | CQI_bd (cmp, bd) -> PCI_bd (cmp, TTC.pf_process_form pe hyps treal bd)
+let process_info pe hyps m = function
+  | CQI_bd (cmp, bd) -> PCI_bd (cmp, {m; inv=TTC.pf_process_form pe hyps treal bd})
 
 let process_conseq notmod ((info1, info2, info3) : conseq_ppterm option tuple3) tc =
   let hyps, concl = FApi.tc1_flat tc in
@@ -1232,18 +1345,18 @@ let process_conseq notmod ((info1, info2, info3) : conseq_ppterm option tuple3) 
      let penv, qenv, gpre, gpost, ty, fmake =
       match concl.f_node with
       | FhoareS hs ->
-        let env = LDecl.push_active hs.hs_m hyps in
+        let env = LDecl.push_active_ss hs.hs_m hyps in
 
         let fmake pre post c_or_bd =
           match c_or_bd with
           | None ->
-            f_hoareS_r { hs with hs_pr = pre; hs_po = post; }
+            f_hoareS(snd hs.hs_m) pre hs.hs_s post
           | Some (PCI_bd (cmp, bd)) ->
-            f_bdHoareS hs.hs_m pre hs.hs_s post (oget cmp) bd
-        in (env, env, hs.hs_pr, hs.hs_po, tbool, fmake)
+            f_bdHoareS (snd hs.hs_m) pre hs.hs_s post (oget cmp) bd
+        in (env, env, Inv_ss (hs_pr hs), Inv_ss (hs_po hs), tbool, lift_ss_inv2 fmake)
 
       | FhoareF hf ->
-        let penv, qenv = LDecl.hoareF hf.hf_f hyps in
+        let penv, qenv = LDecl.hoareF hf.hf_m hf.hf_f hyps in
 
         let fmake pre post c_or_bd =
           match c_or_bd with
@@ -1252,172 +1365,192 @@ let process_conseq notmod ((info1, info2, info3) : conseq_ppterm option tuple3) 
           | Some (PCI_bd (cmp, bd)) ->
             f_bdHoareF pre hf.hf_f post (oget cmp) bd
 
-        in (penv, qenv, hf.hf_pr, hf.hf_po, tbool, fmake)
+        in (penv, qenv, Inv_ss (hf_pr hf), Inv_ss (hf_po hf), tbool, lift_ss_inv2 fmake)
 
       | FeHoareS hs ->
-        let env = LDecl.push_active hs.ehs_m hyps in
+        let env = LDecl.push_active_ss hs.ehs_m hyps in
         let fmake pre post bd =
           ensure_none bd;
-          f_eHoareS_r { hs with ehs_pr = pre; ehs_po = post; } in
-        (env, env, hs.ehs_pr, hs.ehs_po, txreal, fmake)
+          f_eHoareS (snd hs.ehs_m) pre hs.ehs_s post in
+        (env, env, Inv_ss (ehs_pr hs), Inv_ss (ehs_po hs), txreal, lift_ss_inv2 fmake)
 
       | FeHoareF hf ->
-        let penv, qenv = LDecl.hoareF hf.ehf_f hyps in
+        let penv, qenv = LDecl.hoareF hf.ehf_m hf.ehf_f hyps in
         let fmake pre post bd =
           ensure_none bd;
-          f_eHoareF_r { hf with ehf_pr = pre; ehf_po = post } in
-        (penv, qenv, hf.ehf_pr, hf.ehf_po, txreal, fmake)
+          f_eHoareF pre hf.ehf_f post in
+        (penv, qenv, Inv_ss (ehf_pr hf), Inv_ss (ehf_po hf), txreal, lift_ss_inv2 fmake)
 
       | FbdHoareS bhs ->
-        let env = LDecl.push_active bhs.bhs_m hyps in
+        let env = LDecl.push_active_ss bhs.bhs_m hyps in
 
         let fmake pre post c_or_bd =
           match c_or_bd with
           | None                   ->
-            f_bdHoareS_r { bhs with bhs_pr = pre;
-                                    bhs_po = post; }
+            f_bdHoareS (snd bhs.bhs_m) pre bhs.bhs_s post bhs.bhs_cmp (bhs_bd bhs)
           | Some (PCI_bd (cmp,bd)) ->
             let cmp = odfl bhs.bhs_cmp cmp in
-            f_bdHoareS_r { bhs with bhs_pr = pre;
-                                    bhs_po = post;
-                                    bhs_cmp = cmp;
-                                    bhs_bd = bd; }
-        in
+            f_bdHoareS (snd bhs.bhs_m) pre bhs.bhs_s post cmp bd in
 
-        (env, env, bhs.bhs_pr, bhs.bhs_po, tbool, fmake)
+        (env, env, Inv_ss (bhs_pr bhs), Inv_ss (bhs_po bhs), tbool, lift_ss_inv2 fmake)
 
       | FbdHoareF hf ->
-        let penv, qenv = LDecl.hoareF hf.bhf_f hyps in
+        let penv, qenv = LDecl.hoareF hf.bhf_m hf.bhf_f hyps in
 
         let fmake pre post c_or_bd =
           match c_or_bd with
           | None                   ->
-            f_bdHoareF pre hf.bhf_f post hf.bhf_cmp hf.bhf_bd
+            f_bdHoareF pre hf.bhf_f post hf.bhf_cmp (bhf_bd hf)
           | Some (PCI_bd (cmp,bd)) ->
             let cmp = odfl hf.bhf_cmp cmp in
             f_bdHoareF pre hf.bhf_f post cmp bd
         in
 
-        (penv, qenv, hf.bhf_pr, hf.bhf_po, tbool, fmake)
+        (penv, qenv, Inv_ss (bhf_pr hf), Inv_ss (bhf_po hf), tbool, lift_ss_inv2 fmake)
 
       | FequivF ef ->
-        let penv, qenv = LDecl.equivF ef.ef_fl ef.ef_fr hyps in
+        let penv, qenv = LDecl.equivF ef.ef_ml ef.ef_mr ef.ef_fl ef.ef_fr hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd;
           f_equivF pre ef.ef_fl ef.ef_fr post
-        in (penv, qenv, ef.ef_pr, ef.ef_po, tbool, fmake)
+        in (penv, qenv, Inv_ts (ef_pr ef), Inv_ts (ef_po ef), tbool, lift_ts_inv2 fmake)
 
       | FequivS es ->
-        let env = LDecl.push_all [es.es_ml; es.es_mr] hyps in
+        let env = LDecl.push_active_ts es.es_ml es.es_mr hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd;
-          f_equivS_r { es with es_pr = pre; es_po = post; }
-        in (env, env, es.es_pr, es.es_po, tbool, fmake)
+          f_equivS (snd es.es_ml) (snd es.es_mr) pre es.es_sl es.es_sr post
+        in (env, env, Inv_ts (es_pr es), Inv_ts (es_po es), tbool, lift_ts_inv2 fmake)
 
       | _ -> tc_error !!tc "conseq: not a phl/prhl judgement"
     in
 
-    let pre  = pre  |> omap (TTC.pf_process_form !!tc penv ty) |> odfl gpre  in
-    let post = post |> omap (TTC.pf_process_form !!tc qenv ty) |> odfl gpost in
-    let bd   = bd |> omap (process_info !!tc penv) in
+    let pre  = pre  |> omap (TTC.pf_process_form !!tc penv ty) |> odfl (inv_of_inv gpre)  in
+    let post = post |> omap (TTC.pf_process_form !!tc qenv ty) |> odfl (inv_of_inv gpost) in
+
+    let (pre, post, bd) = match gpre, gpost with
+    | Inv_ss gpre, Inv_ss gpost ->
+        let bd = bd |> omap (process_info !!tc penv gpre.m) in
+        (Inv_ss {inv=pre;m=gpre.m}, Inv_ss {inv=post;m=gpost.m}, bd)
+    | Inv_ts gpre, Inv_ts gpost ->
+        ensure_none bd;
+        (Inv_ts {inv=pre;ml=gpre.ml;mr=gpost.mr},
+         Inv_ts {inv=post;ml=gpost.ml;mr=gpost.mr},
+         None)
+    | _ -> tc_error !!tc "conseq: pre and post must be of the same kind" in
 
     fmake pre post bd
-
   in
 
   let process_cut2 side f1 ((pre, post), c_or_bd) =
     let penv, qenv, gpre, gpost, ty, fmake =
       match concl.f_node with
       | FhoareS hs ->
-        let env = LDecl.push_active hs.hs_m hyps in
+        let env = LDecl.push_active_ss hs.hs_m hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd;
-          f_hoareS_r { hs with hs_pr = pre; hs_po = post; }
-        in (env, env, hs.hs_pr, hs.hs_po, tbool, fmake)
+          f_hoareS (snd hs.hs_m) pre hs.hs_s post
+        in (env, env, Inv_ss (hs_pr hs), Inv_ss (hs_po hs), tbool, lift_ss_inv2 fmake)
 
       | FhoareF hf ->
+        let m = hf.hf_m in
         let f, pr, po = match f1 with
-        | None -> hf.hf_f, hf.hf_pr, hf.hf_po
+        | None -> hf.hf_f, hf_pr hf, hf_po hf
         | Some f1 -> match (snd f1).f_node with
-                     | FequivF ef when side = `Left -> ef.ef_fr, f_true, f_true
-                     | _ -> hf.hf_f, hf.hf_pr, hf.hf_po
+                     | FequivF ef when side = `Left -> 
+                      ef.ef_fr, {m; inv=f_true}, {m; inv=f_true}
+                     | _ -> hf.hf_f, hf_pr hf, hf_po hf
         in
-        let penv, qenv = LDecl.hoareF f hyps in
+        let penv, qenv = LDecl.hoareF m f hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd; f_hoareF pre f post in
-        (penv, qenv, pr, po, tbool, fmake)
+        (penv, qenv, Inv_ss pr, Inv_ss po, tbool, lift_ss_inv2 fmake)
 
       | FeHoareF hf ->
-        let f, pr, po = match f1 with
-        | None -> hf.ehf_f, hf.ehf_pr, hf.ehf_po
+        let f, pr, po, m = match f1 with
+        | None -> hf.ehf_f, ehf_pr hf, ehf_po hf, hf.ehf_m
         | Some f1 -> match (snd f1).f_node with
                      | FequivF ef when side = `Left ->
                          let f_xreal_1 = f_r2xr f_r1 in
-                         ef.ef_fr, f_xreal_1, f_xreal_1
-                     | _ -> hf.ehf_f, hf.ehf_pr, hf.ehf_po
+                         ef.ef_fr, {m=ef.ef_mr; inv=f_xreal_1}, 
+                          {m=ef.ef_mr; inv=f_xreal_1}, ef.ef_mr
+                     | _ -> hf.ehf_f, ehf_pr hf, ehf_po hf, hf.ehf_m
         in
-        let penv, qenv = LDecl.hoareF f hyps in
+        let penv, qenv = LDecl.hoareF m f hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd; f_eHoareF pre f post in
-        (penv, qenv, pr, po, txreal, fmake)
+        (penv, qenv, Inv_ss pr, Inv_ss po, txreal, lift_ss_inv2 fmake)
 
       | FbdHoareS bhs ->
-        let env = LDecl.push_active bhs.bhs_m hyps in
+        let env = LDecl.push_active_ss bhs.bhs_m hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd;
-          f_hoareS bhs.bhs_m pre bhs.bhs_s post
-        in (env, env, bhs.bhs_pr, bhs.bhs_po, tbool, fmake)
+          f_hoareS (snd bhs.bhs_m) pre bhs.bhs_s post
+        in (env, env, Inv_ss (bhs_pr bhs), Inv_ss (bhs_po bhs), tbool, lift_ss_inv2 fmake)
 
       | FbdHoareF bhf ->
-        let f, pr, po = match f1 with
-        | None -> bhf.bhf_f, bhf.bhf_pr, bhf.bhf_po
+        let f, pr, po, m = match f1 with
+        | None -> bhf.bhf_f, bhf_pr bhf, bhf_po bhf, bhf.bhf_m
         | Some f1 -> match (snd f1).f_node with
-                     | FequivF ef when side = `Left -> ef.ef_fr, f_true, f_true
-                     | _ -> bhf.bhf_f, bhf.bhf_pr, bhf.bhf_po
+                     | FequivF ef when side = `Left -> ef.ef_fr, 
+                        {m=ef.ef_mr;inv=f_true}, {m=ef.ef_mr;inv=f_true}, ef.ef_mr
+                     | _ -> bhf.bhf_f, bhf_pr bhf, bhf_po bhf, bhf.bhf_m
         in
-        let penv, qenv = LDecl.hoareF f hyps in
+        let penv, qenv = LDecl.hoareF m f hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd; f_hoareF pre f post in
-        (penv, qenv, pr, po, tbool, fmake)
+        (penv, qenv, Inv_ss pr, Inv_ss po, tbool, lift_ss_inv2 fmake)
 
       | FequivF ef ->
         let f = sideif side ef.ef_fl ef.ef_fr in
-        let penv, qenv = LDecl.hoareF f hyps in
+        let m = sideif side ef.ef_ml ef.ef_mr in
+        let penv, qenv = LDecl.hoareF m f hyps in
         let fmake pre post c_or_bd =
           ensure_none c_or_bd;
           f_hoareF pre f post in
-        (penv, qenv, f_true, f_true, tbool, fmake)
+        let f_true = {m; inv=f_true} in
+        (penv, qenv, Inv_ss f_true, Inv_ss f_true, tbool, lift_ss_inv2 fmake)
 
       | FequivS es ->
         let f = sideif side es.es_sl es.es_sr in
         let m = sideif side es.es_ml es.es_mr in
-        let m = (mhr, snd m) in
-        let env = LDecl.push_active m hyps in
+        let m = (EcIdent.create "&hr", snd m) in
+        let env = LDecl.push_active_ss m hyps in
         let fmake pre post c_or_bd =
           match info1, c_or_bd with
           | None, Some (PCI_bd (cmp,bd)) ->
             let cmp = odfl FHeq cmp in
-            f_bdHoareS m pre f post cmp bd
+            f_bdHoareS (snd m) pre f post cmp bd
 
           | None, None ->
-            let cmp, bd = FHeq, f_r1 in
-            f_bdHoareS m pre f post cmp bd
+            let cmp, bd = FHeq, {m=pre.m; inv=f_r1} in
+            f_bdHoareS (snd m) pre f post cmp bd
 
           | _, None ->
-            f_hoareS m pre f post
+            f_hoareS (snd m) pre f post
 
           | _, Some (PCI_bd (cmp,bd)) ->
             let cmp = odfl FHeq cmp in
-            f_bdHoareS m pre f post cmp bd
-
-        in (env, env, f_true, f_true, tbool, fmake)
+            f_bdHoareS (snd m) pre f post cmp bd in
+        let f_true = {m=fst m; inv=f_true} in
+        (env, env, Inv_ss f_true, Inv_ss f_true, tbool, lift_ss_inv2 fmake)
 
       | _ -> tc_error !!tc "conseq: not a phl/prhl judgement"
     in
 
-    let pre  = pre  |> omap (TTC.pf_process_form !!tc penv ty) |> odfl gpre  in
-    let post = post |> omap (TTC.pf_process_form !!tc qenv ty) |> odfl gpost in
-    let c_or_bd = c_or_bd |> omap (process_info !!tc penv) in
+    let pre  = pre  |> omap (TTC.pf_process_form !!tc penv ty) |> odfl (inv_of_inv gpre)  in
+    let post = post |> omap (TTC.pf_process_form !!tc qenv ty) |> odfl (inv_of_inv gpost) in
+
+    let (pre, post, c_or_bd) = match gpre, gpost with
+    | Inv_ss gpre, Inv_ss gpost ->
+        let bd = c_or_bd |> omap (process_info !!tc penv gpre.m) in
+        (Inv_ss {inv=pre;m=gpre.m}, Inv_ss {inv=post;m=gpost.m}, bd)
+    | Inv_ts gpre, Inv_ts gpost ->
+        ensure_none c_or_bd;
+        (Inv_ts {inv=pre;ml=gpre.ml;mr=gpost.mr},
+         Inv_ts {inv=post;ml=gpost.ml;mr=gpost.mr},
+         None)
+    | _ -> tc_error !!tc "conseq: pre and post must be of the same kind" in
 
     fmake pre post c_or_bd
 
@@ -1471,12 +1604,12 @@ let t_conseqauto ?(delta = true) ?tsolve tc =
 
   let todo =
     match concl.f_node with
-    | FhoareF hf  -> Some (t_hoareF_notmod, cond_hoareF_notmod ~mk_other tc hf.hf_po)
-    | FhoareS hs  -> Some (t_hoareS_notmod, cond_hoareS_notmod ~mk_other tc hs.hs_po )
-    | FbdHoareF hf -> Some (t_bdHoareF_notmod, cond_bdHoareF_notmod ~mk_other tc hf.bhf_po)
-    | FbdHoareS hs -> Some (t_bdHoareS_notmod, cond_bdHoareS_notmod ~mk_other tc hs.bhs_po)
-    | FequivF ef   -> Some (t_equivF_notmod, cond_equivF_notmod ~mk_other tc ef.ef_po)
-    | FequivS es   -> Some (t_equivS_notmod, cond_equivS_notmod ~mk_other tc es.es_po )
+    | FhoareF hf  -> Some (lift_ss_inv t_hoareF_notmod, cond_hoareF_notmod ~mk_other tc (hf_po hf))
+    | FhoareS hs  -> Some (lift_ss_inv t_hoareS_notmod, cond_hoareS_notmod ~mk_other tc (hs_po hs) )
+    | FbdHoareF hf -> Some (lift_ss_inv t_bdHoareF_notmod, cond_bdHoareF_notmod ~mk_other tc (bhf_po hf))
+    | FbdHoareS hs -> Some (lift_ss_inv t_bdHoareS_notmod, cond_bdHoareS_notmod ~mk_other tc (bhs_po hs))
+    | FequivF ef   -> Some (lift_ts_inv t_equivF_notmod, cond_equivF_notmod ~mk_other tc (ef_po ef))
+    | FequivS es   -> Some (lift_ts_inv t_equivS_notmod, cond_equivS_notmod ~mk_other tc (es_po es) )
     | _            -> None in
 
   match todo with
@@ -1513,8 +1646,13 @@ let t_conseqauto ?(delta = true) ?tsolve tc =
         (* Build the inversion substitution *)
         let s = Fsubst.f_subst_id in
         let s = List.fold_left2 Fsubst.f_bind_mem s ms bdm in
-        let s = List.fold_left2 Fsubst.f_bind_local s other (List.map snd bdo) in
+        let s = List.fold_left2 Fsubst.f_bind_local s other (List.map (fun (bdo: _*ss_inv) -> (snd bdo).inv) bdo) in
         Fsubst.f_subst s concl in
+    let post =
+      match ms with
+      | [m] -> Inv_ss { inv = post; m}
+      | [ml; mr] -> Inv_ts { inv = post; ml; mr }
+      | _ -> failwith "posts should have 1 or 2 memory parameters" in
 
     let t_end = FApi.t_try (t_crush ~delta ?tsolve @! t_fail) in
     FApi.t_first t_end (t_notmod post tc)

--- a/src/phl/ecPhlConseq.mli
+++ b/src/phl/ecPhlConseq.mli
@@ -1,43 +1,43 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
-open EcFol
 open EcCoreGoal
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 (* FIXME: add t_low* to all these tactics                               *)
 
 (* -------------------------------------------------------------------- *)
-val t_equivF_conseq       : form -> form -> FApi.backward
-val t_equivS_conseq       : form -> form -> FApi.backward
-val t_eagerF_conseq       : form -> form -> FApi.backward
-val t_hoareF_conseq       : form -> form -> FApi.backward
-val t_hoareS_conseq       : form -> form -> FApi.backward
-val t_bdHoareF_conseq     : form -> form -> FApi.backward
-val t_bdHoareS_conseq     : form -> form -> FApi.backward
+val t_equivF_conseq       : ts_inv -> ts_inv -> FApi.backward
+val t_equivS_conseq       : ts_inv -> ts_inv -> FApi.backward
+val t_eagerF_conseq       : ts_inv -> ts_inv -> FApi.backward
+val t_hoareF_conseq       : ss_inv -> ss_inv -> FApi.backward
+val t_hoareS_conseq       : ss_inv -> ss_inv -> FApi.backward
+val t_bdHoareF_conseq     : ss_inv -> ss_inv -> FApi.backward
+val t_bdHoareS_conseq     : ss_inv -> ss_inv -> FApi.backward
 
-val t_ehoareF_conseq      : form -> form -> FApi.backward
-val t_ehoareS_conseq      : form -> form -> FApi.backward
-val t_bdHoareS_conseq_bd  : hoarecmp -> form -> FApi.backward
-val t_bdHoareF_conseq_bd  : hoarecmp -> form -> FApi.backward
+val t_ehoareF_conseq      : ss_inv -> ss_inv -> FApi.backward
+val t_ehoareS_conseq      : ss_inv -> ss_inv -> FApi.backward
+val t_bdHoareS_conseq_bd  : hoarecmp -> ss_inv -> FApi.backward
+val t_bdHoareF_conseq_bd  : hoarecmp -> ss_inv -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_equivF_conseq_nm    : form -> form -> FApi.backward
-val t_equivS_conseq_nm    : form -> form -> FApi.backward
-val t_hoareF_conseq_nm    : form -> form -> FApi.backward
-val t_hoareS_conseq_nm    : form -> form -> FApi.backward
-val t_bdHoareF_conseq_nm  : form -> form -> FApi.backward
-val t_bdHoareS_conseq_nm  : form -> form -> FApi.backward
+val t_equivF_conseq_nm    : ts_inv -> ts_inv -> FApi.backward
+val t_equivS_conseq_nm    : ts_inv -> ts_inv -> FApi.backward
+val t_hoareF_conseq_nm    : ss_inv -> ss_inv -> FApi.backward
+val t_hoareS_conseq_nm    : ss_inv -> ss_inv -> FApi.backward
+val t_bdHoareF_conseq_nm  : ss_inv -> ss_inv -> FApi.backward
+val t_bdHoareS_conseq_nm  : ss_inv -> ss_inv -> FApi.backward
 (* -------------------------------------------------------------------- *)
-val t_ehoareS_concave : form -> form -> form -> FApi.backward
-val t_ehoareF_concave : form -> form -> form -> FApi.backward
+val t_ehoareS_concave : ss_inv -> ss_inv -> ss_inv -> FApi.backward
+val t_ehoareF_concave : ss_inv -> ss_inv -> ss_inv -> FApi.backward
 val t_concave_incr : FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_equivS_conseq_bd : side -> EcFol.form -> EcFol.form ->FApi.backward
+val t_equivS_conseq_bd : side -> ss_inv -> ss_inv ->FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_conseq : form -> form -> FApi.backward
+val t_conseq : inv -> inv -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
 val process_conseq   : bool -> conseq_ppterm option tuple3 -> FApi.backward

--- a/src/phl/ecPhlCoreView.ml
+++ b/src/phl/ecPhlCoreView.ml
@@ -3,33 +3,35 @@ open EcFol
 
 open EcCoreGoal
 open EcLowPhlGoal
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 let t_hoare_of_bdhoareS_r tc =
   let bhs = tc1_as_bdhoareS tc in
-  if not (bhs.bhs_cmp = FHeq && f_equal bhs.bhs_bd f_r0) then
+  if not (bhs.bhs_cmp = FHeq && f_equal (bhs_bd bhs).inv f_r0) then
     tc_error !!tc "%s" "bound must be equal to 0%r";
-  let concl = f_hoareS bhs.bhs_m bhs.bhs_pr bhs.bhs_s (f_not bhs.bhs_po) in
+  let concl = f_hoareS (snd bhs.bhs_m) (bhs_pr bhs) bhs.bhs_s (map_ss_inv1 f_not (bhs_po bhs)) in
   FApi.xmutate1 tc `ViewBdHoare [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_hoare_of_bdhoareF_r tc =
   let bhf = tc1_as_bdhoareF tc in
-  if not (bhf.bhf_cmp = FHeq && f_equal bhf.bhf_bd f_r0) then
+  if not (bhf.bhf_cmp = FHeq && f_equal (bhf_bd bhf).inv f_r0) then
     tc_error !!tc "%s" "bound must be equal to 0%r";
-  let concl = f_hoareF bhf.bhf_pr bhf.bhf_f (f_not bhf.bhf_po) in
+  let post = map_ss_inv1 f_not (bhf_po bhf) in
+  let concl = f_hoareF (bhf_pr bhf) bhf.bhf_f post in
   FApi.xmutate1 tc `ViewBdHoare [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_of_hoareS_r tc =
   let hs = tc1_as_hoareS tc in
-  let concl = f_bdHoareS hs.hs_m hs.hs_pr hs.hs_s (f_not hs.hs_po) FHeq f_r0 in
+  let concl = f_bdHoareS (snd hs.hs_m) (hs_pr hs) hs.hs_s (map_ss_inv1 f_not (hs_po hs)) FHeq {m=fst hs.hs_m;inv=f_r0} in
   FApi.xmutate1 tc `ViewBdHoare [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_bdhoare_of_hoareF_r tc =
   let hf = tc1_as_hoareF tc in
-  let concl = f_bdHoareF hf.hf_pr hf.hf_f (f_not hf.hf_po) FHeq f_r0 in
+  let concl = f_bdHoareF (hf_pr hf) hf.hf_f (map_ss_inv1 f_not (hf_po hf)) FHeq {m=hf.hf_m;inv=f_r0} in
   FApi.xmutate1 tc `ViewBdHoare [concl]
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlDeno.mli
+++ b/src/phl/ecPhlDeno.mli
@@ -1,11 +1,11 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_phoare_deno : form -> form -> backward
-val t_equiv_deno  : form -> form -> backward
+val t_phoare_deno : ss_inv -> ss_inv -> backward
+val t_equiv_deno  : ts_inv -> ts_inv -> backward
 
 (* -------------------------------------------------------------------- *)
 type denoff = deno_ppterm * bool * pformula option

--- a/src/phl/ecPhlEager.mli
+++ b/src/phl/ecPhlEager.mli
@@ -1,17 +1,17 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
 open EcMatching.Position
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_eager_seq     : codepos1 -> codepos1 -> form -> EcIdent.t -> backward
+val t_eager_seq     : codepos1 -> codepos1 -> ts_inv -> EcIdent.t -> backward
 val t_eager_if      : backward
 val t_eager_while   : EcIdent.t -> backward
 val t_eager_fun_def : backward
-val t_eager_fun_abs : EcFol.form -> EcIdent.t -> backward
-val t_eager_call    : form -> form -> backward
+val t_eager_fun_abs : ts_inv -> EcIdent.t -> backward
+val t_eager_call    : ts_inv -> ts_inv -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_seq     : eager_info -> pcodepos1 pair -> pformula -> backward

--- a/src/phl/ecPhlEqobs.ml
+++ b/src/phl/ecPhlEqobs.ml
@@ -42,7 +42,7 @@ let extend_body fsig body =
 (* Invariant ifvl,ifvr = PV.fv env ml inv, PV.fv env mr inv *)
 type sim = {
   sim_env      : env;
-  sim_inv      : form;
+  sim_inv      : ts_inv;
   sim_ifvl     : PV.t;
   sim_ifvr     : PV.t;
   default_spec : EcPath.xpath -> EcPath.xpath -> Mpv2.t -> Mpv2.t;
@@ -81,8 +81,8 @@ let init_sim env spec inv =
 
   { sim_env  = env;
     sim_inv  = inv;
-    sim_ifvl = PV.fv env mleft inv;
-    sim_ifvr = PV.fv env mright inv;
+    sim_ifvl = PV.fv env inv.ml inv.inv;
+    sim_ifvr = PV.fv env inv.mr inv.inv;
     default_spec = default_spec;
     needed_spec  = [];
   }
@@ -322,9 +322,9 @@ and f_eqobs_in fl fr sim eqO =
           aux eqo in
         begin
           try
-            let inv = Mpv2.to_form mleft mright eqi sim.sim_inv in
-            let fvl = PV.fv env mleft inv in
-            let fvr = PV.fv env mright inv in
+            let inv = Mpv2.to_form_ts_inv eqi sim.sim_inv in
+            let fvl = PV.fv env inv.ml inv.inv in
+            let fvr = PV.fv env inv.mr inv.inv in
             PV.check_depend env fvl topl;
             PV.check_depend env fvr topr
           with TcError _ -> raise EqObsInError
@@ -359,6 +359,7 @@ and f_eqobs_in fl fr sim eqO =
 
 (* -------------------------------------------------------------------- *)
 let mk_inv_spec2 env inv (fl, fr, eqi, eqo) =
+  let ml, mr = inv.ml, inv.mr in
   let defl = Fun.by_xpath fl env in
   let defr = Fun.by_xpath fr env in
   let sigl, sigr = defl.f_sig, defr.f_sig in
@@ -367,12 +368,12 @@ let mk_inv_spec2 env inv (fl, fr, eqi, eqo) =
     && EcReduction.EqTest.for_type env sigl.fs_ret sigr.fs_ret in
   if not testty then raise EqObsInError;
   let eq_params =
-    f_eqparams
-      sigl.fs_arg sigl.fs_anames mleft
-      sigr.fs_arg sigr.fs_anames mright in
-  let eq_res = f_eqres sigl.fs_ret mleft sigr.fs_ret mright in
-  let pre = f_and eq_params (Mpv2.to_form mleft mright eqi inv) in
-  let post = f_and eq_res (Mpv2.to_form mleft mright eqo inv) in
+    ts_inv_eqparams
+      sigl.fs_arg sigl.fs_anames ml
+      sigr.fs_arg sigr.fs_anames mr in
+  let eq_res = ts_inv_eqres sigl.fs_ret ml sigr.fs_ret mr in
+  let pre = map_ts_inv2 f_and eq_params (Mpv2.to_form_ts_inv eqi inv) in
+  let post = map_ts_inv2 f_and eq_res (Mpv2.to_form_ts_inv eqo inv) in
   f_equivF pre fl fr post
 
 (* -------------------------------------------------------------------- *)
@@ -384,21 +385,20 @@ let t_eqobs_inS_r sim eqo tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
   let sim = { sim with sim_env = env } in
   let es = tc1_as_equivS tc in
-  let ml = fst (es.es_ml) and mr = fst (es.es_mr) in
   let sl, sr, sim, eqi =
     try s_eqobs_in es.es_sl es.es_sr sim Mpv2.empty_local eqo
     with EqObsInError -> tc_error !!tc "cannot apply sim ..."
   in
   let inv = sim.sim_inv in
-  let post = Mpv2.to_form ml mr eqo inv in
-  let pre  = Mpv2.to_form ml mr eqi inv in
+  let post = Mpv2.to_form_ts_inv eqo inv in
+  let pre  = Mpv2.to_form_ts_inv eqi inv in
 
   let sl = stmt (List.rev sl) and sr = stmt (List.rev sr) in
-  if not (EcReduction.is_alpha_eq hyps post es.es_po) then
+  if not (EcReduction.ts_inv_alpha_eq hyps post (es_po es)) then
     tc_error !!tc "cannot apply sim";
 
   let sg = List.map (mk_inv_spec env inv) sim.needed_spec in
-  let concl = f_equivS es.es_ml es.es_mr es.es_pr sl sr pre in
+  let concl = f_equivS (snd es.es_ml) (snd es.es_mr) (es_pr es) sl sr pre in
 
   FApi.xmutate1 tc `EqobsIn (sg @ [concl])
 
@@ -426,40 +426,41 @@ let t_eqobs_inF = FApi.t_low2 "eqobs-in" t_eqobs_inF_r
 (* -------------------------------------------------------------------- *)
 let process_eqs env tc f =
    try
-      Mpv2.of_form env mleft mright f
+      Mpv2.of_form env f
    with Not_found ->
      tc_error_lazy !!tc (fun fmt ->
        let ppe = EcPrinting.PPEnv.ofenv env in
        Format.fprintf fmt
          "cannot recognize %a as a set of equalities"
-         (EcPrinting.pp_form ppe) f)
+         (EcPrinting.pp_form ppe) f.inv)
 
 (* -------------------------------------------------------------------- *)
-let process_hint tc hyps (feqs, inv) =
+let process_hint ml mr tc hyps (feqs, inv) =
   let env = LDecl.toenv hyps in
-  let ienv = LDecl.inv_memenv hyps in
-  let doinv pf = TTC.pf_process_form !!tc ienv tbool pf in
+  let ienv = LDecl.push_active_ts (EcMemory.abstract ml) (EcMemory.abstract mr) hyps in
+  let doinv pf = {ml;mr;inv=TTC.pf_process_form !!tc ienv tbool pf} in
   let doeq pf = process_eqs env tc (doinv pf) in
   let dof g = omap (EcTyping.trans_gamepath env) g in
   let geqs =
     List.map (fun ((f1,f2),geq) -> dof f1, dof f2, doeq geq)
       feqs in
-  let ginv = odfl f_true (omap doinv inv) in
+  let ginv = odfl {ml;mr;inv=f_true} (omap doinv inv) in
   geqs, ginv
 
 (* -------------------------------------------------------------------- *)
 let process_eqobs_inS info tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
   let es = tc1_as_equivS tc in
-  let spec, inv = process_hint tc hyps info.EcParsetree.sim_hint in
+  let ml, mr = fst es.es_ml, fst es.es_mr in
+  let spec, inv = process_hint ml mr tc hyps info.EcParsetree.sim_hint in
   let eqo =
     match info.EcParsetree.sim_eqs with
     | Some pf ->
       process_eqs env tc (TTC.tc1_process_prhl_formula tc pf)
     | None ->
-      try Mpv2.needed_eq env mleft mright es.es_po
-      with _ -> tc_error !!tc "cannot infer the set of equalities" in
-  let post = Mpv2.to_form mleft mright eqo inv in
+      try Mpv2.needed_eq env (es_po es)
+      with Not_found -> tc_error !!tc "cannot infer the set of equalities" in
+  let post = Mpv2.to_form_ts_inv eqo inv in
   let sim = init_sim env spec inv in
   let t_main tc =
     match info.EcParsetree.sim_pos with
@@ -475,14 +476,14 @@ let process_eqobs_inS info tc =
       let _, eqi =
         try s_eqobs_in_full (stmt sl2) (stmt sr2) sim Mpv2.empty_local eqo
         with EqObsInError -> tc_error !!tc "cannot apply sim" in
-      (EcPhlApp.t_equiv_app (p1, p2) (Mpv2.to_form mleft mright eqi inv) @+ [
+      (EcPhlApp.t_equiv_app (p1, p2) (Mpv2.to_form_ts_inv eqi inv) @+ [
         t_id;
         fun tc ->
           FApi.t_last
             (EcPhlSkip.t_skip @! t_trivial)
             (t_eqobs_inS sim eqo tc)
       ]) tc in
-  (EcPhlConseq.t_equivS_conseq es.es_pr post @+
+  (EcPhlConseq.t_equivS_conseq (es_pr es) post @+
     [t_trivial;
      t_trivial;
      t_main]) tc
@@ -493,16 +494,17 @@ let process_eqobs_inF info tc =
     tc_error !!tc "no positions excepted";
   let env, hyps, _ = FApi.tc1_eflat tc in
   let ef = tc1_as_equivF tc in
-  let spec, inv = process_hint tc hyps info.EcParsetree.sim_hint in
+  let ml, mr = ef.ef_ml, ef.ef_mr in
+  let spec, inv = process_hint ml mr tc hyps info.EcParsetree.sim_hint in
   let fl = ef.ef_fl and fr = ef.ef_fr in
   let eqo =
     match info.EcParsetree.sim_eqs with
-    | Some pf ->
-      let _,(ml,mr) = Fun.equivF_memenv fl fr env in
-      let hyps = LDecl.push_all [ml;mr] hyps in
-      process_eqs env tc (TTC.pf_process_form !!tc hyps tbool pf)
+    | Some pf -> 
+      let _,(mle,mre) = Fun.equivF_memenv ml mr fl fr env in
+      let hyps = LDecl.push_active_ts mle mre hyps in
+      process_eqs env tc {ml; mr; inv=TTC.pf_process_form !!tc hyps tbool pf}
     | None ->
-      try Mpv2.needed_eq env mleft mright ef.ef_po
+      try Mpv2.needed_eq env (ef_po ef)
       with _ -> tc_error !!tc "cannot infer the set of equalities" in
   let eqo = Mpv2.remove env pv_res pv_res eqo in
   let sim = init_sim env spec inv in
@@ -510,7 +512,7 @@ let process_eqobs_inF info tc =
     try f_eqobs_in fl fr sim eqo
     with EqObsInError -> tc_error !!tc "not able to process" in
   let ef' = destr_equivF (mk_inv_spec2 env inv (fl, fr, eqi, eqo)) in
-  (EcPhlConseq.t_equivF_conseq ef'.ef_pr ef'.ef_po @+ [
+  (EcPhlConseq.t_equivF_conseq (ef_pr ef') (ef_po ef') @+ [
     t_trivial;
     t_trivial;
      t_eqobs_inF sim eqo]) tc
@@ -520,7 +522,6 @@ let process_eqobs_in cm info tc =
   let prett cm tc =
     let dt, ts = EcHiGoal.process_crushmode cm in
       EcPhlConseq.t_conseqauto ~delta:dt ?tsolve:ts tc in
-
   let tt tc =
     let concl = FApi.tc1_goal tc in
     match concl.f_node with

--- a/src/phl/ecPhlExists.mli
+++ b/src/phl/ecPhlExists.mli
@@ -1,12 +1,12 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 val t_hr_exists_elim_r : ?bound:int -> backward
 val t_hr_exists_elim   : backward
-val t_hr_exists_intro  : form list -> backward
+val t_hr_exists_intro  : inv list -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_exists_intro : elim:bool -> pformula list -> backward

--- a/src/phl/ecPhlFel.ml
+++ b/src/phl/ecPhlFel.ml
@@ -124,19 +124,19 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
     | _ -> tc_error !!tc "a goal of the form Pr[ _ ] <= _ is required"
   in
 
-  let m  = oget (Memory.byid pr.pr_mem env) in
+  let pr_m  = oget (Memory.byid pr.pr_mem env) in
   let f  = NormMp.norm_xfun env pr.pr_fun in
   let ev = pr.pr_event in
 
   let memenv, (fsig, fdef), _ =
-    try  Fun.hoareS f env
+    try  Fun.hoareS ev.m f env
     with _ -> tc_error !!tc "not applicable to abstract functions"
   in
 
   let s_hd, s_tl = EcLowPhlGoal.s_split env at_pos fdef.f_body in
-  let fve        = PV.fv env mhr f_event in
-  let fvc        = PV.fv env mhr cntr in
-  let fvi        = PV.fv env mhr inv in
+  let fve        = PV.fv env f_event.m f_event.inv in
+  let fvc        = PV.fv env cntr.m cntr.inv in
+  let fvi        = PV.fv env inv.m inv.inv in
   let fv         = PV.union (PV.union fve fvc) fvi in
   let os         = callable_oracles_stmt env fv (stmt s_tl) in
 
@@ -157,12 +157,15 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
   in
 
   (* we must quantify over memories *)
-  let mo = EcIdent.create "&m" in
   let post_goal =
-    let subst = Fsubst.f_bind_mem Fsubst.f_subst_id mhr mo in
-    let p = f_imps [ev;inv] (f_and f_event (f_int_le cntr q)) in
-    let p = Fsubst.f_subst subst p in
-    f_forall_mems [mo, EcMemory.memtype m] p
+    let lev = map_ss_inv2 f_and f_event (map_ss_inv1 (fun cnt -> f_int_le cnt q) cntr) in
+    let m = (EcIdent.create "&hr", snd pr_m) in
+    let lev = EcSubst.ss_inv_rebind lev (fst m) in
+    let ev = EcSubst.ss_inv_rebind ev (fst m) in
+    let inv = EcSubst.ss_inv_rebind inv (fst m) in
+    let f_imps' l = f_imps (List.tl l) (List.hd l) in
+        let p = map_ss_inv f_imps' [lev;ev;inv] in
+    EcSubst.f_forall_mems_ss_inv m p
   in
 
   (* not fail and cntr=0 and invariant holds at designated program point,
@@ -172,20 +175,21 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
 
   let init_goal =
     let xs,gs = PV.ntr_elements (f_read env f) in
-    let mh = fst memenv in
-    let mi = pr.pr_mem in
-    let f_xeq (x,ty) = f_eq (f_pvar x ty mh) (f_pvar x ty mi) in
+    let m = fst memenv in
+    let pr_m = pr.pr_mem in
+    let f_xeq (x,ty) = map_ss_inv2 f_eq (f_pvar x ty m) {m;inv=(f_pvar x ty pr_m).inv} in
     let eqxs = List.map f_xeq xs in
-    let eqgs = List.map (fun m -> f_eqglob m mh m mi) gs in
+    let eqgs = List.map (fun m' -> {m;inv=f_eqglob m' m m' pr_m}) gs in
     let eqparams =
       let vs = fsig.fs_anames in
       let var_of_ovar ov = { v_name = oget ov.ov_name; v_type = ov.ov_type } in
-      let f_x x = assert (is_some x.ov_name); f_pvloc (var_of_ovar x) mh in
-      f_eq (f_tuple (List.map f_x vs)) pr.pr_args in
-    let pre = f_ands (eqparams :: (eqxs@eqgs)) in
-    let p = f_and (f_not f_event) (f_eq cntr f_i0) in
-    let p = f_and_simpl p inv in
-    f_hoareS memenv pre (stmt s_hd) p
+      let f_x x = assert (is_some x.ov_name); (f_pvloc (var_of_ovar x) m) in
+      map_ss_inv2 f_eq (map_ss_inv ~m f_tuple (List.map f_x vs)) {m;inv=pr.pr_args} in
+    let pre = map_ss_inv f_ands (eqparams :: (eqxs@eqgs)) in
+    let p = map_ss_inv2 f_and (map_ss_inv1 f_not f_event) (map_ss_inv2 f_eq cntr {m=cntr.m;inv=f_i0}) in
+    let p = map_ss_inv2 f_and_simpl p inv in
+    let p = EcSubst.ss_inv_rebind p pre.m in
+    f_hoareS (snd memenv) pre (stmt s_hd) p
   in
 
   let oracle_goal o =
@@ -193,15 +197,15 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
       pred_specs
         |> List.ofind (fun (o', _) -> o = o')
         |> omap snd
-        |> odfl f_true
+        |> odfl {m=f_event.m; inv=f_true}
     in
 
     let not_F_to_F_goal =
-      let bound = f_app_simpl ash [cntr] treal in
-      let pre = f_and (f_int_le f_i0 cntr) (f_int_lt cntr q) in
-      let pre = f_and pre (f_not f_event) in
-      let pre = f_and_simpl pre inv in
-      let pre = f_and_simpl pre some_p in
+      let bound = map_ss_inv1 (fun cn -> f_app_simpl ash [cn] treal) cntr in
+      let pre = map_ss_inv1 (fun cn -> f_and (f_int_le f_i0 cn) (f_int_lt cn q)) cntr in
+      let pre = map_ss_inv2 f_and pre (map_ss_inv1 f_not f_event) in
+      let pre = map_ss_inv2 f_and_simpl pre inv in
+      let pre = map_ss_inv2 f_and_simpl pre some_p in
       let post = f_event in
       f_bdHoareF pre o post FHle bound
     in
@@ -211,17 +215,23 @@ let t_failure_event_r (at_pos, cntr, ash, q, f_event, pred_specs, inv) tc =
     let old_b = f_local old_b_id tbool in
 
     let cntr_decr_goal =
-      let pre  = f_and some_p (f_eq old_cntr cntr) in
-      let pre = f_and_simpl pre inv in
-      let post = f_int_lt old_cntr cntr in
-      let post = f_and_simpl post inv in
+      let old_cntr = {m=cntr.m;inv=old_cntr} in
+      let pre  = map_ss_inv2 f_and some_p (map_ss_inv2 f_eq old_cntr cntr) in
+      let pre = map_ss_inv2 f_and_simpl pre inv in
+      let post = map_ss_inv2 f_int_lt old_cntr cntr in
+      let post = map_ss_inv2 f_and_simpl post inv in
         f_forall_simpl [old_cntr_id,GTty tint] (f_hoareF pre o post)
     in
     let cntr_stable_goal =
-      let pre  = f_ands [f_not some_p;f_eq f_event old_b;f_eq cntr old_cntr] in
-      let pre  = f_and_simpl pre inv in
-      let post = f_ands [f_eq f_event old_b;f_int_le old_cntr cntr] in
-      let post = f_and_simpl post inv in
+      let old_cntr = {m=cntr.m;inv=old_cntr} in
+      let old_b = {m=cntr.m;inv=old_b} in
+      let pre  = map_ss_inv f_ands [
+        map_ss_inv1 f_not some_p;
+        map_ss_inv2 f_eq f_event old_b;
+        map_ss_inv2 f_eq cntr old_cntr] in
+      let pre  = map_ss_inv2 f_and_simpl pre inv in
+      let post = map_ss_inv f_ands [map_ss_inv2 f_eq f_event old_b; map_ss_inv2 f_int_le old_cntr cntr] in
+      let post = map_ss_inv2 f_and_simpl post inv in
         f_forall_simpl
           [old_b_id,GTty tbool; old_cntr_id,GTty tint]
           (f_hoareF pre o post)
@@ -256,24 +266,26 @@ let process_fel at_pos (infos : fel_info) tc =
       -> destr_pr pr
     | _ -> tc_error !!tc "a goal of the form Pr[ _ ] <= _ is required" in
 
+
+  let m = EcIdent.create "&hr" in
   let at_pos  = EcTyping.trans_codepos1 env at_pos in
-  let hyps    = LDecl.inv_memenv1 hyps1 in
-  let cntr    = TTC.pf_process_form !!tc hyps tint infos.pfel_cntr in
-  let ash     = TTC.pf_process_form !!tc hyps (tfun tint treal) infos.pfel_asg in
-  let hypsq   = LDecl.push_active (EcMemory.abstract pr.pr_mem) hyps1 in
+  let hyps    = LDecl.inv_memenv1 m hyps1 in
+  let cntr    = {m;inv=TTC.pf_process_form !!tc hyps tint infos.pfel_cntr} in
+  let hypsq   = LDecl.push_active_ss (EcMemory.abstract pr.pr_mem) hyps1 in
+  let ash     = TTC.pf_process_form !!tc hypsq (tfun tint treal) infos.pfel_asg in
   let q       = TTC.pf_process_form !!tc hypsq tint infos.pfel_q in
-  let f_event = TTC.pf_process_form !!tc hyps tbool infos.pfel_event in
+  let f_event = {m;inv=TTC.pf_process_form !!tc hyps tbool infos.pfel_event} in
   let inv     =
     infos.pfel_inv
-      |> omap (fun inv -> TTC.pf_process_form !!tc hyps tbool inv)
-      |> odfl f_true
+      |> omap (fun inv -> {m;inv=TTC.pf_process_form !!tc hyps tbool inv})
+      |> odfl {m;inv=f_true}
   in
 
   let process_pred (f,pre) =
     let env  = LDecl.toenv hyps in
     let f    = EcTyping.trans_gamepath env f in
-    let penv = fst (LDecl.hoareF f hyps) in
-      (f, TTC.pf_process_form !!tc penv tbool pre)
+    let penv = fst (LDecl.hoareF m f hyps) in
+      (f, {m;inv=TTC.pf_process_form !!tc penv tbool pre})
   in
 
   let pred_specs = List.map process_pred infos.pfel_specs in

--- a/src/phl/ecPhlFel.mli
+++ b/src/phl/ecPhlFel.mli
@@ -1,16 +1,16 @@
 (* -------------------------------------------------------------------- *)
 open EcPath
 open EcParsetree
-open EcFol
+open EcAst
 open EcCoreGoal.FApi
 open EcMatching.Position
 
 (* -------------------------------------------------------------------- *)
 val t_failure_event :
      codepos1
-  -> form -> form -> form -> form
-  -> (xpath * form) list
-  -> form
+  -> ss_inv -> form -> form -> ss_inv
+  -> (xpath * ss_inv) list
+  -> ss_inv
   -> backward
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlFun.mli
+++ b/src/phl/ecPhlFun.mli
@@ -1,11 +1,9 @@
 (* -------------------------------------------------------------------- *)
-open EcUtils
 open EcParsetree
 open EcPath
-open EcFol
 open EcModules
-open EcMemory
 open EcCoreGoal
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 (* FIXME: MOVE THIS! *)
@@ -21,29 +19,29 @@ type p_upto_info = pformula * pformula * (pformula option)
 
 val process_fun_def       : FApi.backward
 val process_fun_abs       : pformula -> FApi.backward
-val process_fun_upto_info : p_upto_info -> tcenv1 -> form tuple3
+val process_fun_upto_info : p_upto_info -> tcenv1 -> ss_inv * ts_inv * ts_inv
 val process_fun_upto      : p_upto_info -> FApi.backward
 val process_fun_to_code   : FApi.backward
 
 (* -------------------------------------------------------------------- *)
 module FunAbsLow : sig
   val hoareF_abs_spec :
-       proofenv -> EcEnv.env -> xpath -> form
-    -> form * form * form list
+       proofenv -> EcEnv.env -> xpath -> ss_inv
+    -> ss_inv * ss_inv * form list
 
   val bdhoareF_abs_spec :
-       proofenv -> EcEnv.env -> xpath -> form
-    -> form * form * form list
+       proofenv -> EcEnv.env -> xpath -> ss_inv
+    -> ss_inv * ss_inv * form list
 
   val equivF_abs_spec :
-       proofenv -> EcEnv.env -> xpath -> xpath -> form
-    -> form * form * form list
+       proofenv -> EcEnv.env -> xpath -> xpath -> ts_inv
+    -> ts_inv * ts_inv * form list
 end
 
 (* -------------------------------------------------------------------- *)
-val t_hoareF_abs   : form -> FApi.backward
-val t_bdhoareF_abs : form -> FApi.backward
-val t_equivF_abs   : form -> FApi.backward
+val t_hoareF_abs   : ss_inv -> FApi.backward
+val t_bdhoareF_abs : ss_inv -> FApi.backward
+val t_equivF_abs   : ts_inv -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
 val t_hoareF_fun_def   : FApi.backward
@@ -51,7 +49,7 @@ val t_bdhoareF_fun_def : FApi.backward
 val t_equivF_fun_def   : FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_equivF_abs_upto : form -> form -> form -> FApi.backward
+val t_equivF_abs_upto : ss_inv -> ts_inv -> ts_inv -> FApi.backward
 
 (* -------------------------------------------------------------------- *)
-val t_fun : form -> FApi.backward
+val t_fun : inv -> FApi.backward

--- a/src/phl/ecPhlHiBdHoare.ml
+++ b/src/phl/ecPhlHiBdHoare.ml
@@ -2,7 +2,7 @@
 open EcUtils
 open EcTypes
 open EcFol
-open EcEnv
+open EcAst
 
 open EcCoreGoal
 open EcLowGoal
@@ -11,16 +11,15 @@ module TTC = EcProofTyping
 
 (* -------------------------------------------------------------------- *)
 let process_bdhoare_split info tc =
-  let hyps, concl = FApi.tc1_flat tc in
+  let _, concl = FApi.tc1_flat tc in
 
-  let (penv, qenv), pr, po =
+  let pr, po =
     match concl.f_node with
     | FbdHoareS bhs ->
-        let hyps = LDecl.push_active bhs.bhs_m hyps in
-          ((hyps, hyps), bhs.bhs_pr, bhs.bhs_po)
+        (bhs_pr bhs, bhs_po bhs)
 
     | FbdHoareF bhf ->
-        (LDecl.hoareF bhf.bhf_f hyps, bhf.bhf_pr, bhf.bhf_po)
+        (bhf_pr bhf, bhf_po bhf)
 
     | _ ->
         tc_error !!tc "the conclusion must be a bdhoare judgment" in
@@ -28,23 +27,22 @@ let process_bdhoare_split info tc =
   match info with
   | EcParsetree.BDH_split_bop (b1, b2, b3) ->
       let t =
-             if is_and po then EcPhlBdHoare.t_bdhoare_and
-        else if is_or  po then EcPhlBdHoare.t_bdhoare_or
+             if is_and po.inv then EcPhlBdHoare.t_bdhoare_and
+        else if is_or  po.inv then EcPhlBdHoare.t_bdhoare_or
         else
           tc_error !!tc
             "the postcondition must be a conjunction or a disjunction"
       in
-
-      let b1 = TTC.pf_process_form !!tc penv treal b1 in
-      let b2 = TTC.pf_process_form !!tc penv treal b2 in
-      let b3 = b3 |> omap (TTC.pf_process_form !!tc penv treal) |> odfl f_r0 in
+      let _,b1 = TTC.tc1_process_Xhl_form tc treal b1 in
+      let _,b2 = TTC.tc1_process_Xhl_form tc treal b2 in
+      let b3 = b3 |> omap (fun f -> snd ( TTC.tc1_process_Xhl_form tc treal f)) |> odfl {m=b1.m;inv=f_r0} in
 
       t b1 b2 b3 tc
 
   | EcParsetree.BDH_split_or_case (b1, b2, f) ->
-      let b1 = TTC.pf_process_form !!tc penv treal b1 in
-      let b2 = TTC.pf_process_form !!tc penv treal b2 in
-      let f  = TTC.pf_process_form !!tc qenv tbool f  in
+      let _, b1 = TTC.tc1_process_Xhl_form tc treal b1 in
+      let _, b2 = TTC.tc1_process_Xhl_form tc treal b2 in
+      let _, f  = TTC.tc1_process_Xhl_formula tc f in
 
       let t_conseq po lemma tactic =
         let rwtt tc =
@@ -58,22 +56,22 @@ let process_bdhoare_split info tc =
         in
 
         FApi.t_seqsub
-          (EcPhlConseq.t_conseq pr po)
+          (EcPhlConseq.t_conseq (Inv_ss pr) (Inv_ss po))
           [t_true; rwtt; tactic]
       in
 
       t_conseq
-        (f_or (f_and f po) (f_and (f_not f) po))
+        (map_ss_inv2 f_or (map_ss_inv2 f_and f po) (map_ss_inv2 f_and (map_ss_inv1 f_not f) po))
         (EcCoreLib.CI_Logic.mk_logic "orDandN")
         (FApi.t_on1seq 3
-           (EcPhlBdHoare.t_bdhoare_or b1 b2 f_r0)
+           (EcPhlBdHoare.t_bdhoare_or b1 b2 {m=b1.m;inv=f_r0})
            (t_conseq
-              f_false
+              {inv=f_false;m=b1.m}
               (EcCoreLib.CI_Logic.mk_logic "andDorN")
               EcHiGoal.process_trivial))
         tc
 
   | EcParsetree.BDH_split_not (b1, b2) ->
-      let b1 = b1 |> omap (TTC.pf_process_form !!tc penv treal) |> odfl f_r1 in
-      let b2 = TTC.pf_process_form !!tc penv treal b2 in
-      EcPhlBdHoare.t_bdhoare_not b1 b2 tc
+    let _,b2 = TTC.tc1_process_Xhl_form tc treal b2 in
+    let b1 = b1 |> omap (fun f -> snd (TTC.tc1_process_Xhl_form tc treal f)) |> odfl {m=b2.m;inv=f_r1} in
+    EcPhlBdHoare.t_bdhoare_not b1 b2 tc

--- a/src/phl/ecPhlInline.ml
+++ b/src/phl/ecPhlInline.ml
@@ -169,39 +169,40 @@ end
 
 (* -------------------------------------------------------------------- *)
 let t_inline_hoare_r ~use_tuple sp tc =
-  let hoare      = tc1_as_hoareS tc in
-  let (me, stmt) = LowInternal.inline ~use_tuple tc hoare.hs_m sp hoare.hs_s in
-  let concl      = f_hoareS_r { hoare with hs_m = me; hs_s = stmt; } in
+  let hs           = tc1_as_hoareS tc in
+  let (_,mt), stmt = LowInternal.inline ~use_tuple tc hs.hs_m sp hs.hs_s in
+  let concl        = f_hoareS mt (hs_pr hs) stmt (hs_po hs) in
 
   FApi.xmutate1 tc `Inline [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_inline_ehoare_r ~use_tuple sp tc =
-  let hoare      = tc1_as_ehoareS tc in
-  let (me, stmt) = LowInternal.inline ~use_tuple tc hoare.ehs_m sp hoare.ehs_s in
-  let concl      = f_eHoareS_r { hoare with ehs_m = me; ehs_s = stmt; } in
+  let ehs          = tc1_as_ehoareS tc in
+  let (_,mt), stmt = LowInternal.inline ~use_tuple tc ehs.ehs_m sp ehs.ehs_s in
+  let concl        = f_eHoareS mt (ehs_pr ehs) stmt (ehs_po ehs) in
 
   FApi.xmutate1 tc `Inline [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_inline_bdhoare_r ~use_tuple sp tc =
-  let hoare      = tc1_as_bdhoareS tc in
-  let (me, stmt) = LowInternal.inline ~use_tuple tc hoare.bhs_m sp hoare.bhs_s in
-  let concl      = f_bdHoareS_r { hoare with bhs_m = me; bhs_s = stmt; } in
+  let bhs           = tc1_as_bdhoareS tc in
+  let (_, mt), stmt = LowInternal.inline ~use_tuple tc bhs.bhs_m sp bhs.bhs_s in
+  let concl         = f_bdHoareS mt (bhs_pr bhs) stmt (bhs_po bhs) bhs.bhs_cmp (bhs_bd bhs) in
+
 
   FApi.xmutate1 tc `Inline [concl]
 
 (* -------------------------------------------------------------------- *)
 let t_inline_equiv_r ~use_tuple side sp tc =
-  let equiv = tc1_as_equivS tc in
+  let es = tc1_as_equivS tc in
   let concl =
     match side with
     | `Left  ->
-        let (me, stmt) = LowInternal.inline ~use_tuple tc equiv.es_ml sp equiv.es_sl in
-          f_equivS_r { equiv with es_ml = me; es_sl = stmt; }
+        let ((_,mt), stmt) = LowInternal.inline ~use_tuple tc es.es_ml sp es.es_sl in
+          f_equivS mt (snd es.es_mr) (es_pr es) stmt es.es_sr (es_po es)
     | `Right ->
-        let (me, stmt) = LowInternal.inline ~use_tuple tc equiv.es_mr sp equiv.es_sr in
-          f_equivS_r { equiv with es_mr = me; es_sr = stmt; }
+        let ((_,mt), stmt) = LowInternal.inline ~use_tuple tc es.es_mr sp es.es_sr in
+          f_equivS (snd es.es_ml) mt (es_pr es) es.es_sl stmt (es_po es)
   in
 
   FApi.xmutate1 tc `Inline [concl]

--- a/src/phl/ecPhlOutline.ml
+++ b/src/phl/ecPhlOutline.ml
@@ -56,23 +56,16 @@ let t_outline side cpr variant tc =
 let process_outline info tc =
   let env = tc1_env tc in
   let side = info.outline_side in
-  let goal = tc1_as_equivS tc in
   let ppe = EcPrinting.PPEnv.ofenv env in
 
   let range =
     EcProofTyping.tc1_process_codepos_range tc
       (Some side, info.outline_range) in
 
-  (* Check which memory we are outlining *)
-  let mem = match side with
-    | `Left  -> goal.es_ml
-    | `Right -> goal.es_mr
-  in
-
   try
     match info.outline_kind with
     | OKstmt s ->
-      let s = EcProofTyping.tc1_process_stmt tc (EcMemory.memtype mem) s in
+      let s = EcProofTyping.tc1_process_prhl_stmt tc side s in
       t_outline side range (OV_Stmt s) tc
     | OKproc (f, alias) ->
       (* Get the function *)

--- a/src/phl/ecPhlPr.mli
+++ b/src/phl/ecPhlPr.mli
@@ -1,14 +1,13 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
-open EcTypes
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
 val t_hoare_ppr   : backward
 val t_bdhoare_ppr : backward
-val t_equiv_ppr   : ty -> form -> form -> backward
+val t_equiv_ppr   : ty -> ss_inv -> ss_inv -> backward
 
 (* -------------------------------------------------------------------- *)
 val t_prbounded : bool -> backward

--- a/src/phl/ecPhlPrRw.ml
+++ b/src/phl/ecPhlPrRw.ml
@@ -16,66 +16,73 @@ let t_pr_lemma lemma tc =
   FApi.xmutate1 tc `RwPr []
 
 (* -------------------------------------------------------------------- *)
-let pr_eq env m f args p1 p2 =
-  let mem = Fun.prF_memenv mhr f env in
-  let hyp = f_forall_mems [ mem ] (f_iff p1 p2) in
-  let concl = f_eq (f_pr m f args p1) (f_pr m f args p2) in
+let pr_eq env pr_m f args p1 p2 =
+  let m = p1.m in
+  let mem = Fun.prF_memenv m f env in
+  let hyp = EcSubst.f_forall_mems_ss_inv mem (map_ss_inv2 f_iff p1 p2) in
+  let concl = f_eq (f_pr pr_m f args p1) (f_pr pr_m f args p2) in
   f_imp hyp (f_eq concl f_true)
 
-let pr_sub env m f args p1 p2 =
-  let mem = Fun.prF_memenv mhr f env in
-  let hyp = f_forall_mems [ mem ] (f_imp p1 p2) in
-  let concl = f_real_le (f_pr m f args p1) (f_pr m f args p2) in
+let pr_sub env pr_m f args p1 p2 =
+  let m = p1.m in
+  let mem = Fun.prF_memenv m f env in
+  let hyp = EcSubst.f_forall_mems_ss_inv mem (map_ss_inv2 f_imp p1 p2) in
+  let concl = f_real_le (f_pr pr_m f args p1) (f_pr pr_m f args p2) in
   f_imp hyp (f_eq concl f_true)
 
-let pr_false m f args = f_eq (f_pr m f args f_false) f_r0
+let pr_false pr_m f args = 
+  let m = EcIdent.create "&hr" in
+  f_eq (f_pr pr_m f args {m;inv=f_false}) f_r0
 
-let pr_not m f args p =
+let pr_not pr_m f args p =
+  let m = p.m in
   f_eq
-    (f_pr m f args (f_not p))
-    (f_real_sub (f_pr m f args f_true) (f_pr m f args p))
+    (f_pr pr_m f args (map_ss_inv1 f_not p))
+    (f_real_sub (f_pr pr_m f args {m;inv=f_true}) (f_pr pr_m f args p))
 
-let pr_or m f args por p1 p2 =
-  let pr1 = f_pr m f args p1 in
-  let pr2 = f_pr m f args p2 in
-  let pr12 = f_pr m f args (f_and p1 p2) in
+let pr_or pr_m f args por p1 p2 =
+  let pr1 = f_pr pr_m f args p1 in
+  let pr2 = f_pr pr_m f args p2 in
+  let pr12 = f_pr pr_m f args (map_ss_inv2 f_and p1 p2) in
   let pr = f_real_sub (f_real_add pr1 pr2) pr12 in
-  f_eq (f_pr m f args (por p1 p2)) pr
+  f_eq (f_pr pr_m f args (por p1 p2)) pr
 
-let pr_disjoint env m f args por p1 p2 =
-  let mem = Fun.prF_memenv mhr f env in
-  let hyp = f_forall_mems [ mem ] (f_not (f_and p1 p2)) in
-  let pr1 = f_pr m f args p1 in
-  let pr2 = f_pr m f args p2 in
+let pr_disjoint env pr_m f args por p1 p2 =
+  let m = p1.m in
+  let mem = Fun.prF_memenv m f env in
+  let hyp = EcSubst.f_forall_mems_ss_inv mem (map_ss_inv1 f_not (map_ss_inv2 f_and p1 p2)) in
+  let pr1 = f_pr pr_m f args p1 in
+  let pr2 = f_pr pr_m f args p2 in
   let pr = f_real_add pr1 pr2 in
-  f_imp hyp (f_eq (f_pr m f args (por p1 p2)) pr)
+  f_imp hyp (f_eq (f_pr pr_m f args (por p1 p2)) pr)
 
-let pr_split m f args ev1 ev2 =
-  let pr = f_pr m f args ev1 in
-  let pr1 = f_pr m f args (f_and ev1 ev2) in
-  let pr2 = f_pr m f args (f_and ev1 (f_not ev2)) in
+let pr_split pr_m f args ev1 ev2 =
+  let pr = f_pr pr_m f args ev1 in
+  let pr1 = f_pr pr_m f args (map_ss_inv2 f_and ev1 ev2) in
+  let pr2 = f_pr pr_m f args (map_ss_inv2 f_and ev1 (map_ss_inv1 f_not ev2)) in
   f_eq pr (f_real_add pr1 pr2)
 
-let pr_ge0 m f args ev =
-  let pr = f_pr m f args ev in
+let pr_ge0 pr_m f args ev =
+  let pr = f_pr pr_m f args ev in
   f_eq (f_real_le f_r0 pr) f_true
 
-let pr_le1 m f args ev =
-  let pr = f_pr m f args ev in
+let pr_le1 pr_m f args ev =
+  let pr = f_pr pr_m f args ev in
   f_eq (f_real_le pr f_r1) f_true
 
 let pr_sum env pr =
   let prf = EcEnv.Fun.by_xpath pr.pr_fun env in
   let xty = prf.f_sig.fs_ret in
   let x = EcIdent.create "x" in
-  let fx = f_local x xty in
-
+  let ev = pr.pr_event in
+  let m = ev.m in
+  let fx = {m;inv=f_local x xty} in
   let prx =
     let event =
-      f_and_simpl pr.pr_event (f_eq (f_pvar EcTypes.pv_res xty EcFol.mhr) fx)
-    in
-    f_pr pr.pr_mem pr.pr_fun pr.pr_args event
-  in
+      map_ss_inv2 f_and_simpl
+        ev
+        (map_ss_inv2 f_eq (f_pvar EcTypes.pv_res xty ev.m) fx)
+    in f_pr pr.pr_mem pr.pr_fun pr.pr_args event in
 
   let prx =
     EcFol.f_app
@@ -87,13 +94,14 @@ let pr_sum env pr =
 
   f_eq (f_pr_r pr) prx
 
-let pr_mu1_le_eq_mu1 m f args resv k fresh_id d =
+let pr_mu1_le_eq_mu1 pr_m f args resv k fresh_id d =
+  let m = resv.m in
   let kfresh = f_local fresh_id k.f_ty in
-  let f_ll = f_bdHoareF f_true f f_true FHeq f_r1
+  let f_ll = f_bdHoareF {m;inv=f_true} f {m;inv=f_true} FHeq {m;inv=f_r1}
   and f_le_mu1 = f_forall [ (fresh_id, gtty k.f_ty) ]
-    (f_real_le (f_pr m f args (f_eq resv kfresh)) (f_mu_x d kfresh))
+    (f_real_le (f_pr pr_m f args {m;inv=f_eq resv.inv kfresh}) (f_mu_x d kfresh))
   and concl =
-    f_eq (f_pr m f args (f_eq resv k)) (f_mu_x d k) in
+    f_eq (f_pr pr_m f args {m;inv=f_eq resv.inv k}) (f_mu_x d k) in
   f_imp f_ll (f_imp f_le_mu1 concl)
 
 let p_List = [EcCoreLib.i_top; "List"]
@@ -102,10 +110,11 @@ let p_list_has = EcPath.fromqsymbol (p_List, "has")
 let p_BRA_big = EcPath.fromqsymbol (p_BRA, "big")
 
 let destr_pr_has pr =
-  match pr.pr_event.f_node with
+  let m = pr.pr_event.m in
+  match pr.pr_event.inv.f_node with
   | Fapp ({ f_node = Fop(op, [ty_elem]) }, [f_f; f_l]) ->
       if EcPath.p_equal p_list_has op then
-        Some(ty_elem, f_f, f_l)
+        Some(ty_elem, {m;inv=f_f}, {m;inv=f_l})
       else None
   | _ -> None
 (*
@@ -118,11 +127,12 @@ let pr_has_le f_pr =
   let ty_elem, f_f, f_l = oget (destr_pr_has pr) in
   let idx = EcIdent.create "x" in
   let x = f_local idx ty_elem in
-  let pr_event = f_app f_f [x] EcTypes.tbool in
+  let pr_event = map_ss_inv1 (fun f -> f_app f [x] EcTypes.tbool) f_f in
   let f_pr1 = f_pr_r {pr with pr_event} in
   let f_fsum = f_lambda [idx, GTty ty_elem] f_pr1 in
   let f_sum =
-    f_app (f_op p_BRA_big [ty_elem] EcTypes.treal) [f_predT ty_elem; f_fsum; f_l] EcTypes.treal in
+    (* FIXME: Ensure that `f_l` does not use its memory *)
+    f_app (f_op p_BRA_big [ty_elem] EcTypes.treal) [f_predT ty_elem; f_fsum; f_l.inv] EcTypes.treal in
   f_real_le f_pr f_sum
 
 (* -------------------------------------------------------------------- *)
@@ -131,7 +141,7 @@ exception FoundPr of form
 let select_pr on_ev sid f =
   match f.f_node with
   | Fpr { pr_event = ev } ->
-      if on_ev ev && Mid.set_disjoint f.f_fv sid then raise (FoundPr f)
+      if on_ev ev.inv && Mid.set_disjoint f.f_fv sid then raise (FoundPr f)
       else false
   | _ -> false
 
@@ -175,7 +185,7 @@ let select_pr_muhasle sid f =
       if EcPath.p_equal EcCoreLib.CI_Real.p_real_le op then
         match destr_pr_has pr with
         | Some (_, _, f_l) when
-          Mid.set_disjoint f_l.f_fv (Mid.add EcCoreFol.mhr () sid) ->
+          Mid.set_disjoint f_l.inv.f_fv (Mid.add f_l.m () sid) ->
             raise (FoundPr f_pr)
         | _ -> false
       else false
@@ -199,7 +209,7 @@ let pr_rewrite_lemma =
   ]
 
 (* -------------------------------------------------------------------- *)
-let t_pr_rewrite_low (s, dof) tc =
+let t_pr_rewrite_low (s, (dof: (_ -> _ -> _ -> ss_inv) option)) tc =
   let kind =
     try List.assoc s pr_rewrite_lemma
     with Not_found ->
@@ -236,19 +246,23 @@ let t_pr_rewrite_low (s, dof) tc =
 
   let lemma, args =
     match kind with
-    | `Mu1LeEqMu1 ->
-      let { pr_mem; pr_fun; pr_args; pr_event } = destr_pr torw in
-      let (resv, k) = destr_eq pr_event in
+    | `Mu1LeEqMu1 -> 
+      let { pr_fun; pr_args; pr_mem } as pr = destr_pr torw in
+      let (resv, k) = map_ss_inv_destr2 destr_eq pr.pr_event in
       let k_id = EcEnv.LDecl.fresh_id hyps "k" in
-      let d = (oget dof) tc torw (EcTypes.tdistr k.f_ty) in
-      (pr_mu1_le_eq_mu1 pr_mem pr_fun pr_args resv k k_id d, 2)
+      let d = (oget dof) tc torw (EcTypes.tdistr k.inv.f_ty) in
+      (* FIXME: Ensure that d.inv does not use d.m *)
+      (* FIXME: Ensure that k.inv does not use k.m *)
+      (pr_mu1_le_eq_mu1 pr_mem pr_fun pr_args resv k.inv k_id d.inv, 2)
 
     | (`MuEq | `MuSub as kind) -> begin
       match torw.f_node with
-      | Fapp(_, [{f_node = Fpr ({ pr_event = ev1 } as pr) };
-                 {f_node = Fpr ({ pr_event = ev2 }) };])
+      | Fapp(_, [{f_node = Fpr pr1 };
+                 {f_node = Fpr pr2 };])
         -> begin
-          let { pr_mem = m; pr_fun = f; pr_args = args } = pr in
+          let { pr_mem = m ; pr_fun = f; pr_args = args } = pr1 in
+          let ev1 = pr1.pr_event in
+          let ev2 = EcSubst.ss_inv_rebind pr2.pr_event ev1.m in
           match kind with
           | `MuEq  -> (pr_eq  env m f args ev1 ev2, 1)
           | `MuSub -> (pr_sub env m f args ev1 ev2, 1)
@@ -262,37 +276,39 @@ let t_pr_rewrite_low (s, dof) tc =
 
     | `MuNot ->
         let { pr_mem = m ; pr_fun = f; pr_args = args; } as pr = destr_pr torw in
-        let ev = destr_not pr.pr_event in
+        let ev = map_ss_inv1 destr_not pr.pr_event in
         (pr_not m f args ev, 0)
 
     | `MuOr ->
         let { pr_mem = m ; pr_fun = f; pr_args = args; } as pr = destr_pr torw in
-        let (asym, (ev1, ev2)) = destr_or_r pr.pr_event in
-        (pr_or m f args (match asym with | `Asym -> f_ora | `Sym -> f_or) ev1 ev2, 0)
+        let asym = fst (destr_or_r pr.pr_event.inv) in
+        let (ev1, ev2) = map_ss_inv_destr2 (fun prev -> snd (destr_or_r prev)) pr.pr_event in
+        (pr_or m f args (match asym with | `Asym -> map_ss_inv2 f_ora | `Sym -> map_ss_inv2 f_or) ev1 ev2, 0)
 
     | `MuDisj ->
         let { pr_mem = m ; pr_fun = f; pr_args = args; } as pr = destr_pr torw in
-        let (asym, (ev1, ev2)) = destr_or_r pr.pr_event in
-        (pr_disjoint env m f args (match asym with | `Asym -> f_ora | `Sym -> f_or) ev1 ev2, 1)
+        let asym = fst (destr_or_r pr.pr_event.inv) in
+        let (ev1, ev2) = map_ss_inv_destr2 (fun prev -> snd (destr_or_r prev)) pr.pr_event in
+        (pr_disjoint env m f args (match asym with | `Asym -> map_ss_inv2 f_ora | `Sym -> map_ss_inv2 f_or) ev1 ev2, 1)
 
     | `MuSplit ->
       let pr = destr_pr torw in
-      let ev' = (oget dof) tc torw EcTypes.tbool in
+      let ev' = EcSubst.ss_inv_rebind ((oget dof) tc torw EcTypes.tbool) pr.pr_event.m in
       (pr_split pr.pr_mem pr.pr_fun pr.pr_args pr.pr_event ev', 0)
 
     | `MuGe0 -> begin
       match torw.f_node with
       | Fapp({f_node = Fop _}, [_; {f_node = Fpr pr}]) ->
-            let { pr_mem = m; pr_fun = f; pr_args = args; pr_event = ev } = pr in
-            (pr_ge0 m f args ev, 0)
+            let { pr_mem = m; pr_fun = f; pr_args = args } = pr in
+            (pr_ge0 m f args pr.pr_event, 0)
       | _ -> assert false
       end
 
     | `MuLe1 -> begin
       match torw.f_node with
       | Fapp({f_node = Fop _}, [{f_node = Fpr pr}; _]) ->
-            let { pr_mem = m; pr_fun = f; pr_args = args; pr_event = ev } = pr in
-            (pr_le1 m f args ev, 0)
+            let { pr_mem = m; pr_fun = f; pr_args = args } = pr in
+            (pr_le1 m f args pr.pr_event, 0)
       | _ -> assert false
       end
 
@@ -318,8 +334,9 @@ let t_pr_rewrite (s, f) tc =
   let to_env f tc torw ty =
     let env, hyps, _ = FApi.tc1_eflat tc in
     let pr = destr_pr torw in
-    let mp = EcEnv.Fun.prF_memenv EcFol.mhr pr.pr_fun env in
-    let hyps = LDecl.push_active mp hyps in
-    EcProofTyping.process_form hyps f ty
+    let m = EcIdent.create "&hr" in
+    let mp = EcEnv.Fun.prF_memenv m pr.pr_fun env in
+    let hyps = LDecl.push_active_ss mp hyps in
+    {m;inv=EcProofTyping.process_form hyps f ty}
   in
   t_pr_rewrite_low (s, omap to_env f) tc

--- a/src/phl/ecPhlPrRw.mli
+++ b/src/phl/ecPhlPrRw.mli
@@ -1,8 +1,9 @@
 (* -------------------------------------------------------------------- *)
 open EcSymbols
 open EcCoreGoal
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_pr_rewrite_i : symbol *  EcFol.form option -> FApi.backward
+val t_pr_rewrite_i : symbol * ss_inv option -> FApi.backward
 val t_pr_rewrite : symbol * EcParsetree.pformula option -> FApi.backward
 

--- a/src/phl/ecPhlRnd.mli
+++ b/src/phl/ecPhlRnd.mli
@@ -1,16 +1,14 @@
 (* -------------------------------------------------------------------- *)
 open EcUtils
 open EcParsetree
-open EcTypes
-open EcFol
 open EcCoreGoal.FApi
 open EcMatching.Position
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-type chl_infos_t = (form, form option, form) rnd_tac_info
-type bhl_infos_t = (form, ty -> form option, ty -> form) rnd_tac_info
+type bhl_infos_t = (ss_inv, ty -> ss_inv option, ty -> ss_inv) rnd_tac_info
 type rnd_infos_t = (pformula, pformula option, pformula) rnd_tac_info
-type mkbij_t     = EcTypes.ty -> EcTypes.ty -> EcFol.form
+type mkbij_t     = EcTypes.ty -> EcTypes.ty -> ts_inv
 
 (* -------------------------------------------------------------------- *)
 val wp_equiv_disj_rnd : side -> backward

--- a/src/phl/ecPhlRwEquiv.ml
+++ b/src/phl/ecPhlRwEquiv.ml
@@ -4,6 +4,7 @@ open EcParsetree
 open EcFol
 open EcModules
 open EcPath
+open EcAst
 
 open EcCoreGoal
 open EcCoreGoal.FApi
@@ -85,7 +86,7 @@ let t_rewrite_equiv side dir cp (equiv : equivF) equiv_pt rargslv tc =
        | `Left, `RtoL  -> EcPhlSym.t_equiv_sym
        | `Right, `LtoR -> EcPhlSym.t_equiv_sym
        | `Right, `RtoL  -> t_id);
-      EcPhlCall.t_call None (f_equivF_r equiv);
+      EcPhlCall.t_call None (f_equivF (ef_pr equiv) equiv.ef_fl equiv.ef_fr (ef_po equiv));
       t_try (t_apply equiv_pt); (* FIXME: Can do better here, we know this applies to just the first sub goal of call *)
       t_try (t_seqs [
         EcPhlInline.process_inline (`ByName (None, None, ([], None)));
@@ -139,7 +140,7 @@ let process_rewrite_equiv info tc =
         begin
           try
             let proc = EcEnv.Fun.by_xpath new_func env in
-            let subenv = EcEnv.Memory.push_active mem env in
+            let subenv = EcEnv.Memory.push_active_ss mem env in
             let ue = EcUnify.UniEnv.create (Some []) in
             let args, ret_ty = EcTyping.trans_args subenv ue (loc pargs) proc.f_sig (unloc pargs) in
             let res = omap (fun v -> EcTyping.transexpcast subenv `InProc ue ret_ty v) pres in

--- a/src/phl/ecPhlSwap.ml
+++ b/src/phl/ecPhlSwap.ml
@@ -160,7 +160,7 @@ let rec process_swap1 (info : (oside * pswap_kind) located) (tc : tcenv1) =
     let me, _ = EcLowPhlGoal.tc1_get_stmt side tc in
 
     let process_codepos =
-      let env = EcEnv.Memory.push_active me env in
+      let env = EcEnv.Memory.push_active_ss me env in
       fun p -> EcTyping.trans_codepos1 env p in
 
     let process_codeoffset (o : pcodeoffset1) : codeoffset1 =

--- a/src/phl/ecPhlSym.ml
+++ b/src/phl/ecPhlSym.ml
@@ -2,34 +2,25 @@
 open EcFol
 open EcCoreGoal
 open EcLowPhlGoal
-
-(*-------------------------------------------------------------------- *)
-let build_sym ml mr pr po =
-  let s = Fsubst.f_subst_id in
-  let s = Fsubst.f_bind_mem s ml mr in
-  let s = Fsubst.f_bind_mem s mr ml in
-  let s = Fsubst.f_subst s in
-  (s pr, s po)
+open EcAst
+open EcSubst
 
 (*-------------------------------------------------------------------- *)
 let t_equivF_sym tc =
-  let ef    = tc1_as_equivF tc in
-  let pr,po = build_sym mleft mright ef.ef_pr ef.ef_po in
-  let cond  = f_equivF pr ef.ef_fr ef.ef_fl po in
+  let ef     = tc1_as_equivF tc in
+  let ml, mr = ef.ef_ml, ef.ef_mr in
+  let pr     = {ml;mr;inv=(ts_inv_rebind (ef_pr ef) mr ml).inv} in
+  let po     = {ml;mr;inv=(ts_inv_rebind (ef_po ef) mr ml).inv} in
+  let cond   = f_equivF pr ef.ef_fr ef.ef_fl po in
   FApi.xmutate1 tc `EquivSym [cond]
 
 (*-------------------------------------------------------------------- *)
 let t_equivS_sym tc =
   let es    = tc1_as_equivS tc in
-  let pr,po = build_sym (fst es.es_ml) (fst es.es_mr) es.es_pr es.es_po in
-  let cond  = f_equivS_r {
-    es_ml = fst es.es_ml, snd es.es_mr;
-    es_mr = fst es.es_mr, snd es.es_ml;
-    es_sl = es.es_sr;
-    es_sr = es.es_sl;
-    es_pr = pr;
-    es_po = po; } in
-
+  let (ml, mtl), (mr, mtr) = es.es_ml, es.es_mr in
+  let pr    = {ml;mr;inv=(ts_inv_rebind (es_pr es) mr ml).inv} in
+  let po    = {ml;mr;inv=(ts_inv_rebind (es_po es) mr ml).inv} in
+  let cond  = f_equivS mtl mtr pr es.es_sr es.es_sl po in
   FApi.xmutate1 tc `EquivSym [cond]
 
 (*-------------------------------------------------------------------- *)

--- a/src/phl/ecPhlTAuto.ml
+++ b/src/phl/ecPhlTAuto.ml
@@ -1,5 +1,6 @@
 (* -------------------------------------------------------------------- *)
 open EcFol
+open EcAst
 
 open EcCoreGoal
 open EcLowPhlGoal
@@ -7,10 +8,10 @@ open EcLowPhlGoal
 (* -------------------------------------------------------------------- *)
 let t_hoare_true_r tc =
   match (FApi.tc1_goal tc).f_node with
-  | FhoareF hf when f_equal hf.hf_po f_true ->
+  | FhoareF hf when f_equal (hf_po hf).inv f_true ->
       FApi.xmutate1 tc `HoareTrue []
 
-  | FhoareS hs when f_equal hs.hs_po f_true ->
+  | FhoareS hs when f_equal (hs_po hs).inv f_true ->
       FApi.xmutate1 tc `HoareTrue []
 
   | _ ->
@@ -25,10 +26,10 @@ let f_xr0 = f_r2xr f_r0
 
 let t_ehoare_zero_r tc =
   match (FApi.tc1_goal tc).f_node with
-  | FeHoareF hf when f_equal hf.ehf_po f_xr0 ->
+  | FeHoareF hf when f_equal (ehf_po hf).inv f_xr0 ->
        FApi.xmutate1 tc `eHoareZero []
 
-  | FeHoareS hs when f_equal hs.ehs_po f_xr0 ->
+  | FeHoareS hs when f_equal (ehs_po hs).inv f_xr0 ->
        FApi.xmutate1 tc `eHoareZero []
   | _ ->
     tc_error !!tc
@@ -40,7 +41,7 @@ let t_ehoare_zero = FApi.t_low0 "hoare-zero" t_ehoare_zero_r
 (* -------------------------------------------------------------------- *)
 let t_core_exfalso_r tc =
   let pre   = tc1_get_pre tc in
-    if not (f_equal pre f_false) then
+    if not (f_equal (inv_of_inv pre) f_false) then
       tc_error !!tc "pre-condition is not `false'";
     FApi.xmutate1 tc `ExFalso []
 

--- a/src/phl/ecPhlTrans.ml
+++ b/src/phl/ecPhlTrans.ml
@@ -8,6 +8,7 @@ open EcPV
 open EcMatching
 open EcTransMatching
 open EcMaps
+open EcAst
 
 open EcCoreGoal
 open EcLowPhlGoal
@@ -17,23 +18,25 @@ module TTC = EcProofTyping
 (* -------------------------------------------------------------------- *)
 module Low = struct
   (* ------------------------------------------------------------------ *)
-  let transitivity_side_cond hyps prml prmr poml pomr p q p1 q1 pomt p2 q2 =
+  let transitivity_side_cond hyps prml prmr poml pomr p q (p1: ts_inv) (q1: ts_inv) pomt (p2: ts_inv) (q2: ts_inv) =
     let env = LDecl.toenv hyps in
     let cond1 =
-      let fv1 = PV.fv env mright p1 in
-      let fv2 = PV.fv env mleft  p2 in
+      let fv1 = PV.fv env p1.mr p1.inv in
+      let fv2 = PV.fv env p2.ml p2.inv in
       let fv  = PV.union fv1 fv2 in
       let elts, glob = PV.ntr_elements fv in
-      let bd, s = generalize_subst env mhr elts glob in
-      let s1 = PVM.of_mpv s mright in
-      let s2 = PVM.of_mpv s mleft in
-      let concl = f_and (PVM.subst env s1 p1) (PVM.subst env s2 p2) in
-      f_forall_mems [prml;prmr] (f_imp p (f_exists bd concl)) in
+      let m = EcIdent.create "&m" in
+      let bd, s = generalize_subst env m elts glob in
+      let s1 = PVM.of_mpv s p.mr in
+      let s2 = PVM.of_mpv s p.ml in
+      let concl = map_ts_inv2 f_and (map_ts_inv1 (PVM.subst env s1) p1) (map_ts_inv1 (PVM.subst env s2) p2) in
+      EcSubst.f_forall_mems_ts_inv prml prmr (map_ts_inv2 f_imp p (map_ts_inv1 (f_exists bd) concl)) in
     let cond2 =
       let m2 = LDecl.fresh_id hyps "&m" in
-      let q1 = Fsubst.f_subst_mem mright m2 q1 in
-      let q2 = Fsubst.f_subst_mem mleft  m2 q2 in
-      f_forall_mems [poml;(m2,pomt);pomr] (f_imps [q1;q2] q) in
+      assert (q.ml = q1.ml && q.mr = q2.mr);
+      let q1 = (EcSubst.ts_inv_rebind_right q1 m2).inv in
+      let q2 = (EcSubst.ts_inv_rebind_left q2 m2).inv in
+      f_forall_mems [poml;(m2,pomt);pomr] (f_imps [q1;q2] q.inv) in
     (cond1, cond2)
 
   (* ------------------------------------------------------------------ *)
@@ -43,21 +46,11 @@ module Low = struct
     let m1, m3 = es.es_ml, es.es_mr in
     let cond1, cond2 =
       transitivity_side_cond hyps
-        m1 m3 m1 m3 es.es_pr es.es_po p1 q1 mt p2 q2 in
+        m1 m3 m1 m3 (es_pr es) (es_po es) p1 q1 mt p2 q2 in
     let cond3 =
-      f_equivS_r { es with
-        es_mr = (mright,mt);
-        es_sr = c2;
-        es_pr = p1;
-        es_po = q1;
-      } in
+      f_equivS (snd es.es_ml) mt p1 es.es_sl c2 q1 in
     let cond4 =
-      f_equivS_r { es with
-        es_ml = (mleft, mt);
-        es_sl = c2;
-        es_pr = p2;
-        es_po = q2;
-      } in
+      f_equivS mt (snd es.es_mr) p2 c2 es.es_sr q2 in
 
      FApi.xmutate1 tc `Trans [cond1; cond2; cond3; cond4]
 
@@ -65,12 +58,13 @@ module Low = struct
   let t_equivF_trans_r f (p1, q1) (p2, q2) tc =
     let env, hyps, _ = FApi.tc1_eflat tc in
     let ef = tc1_as_equivF tc in
-    let (prml, prmr), (poml, pomr) = Fun.equivF_memenv ef.ef_fl ef.ef_fr env in
-    let (_, pomt) = snd (Fun.hoareF_memenv f env) in
+    let ml, mr = ef.ef_ml, ef.ef_mr in
+    let (prml, prmr), (poml, pomr) = Fun.equivF_memenv ml mr ef.ef_fl ef.ef_fr env in
+    let (_, pomt) = snd (Fun.hoareF_memenv p1.ml f env) in
     let cond1, cond2 =
       transitivity_side_cond
         hyps prml prmr poml pomr
-        ef.ef_pr ef.ef_po p1 q1 pomt p2 q2 in
+        (ef_pr ef) (ef_po ef) p1 q1 pomt p2 q2 in
     let cond3 = f_equivF p1 ef.ef_fl f q1 in
     let cond4 = f_equivF p2 f ef.ef_fr q2 in
 
@@ -85,23 +79,33 @@ let t_equivF_trans = FApi.t_low3 "equiv-trans" Low.t_equivF_trans_r
 let t_equivS_trans_eq side s tc =
   let env = FApi.tc1_env tc in
   let es = tc1_as_equivS tc in
-  let c, m = match side with `Left -> es.es_sl, es.es_ml | `Right -> es.es_sr, es.es_mr in
+  let c, m, mem_pre = match side with 
+    | `Left -> 
+      let mem_pre_ss = EcFol.split_sided (fst es.es_ml) (es_pr es) in
+      let mem_pre = Option.map (fun mpre -> ss_inv_generalize_right mpre (fst es.es_mr)) mem_pre_ss in
+      es.es_sl, es.es_ml, mem_pre
+    | `Right -> 
+      let mem_pre_ss = EcFol.split_sided (fst es.es_mr) (es_pr es) in
+      let mem_pre = Option.map (fun mpre -> ss_inv_generalize_left mpre (fst es.es_ml)) mem_pre_ss in
+      es.es_sr, es.es_mr, mem_pre in
 
-  let mem_pre = EcFol.split_sided (EcMemory.memory m) es.es_pr in
-  let fv_pr  = EcPV.PV.fv env (EcMemory.memory m) es.es_pr in
-  let fv_po  = EcPV.PV.fv env (fst m) es.es_po in
+  let fv_pr  = EcPV.PV.fv env (fst m) (es_pr es).inv in
+  let fv_po  = EcPV.PV.fv env (fst m) (es_po es).inv in
   let fv_r = EcPV.s_read env c in
+  let ml, mr = (fst es.es_ml), (fst es.es_mr) in
   let mk_eqs fv =
     let vfv, gfv = EcPV.PV.elements fv in
-    let veq = List.map (fun (x,ty) -> f_eq (f_pvar x ty mleft) (f_pvar x ty mright)) vfv in
-    let geq = List.map (fun mp -> f_eqglob mp mleft mp mright) gfv in
-    f_ands (veq @ geq) in
+    let xl x ty = ss_inv_generalize_right (f_pvar x ty ml) mr in
+    let xr x ty = ss_inv_generalize_left (f_pvar x ty mr) ml in
+    let veq = List.map (fun (x,ty) -> map_ts_inv2 f_eq (xl x ty) (xr x ty)) vfv in
+    let geq = List.map (fun mp -> ts_inv_eqglob mp ml mp mr) gfv in
+    map_ts_inv ~ml ~mr f_ands (veq @ geq) in
   let pre = mk_eqs (EcPV.PV.union (EcPV.PV.union fv_pr fv_po) fv_r) in
-  let pre = f_and pre (odfl f_true mem_pre) in
+  let pre = map_ts_inv2 f_and pre (odfl {ml=pre.ml;mr=pre.mr;inv=f_true} mem_pre) in
   let post = mk_eqs fv_po in
   let c1, c2 =
-    if side = `Left then (pre, post), (es.es_pr, es.es_po)
-    else (es.es_pr, es.es_po), (pre, post)
+    if side = `Left then (pre, post), (es_pr es, es_po es)
+    else (es_pr es, es_po es), (pre, post)
   in
 
   let exists_subtac (tc : tcenv1) =
@@ -185,13 +189,20 @@ let process_trans_stmt tf s ?pat c tc =
       t_equivS_trans_eq s c tc
   | TFform (p1, q1, p2, q2) ->
     let p1, q1 =
-      let hyps = LDecl.push_all [es.es_ml; (mright, mt)] hyps in
-      TTC.pf_process_form !!tc hyps tbool p1, TTC.pf_process_form !!tc hyps tbool q1
+      let ml, mr = fst es.es_ml, fst es.es_mr in
+      let hyps = LDecl.push_active_ts es.es_ml (mr, mt) hyps in
+      let p1 = TTC.pf_process_form !!tc hyps tbool p1 in
+      let q1 = TTC.pf_process_form !!tc hyps tbool q1 in
+      {ml;mr;inv=p1}, {ml;mr;inv=q1}
     in
     let p2, q2 =
-      let hyps = LDecl.push_all [(mleft, mt); es.es_mr] hyps in
-      TTC.pf_process_form !!tc hyps tbool p2, TTC.pf_process_form !!tc hyps tbool q2
+      let ml, mr = fst es.es_ml, fst es.es_mr in
+      let hyps = LDecl.push_active_ts (ml, mt) es.es_mr hyps in
+      let p2 = TTC.pf_process_form !!tc hyps tbool p2 in
+      let q2 = TTC.pf_process_form !!tc hyps tbool q2 in
+      {ml;mr;inv=p2}, {ml;mr;inv=q2} 
     in
+
     t_equivS_trans (mt, c) (p1, q1) (p2, q2) tc
 
 (* -------------------------------------------------------------------- *)
@@ -199,14 +210,15 @@ let process_trans_fun f p1 q1 p2 q2 tc =
   let env, hyps, _ = FApi.tc1_eflat tc in
   let ef = tc1_as_equivF tc in
   let f = EcTyping.trans_gamepath env f in
-  let (_, prmt), (_, pomt) = Fun.hoareF_memenv f env in
-  let (prml, prmr), (poml, pomr) = Fun.equivF_memenv ef.ef_fl ef.ef_fr env in
+  let (_, prmt), (_, pomt) = Fun.hoareF_memenv (EcIdent.create "&dummy") f env in
+  let (prml, prmr), (poml, pomr) = Fun.equivF_memenv ef.ef_ml ef.ef_mr ef.ef_fl ef.ef_fr env in
   let process ml mr fo =
-    TTC.pf_process_form !!tc (LDecl.push_all [ml; mr] hyps) tbool fo in
-  let p1 = process prml (mright, prmt) p1 in
-  let q1 = process poml (mright, pomt) q1 in
-  let p2 = process (mleft,prmt) prmr p2 in
-  let q2 = process (mleft,pomt) pomr q2 in
+    let inv = TTC.pf_process_form !!tc (LDecl.push_active_ts ml mr hyps) tbool fo in
+    {ml=fst ml;mr=fst mr;inv} in
+  let p1 = process prml (fst prmr, prmt) p1 in
+  let q1 = process poml (fst pomr, pomt) q1 in
+  let p2 = process (fst prml, prmt) prmr p2 in
+  let q2 = process (fst poml, pomt) pomr q2 in
   t_equivF_trans f (p1, q1) (p2, q2) tc
 
 (* -------------------------------------------------------------------- *)

--- a/src/phl/ecPhlTrans.mli
+++ b/src/phl/ecPhlTrans.mli
@@ -22,14 +22,14 @@ open EcCoreGoal.FApi
 (* -------------------------------------------------------------------- *)
 val t_equivS_trans :
      EcMemory.memtype * EcModules.stmt
-  -> EcFol.form * EcFol.form
-  -> EcFol.form * EcFol.form
+  -> EcAst.ts_inv * EcAst.ts_inv
+  -> EcAst.ts_inv * EcAst.ts_inv
   -> EcCoreGoal.FApi.backward
 
 val t_equivF_trans :
      EcPath.xpath
-  -> EcFol.form * EcFol.form
-  -> EcFol.form * EcFol.form
+  -> EcAst.ts_inv * EcAst.ts_inv
+  -> EcAst.ts_inv * EcAst.ts_inv
   -> EcCoreGoal.FApi.backward
 
 (*---------------------------------------------------------------------------------------*)

--- a/src/phl/ecPhlWhile.mli
+++ b/src/phl/ecPhlWhile.mli
@@ -1,13 +1,13 @@
 (* -------------------------------------------------------------------- *)
 open EcParsetree
-open EcFol
 open EcCoreGoal.FApi
+open EcAst
 
 (* -------------------------------------------------------------------- *)
-val t_hoare_while      : form -> backward
-val t_bdhoare_while    : form -> form -> backward
-val t_equiv_while_disj : side -> form -> form -> backward
-val t_equiv_while      : form -> backward
+val t_hoare_while      : ss_inv -> backward
+val t_bdhoare_while    : ss_inv -> ss_inv -> backward
+val t_equiv_while_disj : side -> ts_inv -> ts_inv -> backward
+val t_equiv_while      : ts_inv -> backward
 
 (* -------------------------------------------------------------------- *)
 val process_while : oside -> while_info -> backward

--- a/theories/algebra/Ideal.ec
+++ b/theories/algebra/Ideal.ec
@@ -132,7 +132,6 @@ proof. by []. qed.
 lemma ideal_id0 : ideal id0.
 proof.
 rewrite /id0 /pred1; apply/idealP => //.
-- by move=> x y -> -> /=; rewrite subrr.
 - by move=> a x -> /=; rewrite mulr0.
 qed.
 

--- a/theories/algebra/Ring.ec
+++ b/theories/algebra/Ring.ec
@@ -50,6 +50,8 @@ abstract theory ZModule.
   lemma subrr (x : t): x - x = zeror.
   proof. by rewrite addrN. qed.
 
+  hint simplify subrr.
+
   lemma addKr: left_loop [-] (+).
   proof. by move=> x y; rewrite addrA addNr add0r. qed.
 

--- a/theories/crypto/AdvAbsVal.ec
+++ b/theories/crypto/AdvAbsVal.ec
@@ -38,6 +38,6 @@ lemma abs_val (P:real -> bool):
 proof.
 move=> HP &m A Hl.
 case (Pr[A.main() @ &m : res] <= 1%r / 2%r)=> Hle.
-+ by move: (HP &m (Neg_main(A))); rewrite (Neg_A_Pr_minus A &m) /#.
++ by move: (HP &m (Neg_main(A))); rewrite (Neg_A_Pr_minus A &m) //#.
 by move: (HP &m A)=> /#.
 qed.

--- a/theories/crypto/KeyEncapsulationMechanisms.eca
+++ b/theories/crypto/KeyEncapsulationMechanisms.eca
@@ -3238,7 +3238,15 @@ local equiv Eqv_DecapsOrder :
 proof.
 bypr (res.`1, res.`2){1} (res.`2, res.`1){2} => [/#|]. 
 move=> /> &1 &2 [kt kt'] eqglS -> /=. 
-rewrite (EqPr_DecapsOrder &1 _ _ _ _ kt kt') andbC (EqPr_DecapsOrder &2 _ _ _ _ kt' kt). 
+rewrite (EqPr_DecapsOrder &1 _ _ _ _ kt kt'). 
+have->: Pr[Decaps_Order.main(sk{2}, sk'{2}, c{2},
+                     c'{2}) @ &2 :
+   res.`2 = kt /\ res.`1 = kt'] =
+  Pr[Decaps_Order.main(sk{2}, sk'{2}, c{2},
+                     c'{2}) @ &2 :
+   res.`1 = kt' /\ res.`2 = kt].
+- byequiv => //; conseq (: ={glob Decaps_Order, arg} ==> ={glob Decaps_Order, res}) => //; 1:sim.
+rewrite (EqPr_DecapsOrder &2 _ _ _ _ kt' kt). 
 by rewrite 2?(EqPr_Decaps &1 &2) 3:RField.mulrC.
 qed. 
 


### PR DESCRIPTION
Rather than program logic formulas hardcoding `mhr` as the bound memory in single sided formulas and `mleft` and `mright` as the bound memories in two sided formulas we make the formulas carry along the bound memor(y/ies).

The end goal is to allow things like nested hoare statements.

Re-do of #762

The number of touched files in the PR is causing significant slowdown in the GitHub web-interface on my end, so if this happens to anyone else just waiting half a minute seems to work.