### PR TITLE
depext -> confirm level = unsafe-yes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Install EasyCrypt dependencies
       run: |
         opam pin add -n easycrypt .
+        opam install --deps-only --depext-only --confirm-level=unsafe-yes easycrypt
         opam install --deps-only easycrypt
     - name: Compile EasyCrypt
       run: opam exec -- make PROFILE=ci
@@ -61,6 +62,7 @@ jobs:
     - name: Install EasyCrypt dependencies
       run: |
         opam pin add -n easycrypt .
+        opam install --deps-only --depext-only --confirm-level=unsafe-yes easycrypt
         opam install --deps-only easycrypt
     - name: Compile EasyCrypt
       run: opam exec -- make
@@ -128,6 +130,7 @@ jobs:
     - name: Install EasyCrypt dependencies
       run: |
         opam pin add -n easycrypt easycrypt
+        opam install --deps-only --depext-only --confirm-level=unsafe-yes easycrypt
         opam install --deps-only easycrypt
     - name: Compile & Install EasyCrypt
       run: opam exec -- make -C easycrypt build install


### PR DESCRIPTION
Running `opam depext` with `confirm-level=unsafe-yes`. This allows `opam` to install missing external dependencies (via the host package manager)