### PR TITLE
Proc change multiline to range + deep code position

### DIFF
--- a/src/ecMatching.mli
+++ b/src/ecMatching.mli
@@ -99,6 +99,7 @@ module Zipper : sig
    * Raise [InvalidCPos] if [codepos_range] is not a valid range for [stmt].
    *)
   val zipper_of_cpos_range : env -> codepos_range -> stmt -> zipper * codepos1
+  val zipper_and_split_of_cpos_range : env -> codepos_range -> stmt -> (zipper * codepos1) * (instr list * instr list)
 
   (* Zip the zipper, returning the corresponding statement *)
   val zip : zipper -> stmt

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3194,10 +3194,8 @@ interleave_info:
 | LOSSLESS
     { Plossless }
 
-| PROC CHANGE side=side? pos=loc(codepos) offset=codeoffset1 COLON s=brace(stmt)
-   { if not (List.is_empty (fst (unloc pos))) then
-       parse_error (loc pos) (Some "only top-level positions are supported");
-     Pchangestmt (side, (snd (unloc pos), offset), s) }
+| PROC CHANGE side=side? pos=loc(codepos_or_range) COLON s=brace(stmt)
+    { Pchangestmt (side, (unloc pos), s) }
 
 | PROC REWRITE side=side? pos=codepos f=pterm
     { Pprocrewrite (side, pos, `Rw f) }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -770,9 +770,9 @@ type phltactic =
   | Prw_equiv      of rw_eqv_info
   | Psymmetry
   | Pbdhoare_split of bdh_split
-  | Pchangestmt    of side option * (pcodepos1 * pcodeoffset1) * pstmt
-  | Pprocrewrite   of side option * pcodepos * prrewrite
   | Prwprgm of rwprgm
+  | Pprocrewrite   of side option * pcodepos * prrewrite
+  | Pchangestmt    of side option * pcodepos_range * pstmt
 
 
     (* Eager *)

--- a/src/phl/ecPhlRewrite.mli
+++ b/src/phl/ecPhlRewrite.mli
@@ -8,4 +8,4 @@ val process_change : side option -> pcodepos -> pexpr -> backward
 val process_rewrite_rw    : side option -> pcodepos -> ppterm -> backward
 val process_rewrite_simpl : side option -> pcodepos -> backward
 val process_rewrite       : side option -> pcodepos -> prrewrite -> backward
-val process_change_stmt : side option -> pcodepos1 * pcodeoffset1 -> pstmt -> backward
+val process_change_stmt   : side option -> pcodepos_range -> pstmt -> backward

--- a/tests/procchange.ec
+++ b/tests/procchange.ec
@@ -4,14 +4,17 @@ require import AllCore Distr.
 theory ProcChangeAssignEquiv.
   module M = {
     proc f(x : int) = {
-      x <- x + 0;
+      x <- 0;
+      x <- x + 1;
+      x <- x + 2;
+      x <- x + 3;
     }
   }.
   
   lemma L : equiv[M.f ~ M.f: true ==> true].
   proof.
   proc.
-    proc change {1} 1 1 : { x <- x; }.
+    proc change {1} [1..3] : { x <- 3; }.
     
     wp. skip. smt().
   abort.
@@ -27,7 +30,7 @@ theory ProcChangeAssignHoareEquiv.
   lemma L : hoare[M.f : true ==> true].
   proof.
   proc.
-    proc change 1 1 : { x <- x ; }. wp. skip. smt().
+    proc change [1..1] : { x <- x ; }. wp. skip. smt().
   abort.
 end ProcChangeAssignHoareEquiv.
 
@@ -42,7 +45,7 @@ theory ProcChangeSampleEquiv.
   lemma L : equiv[M.f ~ M.f : true ==> true].
   proof.
   proc.
-  proc change {1} 1 1 : { x <$ (dunit x); }.
+  proc change {1} [1..1] : { x <$ (dunit x); }.
   rnd. skip. smt().
   abort.
 end ProcChangeSampleEquiv.
@@ -62,7 +65,7 @@ theory ProcChangeIfEquiv.
   lemma L : equiv[M.f ~ M.f : true ==> true].
   proof.
   proc.
-  proc change {1} 1 1 : { 
+  proc change {1} [1..1] : { 
     if (x = y) {
       x <- y;
     } else {
@@ -85,14 +88,46 @@ theory ProcChangeWhileEquiv.
   lemma L : equiv[M.f ~ M.f : true ==> true].
   proof.
   proc.
-  proc change {1} 1 1 : {
+  proc change {1} [1..1] : {
     while (x <> y) {
-      x <- x + 1;
+      x <- x + 1 + 0;
     }
   }.
-  admit. (* FIXME *)
+  proc rewrite {1} 1 /=.
+  proc rewrite {2} 1.1 /=. 
+  sim.
   abort.
 end ProcChangeWhileEquiv.
+
+
+(* -------------------------------------------------------------------- *)
+theory ProcChangeInWhileEquiv.
+  module M = {
+    proc f(x : int, y : int) = {
+    while (x + 0 <> y) {
+        x <- 1;
+        x <- x + 1;
+        x <- 2;
+      }
+    }
+  }.
+  
+  lemma L : equiv[M.f ~ M.f : true ==> true].
+  proof.
+  proc.
+  proc change {1} ^while.2 : {
+    x <- x + 0 + 1;
+  }.
+  wp; skip. smt().
+  proc change {1} [^while.1..^while.2] : {
+    x <- 2;
+  }. wp; skip. smt().
+  proc change {2} [^while.1-1] : {
+    x <- 2;
+  }. wp; skip. smt().
+  abort.
+end ProcChangeInWhileEquiv.
+
 
 (* -------------------------------------------------------------------- *)
 theory ProcChangeAssignHoare.
@@ -105,7 +140,7 @@ theory ProcChangeAssignHoare.
   lemma L : hoare[M.f: true ==> true].
   proof.
   proc.
-    proc change 1 1 : { x <- x; }.
+    proc change [1..1] : { x <- x; }.
     wp; skip; smt().
   abort.
 end ProcChangeAssignHoare.
@@ -121,7 +156,7 @@ theory ProcChangeSampleHoare.
   lemma L : hoare[M.f: true ==> true].
   proof.
   proc.
-  proc change 1 1 : { x <$ (dunit x); }.
+  proc change 1 : { x <$ (dunit x); }.
   rnd; skip; smt().
   abort.
 end ProcChangeSampleHoare.
@@ -141,7 +176,7 @@ theory ProcChangeIfHoare.
   lemma L : hoare[M.f: true ==> true].
   proof.
   proc.
-  proc change 1 1 : { 
+  proc change 1 : { 
     if (x = y) {
       x <- y;
     } else {
@@ -164,11 +199,33 @@ theory ProcChangeWhileHoare.
   lemma L : hoare[M.f: true ==> true].
   proof.
   proc.
-  proc change 1 1 : {
+  proc change 1 : {
     while (x <> y) {
       x <- x + 1;
     }
   }.
-  admit. (* FIXME *)
+  proc rewrite {1} ^while /=; sim.
   abort.
 end ProcChangeWhileHoare.
+
+
+(* -------------------------------------------------------------------- *)
+theory ProcChangeInWhileHoare.
+  module M = {
+    proc f(x : int, y : int) = {
+      while (x + 0 <> y) {
+        x <- x + 1;
+      }
+    }
+  }.
+  
+  lemma L : hoare[M.f : true ==> true].
+  proof.
+  proc.
+  proc change ^while.1 : {
+    x <- x + 0 + 1;
+  }.
+  wp; skip. smt().
+  abort.
+end ProcChangeInWhileHoare.
+


### PR DESCRIPTION
Changed proc change syntax to use ranges (inline with other tactics) and added support for changing in deep code position.

Added zipper_and_split_of_codepos_range utility function

Also removed admits from proc change test