### PR TITLE
Removing spurious `print` statements in `theories`

### DIFF
--- a/theories/datatypes/MSet.ec
+++ b/theories/datatypes/MSet.ec
@@ -377,8 +377,6 @@ proof. by apply/mset_eqP => x; rewrite !multE; smt(mult_ge0). qed.
 lemma msetU0 (A : 'a mset) : A `|` mset0 = A.
 proof. by apply/mset_eqP => x; rewrite !multE; smt(mult_ge0). qed.
 
-print maxrC.
-
 lemma msetUA (A B C : 'a mset) : A `|` (B `|` C) = A `|` B `|` C.
 proof. by apply/mset_eqP => x; rewrite !multE maxrA. qed.
 

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -545,7 +545,6 @@ have eq_main_O1e_O1l: equiv[Game(A, O1e).main ~ Gr(O1l).main:
 eager proc H (={glob Var}) => //; 2: by sim.
     proc*; inline *; rcondf{2} 6; [ by auto | by sp; if; auto].
 proc.
-print Game.
 transitivity* {1} {r <@ Game(A, O1e).main(d);}.
 + by inline *; rcondt{2} 8; auto; call(: ={Var.x}); 1: sim; auto.
 rewrite equiv[{1} 1 eq_main_O1e_O1l].


### PR DESCRIPTION
There should be no `print` statement in the standard library, which tend to be displayed quite often when compiling a bigger project. Maybe this could be checked by the CI?