### PR TITLE
Kill warnings + unify flags for ci/dev dune environments

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,9 @@
 (env
- (dev     (flags :standard -rectypes -warn-error -a+31 -w +28+33-9-23-32-58-67-69))
- (ci      (flags :standard -rectypes -warn-error +a    -w +28+33-9-23-32-58-67-69))
- (release (flags :standard -rectypes -warn-error -a    -w +28+33-9-23-32-58-67-69)
+ (dev     (flags :standard -rectypes -w @1..3@5..28@31..39@43@46..47@49..57@61..62-40-9-23-32-67-69 -warn-error -a+31))
+ (ci      (flags :standard -rectypes -w @1..3@5..28@31..39@43@46..47@49..57@61..62-40-9-23-32-67-69 -warn-error +a))
+ (release (flags :standard -rectypes)
           (ocamlopt_flags -O3 -unbox-closures)))
+
 
 (include_subdirs unqualified)
 
@@ -30,4 +31,4 @@
 (menhir
  (modules ecParser)
  (explain true)
- (flags --table))
+ (flags --table --unused-token COMMENT))

--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -620,7 +620,7 @@ let pp_modtype1 (ppe : PPEnv.t) fmt mty =
 
 (* -------------------------------------------------------------------- *)
 let pp_local (ppe : PPEnv.t) fmt x =
-  Format.fprintf fmt "%s" (EcIdent.name x)
+  Format.fprintf fmt "%s" (PPEnv.local_symb ppe x)
 
 (* -------------------------------------------------------------------- *)
 let pp_local ?fv (ppe : PPEnv.t) fmt x =


### PR DESCRIPTION
This commit makes the warning flags now explicit for the dev/ci environments and use the same set of warning flags for both of them. This will allow us to catch more warnings in the CI.

For the release environment, we now use the default set of flags.

As a side effect, this commit fixes the pretty printing of local variables (the actual code was not using the printing environment anymore to get the display name)