### PR TITLE
Make casts from existing single sided formulas to two sided ones use a more robust pattern

### DIFF
--- a/src/phl/ecPhlApp.ml
+++ b/src/phl/ecPhlApp.ml
@@ -124,13 +124,13 @@ let t_equiv_app_onesided side i pre post tc =
   let (ml, mr) = fst es.es_ml, fst es.es_mr in
   let s, s', p', q' =
     match side with
-    | `Left  ->
-      let p' = ss_inv_generalize_right (EcSubst.ss_inv_rebind pre ml) mr in
-      let q' = ss_inv_generalize_right (EcSubst.ss_inv_rebind post ml) mr in
+    | `Left  -> 
+      let p' = ss_inv_generalize_as_left pre ml mr in
+      let q' = ss_inv_generalize_as_left post ml mr in
       es.es_sl, es.es_sr, p', q'
-    | `Right ->
-      let p' = ss_inv_generalize_left (EcSubst.ss_inv_rebind pre mr) ml in
-      let q' = ss_inv_generalize_left (EcSubst.ss_inv_rebind post mr) ml in
+    | `Right -> 
+      let p' = ss_inv_generalize_as_right pre ml mr in
+      let q' = ss_inv_generalize_as_right post ml mr in
       es.es_sr, es.es_sl, p', q'
   in
   let generalize_mod_side= sideif side generalize_mod_left generalize_mod_right in

--- a/tests/conseq_equiv_phoare_at_equiv.ec
+++ b/tests/conseq_equiv_phoare_at_equiv.ec
@@ -1,0 +1,13 @@
+module Foo = {
+   proc foo(i : int) = {
+   }
+}.
+
+lemma foo_corr : hoare [ Foo.foo : true ==> true] by proc;auto.
+
+lemma foo_eq : equiv [ Foo.foo ~ Foo.foo : ={arg} ==> true ] by sim.
+
+lemma foo_eq_corr:
+       equiv [ Foo.foo ~ Foo.foo : ={arg} ==> ={res} ].
+       conseq foo_eq foo_corr.
+qed.


### PR DESCRIPTION
Fixes #850, which was caused by a typo in the old pattern where the left and right memory were in the wrong place. In the more robust pattern the left memory is always on the left and the right is always on the right, making it harder to make such mistakes.