### PR TITLE
Build docker images in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: EasyCrypt Docker Containers Build
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release'
+    tags:
+      - 'r[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  make-images:
+    name: Build and Push Container Images
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build `base` Image
+      run: TAG=${{ github.ref_name }} VARIANT=base make -C scripts/docker
+
+    - name: Build `build` Image
+      run: TAG=${{ github.ref_name }} VARIANT=build make -C scripts/docker
+
+    - name: Build `formosa` Image
+      run: TAG=${{ github.ref_name }} VARIANT=formosa make -C scripts/docker
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: https://ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push All Images
+      run: |
+        TAG=${{ github.ref_name }} VARIANT=base make -C scripts/docker publish
+        TAG=${{ github.ref_name }} VARIANT=build make -C scripts/docker publish
+        TAG=${{ github.ref_name }} VARIANT=formosa make -C scripts/docker publish

--- a/scripts/docker/Makefile
+++ b/scripts/docker/Makefile
@@ -2,6 +2,7 @@
 
 # --------------------------------------------------------------------
 VARIANT ?= build
+TAG     ?= main
 
 # --------------------------------------------------------------------
 .PHONY: default build publish
@@ -11,8 +12,8 @@ default: build
 build:
 	docker build -f Dockerfile.$(VARIANT) \
 	  --platform linux/amd64 \
-	  -t ghcr.io/easycrypt/ec-$(VARIANT)-box \
+	  -t ghcr.io/easycrypt/ec-$(VARIANT)-box:$(TAG) \
 	  .
 
 publish:
-	docker push ghcr.io/easycrypt/ec-$(VARIANT)-box
+	docker push ghcr.io/easycrypt/ec-$(VARIANT)-box:$(TAG)


### PR DESCRIPTION
This adds a pipeline to generate `base`, `build` and `formosa` containers in CI for release branches (tagged by the release tag). This captures the software environment at the time of release and should help ensure we have stable-ish artefacts going forward.