### PR TITLE
Expose memory binding(s) in program logic statements

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -1124,10 +1124,10 @@ sform_u(P):
 | EAGER LBRACKET eb=eager_body(P) RBRACKET { eb }
 
 | PR LBRACKET
-    mp=loc(fident) args=paren(plist0(form_r(P), COMMA)) AT pn=mident
+    mp=loc(fident) args=paren(plist0(form_r(P), COMMA)) m=brace(mident)? AT pn=mident
     COLON event=form_r(P)
   RBRACKET
-    { PFprob (mp, args, pn, event) }
+    { PFprob (m, mp, args, pn, event) }
 
 | r=loc(RBOOL)
     { PFident (mk_loc r.pl_loc EcCoreLib.s_dbool, None) }
@@ -1222,30 +1222,30 @@ hoare_bd_cmp :
 | GE { EcAst.FHge }
 
 hoare_body(P):
-  mp=loc(fident) COLON pre=form_r(P) LONGARROW post=form_r(P)
-    { PFhoareF (pre, mp, post) }
+  mp=loc(fident) m=brace(mident)? COLON pre=form_r(P) LONGARROW post=form_r(P)
+    { PFhoareF (m, pre, mp, post) }
 
 ehoare_body(P):
-  mp=loc(fident) COLON pre=form_r(P) LONGARROW
+  mp=loc(fident) m=brace(mident)? COLON pre=form_r(P) LONGARROW
                        post=form_r(P)
-    { PFehoareF (pre, mp, post) }
+    { PFehoareF (m, pre, mp, post) }
 
 phoare_body(P):
-  LBRACKET mp=loc(fident) COLON
+  LBRACKET mp=loc(fident) m=brace(mident)? COLON
     pre=form_r(P) LONGARROW post=form_r(P)
   RBRACKET
     cmp=hoare_bd_cmp bd=sform_r(P)
-  { PFBDhoareF (pre, mp, post, cmp, bd) }
+  { PFBDhoareF (m, pre, mp, post, cmp, bd) }
 
 equiv_body(P):
-  mp1=loc(fident) TILD mp2=loc(fident)
+  mp1=loc(fident) ml=brace(mident)? TILD mp2=loc(fident) mr=brace(mident)?
   COLON pre=form_r(P) LONGARROW post=form_r(P)
-    { PFequivF (pre, (mp1, mp2), post) }
+    { PFequivF (ml, mr, pre, (mp1, mp2), post) }
 
 eager_body(P):
-| s1=stmt COMMA  mp1=loc(fident) TILD mp2=loc(fident) COMMA s2=stmt
+| s1=stmt COMMA  mp1=loc(fident) ml=brace(mident)? TILD mp2=loc(fident) COMMA s2=stmt mr=brace(mident)?
     COLON pre=form_r(P) LONGARROW post=form_r(P)
-    { PFeagerF (pre, (s1, mp1, mp2,s2), post) }
+    { PFeagerF (ml, mr, pre, (s1, mp1, mp2,s2), post) }
 
 pgtybinding1:
 | x=ptybinding1

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -202,12 +202,12 @@ and pformula_r =
   | PFlsless  of pgamepath
   | PFscope   of pqsymbol * pformula
 
-  | PFhoareF   of pformula * pgamepath * pformula
-  | PFehoareF  of pformula * pgamepath * pformula
-  | PFequivF   of pformula * (pgamepath * pgamepath) * pformula
-  | PFeagerF   of pformula * (pstmt * pgamepath * pgamepath * pstmt) * pformula
-  | PFprob     of pgamepath * (pformula list) * pmemory * pformula
-  | PFBDhoareF of pformula * pgamepath * pformula * phoarecmp * pformula
+  | PFhoareF   of psymbol option * pformula * pgamepath * pformula
+  | PFehoareF  of psymbol option * pformula * pgamepath * pformula
+  | PFequivF   of psymbol option * psymbol option * pformula * (pgamepath * pgamepath) * pformula
+  | PFeagerF   of psymbol option * psymbol option * pformula * (pstmt * pgamepath * pgamepath * pstmt) * pformula
+  | PFprob     of psymbol option * pgamepath * (pformula list) * pmemory * pformula
+  | PFBDhoareF of psymbol option * pformula * pgamepath * pformula * phoarecmp * pformula
 
 and pmemtype_el = ([`Single|`Tuple] * (psymbol list)) located * pty
 and pmemtype    = pmemtype_el list

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -3425,7 +3425,7 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           tyerror psubf.pl_loc env (AmbiguousProji (i, ty))
     end
 
-    | PFprob (gp, args, pr_m, event) ->
+    | PFprob (m, gp, args, pr_m, event) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Pr);
 
@@ -3435,18 +3435,19 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           transcall (fun f -> let f = transf env f in f, f.f_ty)
             env ue f.pl_loc fun_.f_sig args in
         let memid = transmem env pr_m in
-        let m = EcIdent.create "&hr" in
+        let m = odfl "&hr" (omap unloc m) in
+        let m = EcIdent.create m in
         let env = EcEnv.Fun.prF m fpath env in
         let event' = {m;inv=transf env event} in
         unify_or_fail env ue event.pl_loc ~expct:tbool event'.inv.f_ty;
         f_pr memid fpath (f_tuple args) event'
 
-    | PFhoareF (pre, gp, post) ->
+    | PFhoareF (m, pre, gp, post) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Logic);
-
         let fpath = trans_gamepath env gp in
-        let m = EcIdent.create "&hr" in
+        let m = odfl "&hr" (omap unloc m) in
+        let m = EcIdent.create m in
         let penv, qenv = EcEnv.Fun.hoareF m fpath env in
         let pre'  = transf penv pre in
         let post' = transf qenv post in
@@ -3454,10 +3455,11 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           unify_or_fail qenv ue post.pl_loc ~expct:tbool post'.f_ty;
           f_hoareF {m;inv=pre'} fpath {m;inv=post'}
 
-    | PFehoareF (pre, gp, post) ->
+    | PFehoareF (m, pre, gp, post) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Logic);
-        let m = EcIdent.create "&hr" in
+        let m = odfl "&hr" (omap unloc m) in
+        let m = EcIdent.create m in
         let fpath = trans_gamepath env gp in
         let penv, qenv = EcEnv.Fun.hoareF m fpath env in
         let pre'  = transf penv pre in
@@ -3466,10 +3468,11 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           unify_or_fail qenv ue post.pl_loc ~expct:txreal post'.f_ty;
           f_eHoareF {m;inv=pre'} fpath {m;inv=post'}
 
-    | PFBDhoareF (pre, gp, post, hcmp, bd) ->
+    | PFBDhoareF (m, pre, gp, post, hcmp, bd) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Logic);
-        let m = EcIdent.create "&hr" in
+        let m = odfl "&hr" (omap unloc m) in
+        let m = EcIdent.create m in
         let fpath = trans_gamepath env gp in
         let penv, qenv = EcEnv.Fun.hoareF m fpath env in
         let pre'  = transf penv pre in
@@ -3487,11 +3490,13 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
         let fpath = trans_gamepath env gp in
           f_losslessF fpath
 
-    | PFequivF (pre, (gp1, gp2), post) ->
+    | PFequivF (ml, mr, pre, (gp1, gp2), post) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Logic);
-        let ml = EcIdent.create "&1" in
-        let mr = EcIdent.create "&2" in
+        let ml = odfl "&1" (omap unloc ml) in
+        let ml = EcIdent.create ml in
+        let mr = odfl "&2" (omap unloc mr) in
+        let mr = EcIdent.create mr in
         let fpath1 = trans_gamepath env gp1 in
         let fpath2 = trans_gamepath env gp2 in
         let penv, qenv = EcEnv.Fun.equivF ml mr fpath1 fpath2 env in
@@ -3501,11 +3506,13 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           unify_or_fail qenv ue post.pl_loc ~expct:tbool post'.f_ty;
           f_equivF {ml;mr;inv=pre'} fpath1 fpath2 {ml;mr;inv=post'}
 
-    | PFeagerF (pre, (s1,gp1,gp2,s2), post) ->
+    | PFeagerF (ml, mr, pre, (s1,gp1,gp2,s2), post) ->
         if mode <> `Form then
           tyerror f.pl_loc env (NotAnExpression `Logic);
-        let ml = EcIdent.create "&1" in
-        let mr = EcIdent.create "&2" in
+        let ml = odfl "&1" (omap unloc ml) in
+        let ml = EcIdent.create ml in
+        let mr = odfl "&2" (omap unloc mr) in
+        let mr = EcIdent.create mr in
         let fpath1 = trans_gamepath env gp1 in
         let fpath2 = trans_gamepath env gp2 in
         let penv, qenv = EcEnv.Fun.equivF ml mr fpath1 fpath2 env in


### PR DESCRIPTION
This is a follow up PR to #789 that now allows the user to decide the name of the memory bound by a program logic statement or probability expression. This makes nested program logic statements clearer.

The syntax is `{&my_memory}` after the procedures (and arguments for a Pr) (for the relevant side if two-sided).
Examples:
 - `hoare[P.p {&m}: true ==> true]`
 - `Pr[P.p(a) {&end_mem} @ &start_mem: true] = 0%r`
 - `equiv[P.p {&left} ~ P.p {&right}: true ==> true]`

The change is backwards compatible since it is optional to provide the memory. If not provided a default name will be used instead (`&hr` for one-sided cases and `&1`/`&2` for left/right in two-sided cases). The pretty printer omits the memory binding if the default names are used.

Some tactics (conseq?) will probably also want an optional memory parameter, but I'd rather deal with that as needed.