### PR TITLE
Introduce a system-wide, parts-oriented configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 
 /_build
 /result
-/etc
 /theories/attic
 
 /ec.*

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
-(dirs 3rdparty src theories examples scripts)
+(dirs 3rdparty src etc theories examples scripts)
 
 (install
   (section (site (easycrypt commands)))

--- a/dune-project
+++ b/dune-project
@@ -10,7 +10,7 @@
 
 (package
  (name easycrypt)
- (sites (lib theories) (libexec commands))
+ (sites (lib theories) (libexec commands) (lib config))
  (depends
   (ocaml (>= 4.08.0))
   (batteries (>= 3))

--- a/etc/README
+++ b/etc/README
@@ -1,0 +1,2 @@
+; All .conf files in this directory are automatically loaded by EasyCrypt at startup.
+; They are processed in alphanumeric order, based on their filenames.

--- a/etc/dune
+++ b/etc/dune
@@ -1,0 +1,7 @@
+(install
+  (section (site (easycrypt config)))
+  (files (glob_files_rec *.conf)))
+
+(install
+  (section (site (easycrypt config)))
+  (files README))

--- a/src/ecRelocate.ml
+++ b/src/ecRelocate.ml
@@ -23,12 +23,14 @@ let local (name : string list) : string =
 module type Sites = sig
   val commands : string
   val theories : string list
+  val config   : string
 end
 
 (* -------------------------------------------------------------------- *)
 module LocalSites() : Sites = struct
   let commands = local ["scripts"; "testing"]
   let theories = [local ["theories"]]
+  let config   = local ["etc"]
 end
 
 (* -------------------------------------------------------------------- *)
@@ -39,6 +41,10 @@ module DuneSites() : Sites = struct
 
   let theories =
     EcDuneSites.Sites.theories
+
+  let config =
+    Option.value ~default:"etc"
+      (EcUtils.List.Exceptionless.hd EcDuneSites.Sites.config)
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecRelocate.mli
+++ b/src/ecRelocate.mli
@@ -5,6 +5,7 @@ val sourceroot : string option
 module type Sites = sig
   val commands : string
   val theories : string list
+  val config   : string
 end
 
 (* -------------------------------------------------------------------- *)


### PR DESCRIPTION
At startup, EasyCrypt now loads all configuration files from `site:config` (default: `lib/easycrypt/config`) with a `.conf` extension. These files are processed in alphabetical order, after the main system-wide configuration file.