### PR TITLE
Improve nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake .#withDevTools
+export OCAMLRUNPARAM=b

--- a/flake.lock
+++ b/flake.lock
@@ -1,13 +1,32 @@
 {
   "nodes": {
+    "emacs-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1774604501,
+        "narHash": "sha256-0aa3yWOhU8uLfMFTHY9Gy8Vu9EIXvdJUk/KsEuAxB7c=",
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "rev": "6763245bda7274bf6b9eb62a65838d3241553385",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -39,11 +58,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -70,11 +89,43 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1774388614,
+        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {
@@ -84,22 +135,38 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "mirage-opam-overlays": "mirage-opam-overlays",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "opam-overlays": "opam-overlays",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1736955560,
-        "narHash": "sha256-9I42xwKXH7h+jQGJQ8t797j/mWylIItIljRLm44CHS8=",
+        "lastModified": 1771067167,
+        "narHash": "sha256-XSw8dQIkdr+6eLvbUHo3cJPtTU7o5SMODz3qlnzmGpQ=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "5f760f445d6693eb086327fa7d7ae8e43c906718",
+        "rev": "2e20bbbe8130d1880338291446fd4e710a4db9a1",
         "type": "github"
       },
       "original": {
@@ -111,11 +178,11 @@
     "opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1726822209,
-        "narHash": "sha256-bwM18ydNT9fYq91xfn4gmS21q322NYrKwfq0ldG9GYw=",
+        "lastModified": 1741116009,
+        "narHash": "sha256-Z0PIW82fHJFvAv/JYpAffnp2DaOjLhsPutqyIrORZd0=",
         "owner": "dune-universe",
         "repo": "opam-overlays",
-        "rev": "f2bec38beca4aea9e481f2fd3ee319c519124649",
+        "rev": "e031bb64e33bf93be963e9a38b28962e6e14381f",
         "type": "github"
       },
       "original": {
@@ -127,11 +194,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1736935757,
-        "narHash": "sha256-LNkGSkZJXJmxpUd+luDUIIV/1B5MZIBMTB1qZqypa4o=",
+        "lastModified": 1759971927,
+        "narHash": "sha256-aUZWd0KOpEnioBwqlwRU40rUFAqT3RTlojXt2oI3omY=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "a8b00ead922e2049581ab16994586ed4ddbdb784",
+        "rev": "551314ad1550478ec6be39bb0eaadd2569190464",
         "type": "github"
       },
       "original": {
@@ -145,14 +212,15 @@
         "nixpkgs": [
           "opam-nix",
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "lastModified": 1749457947,
+        "narHash": "sha256-+QVm+HOYikF3wUhqSIV8qJbE/feSG+p48fgxIosbHS0=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "rev": "0ecd66fc2bfb25d910522c990dd36412259eac1f",
         "type": "github"
       },
       "original": {
@@ -178,42 +246,43 @@
         "type": "github"
       }
     },
-    "prover_cvc5_1_0_9": {
+    "prover_cvc5_1_3_0": {
       "flake": false,
       "locked": {
-        "lastModified": 1702998934,
-        "narHash": "sha256-AwUQHFftn51Xt6HtmDsWAdkOS8i64r2FhaHu31KYwZA=",
+        "lastModified": 1750292852,
+        "narHash": "sha256-w8rIGPG9BTEPV9HG2U40A4DYYnC6HaWbzqDKCRhaT00=",
         "owner": "cvc5",
         "repo": "cvc5",
-        "rev": "8fca72aebcb5293434c3207dca081a845ff8d6fe",
+        "rev": "02c4e43d191f86b67a8a6d615544630a8df0f18e",
         "type": "github"
       },
       "original": {
         "owner": "cvc5",
-        "ref": "cvc5-1.0.9",
+        "ref": "cvc5-1.3.0",
         "repo": "cvc5",
         "type": "github"
       }
     },
-    "prover_z3_4_12_6": {
+    "prover_z3_4_14_1": {
       "flake": false,
       "locked": {
-        "lastModified": 1708814107,
-        "narHash": "sha256-X4wfPWVSswENV0zXJp/5u9SQwGJWocLKJ/CNv57Bt+E=",
+        "lastModified": 1741647008,
+        "narHash": "sha256-pTsDzf6Frk4mYAgF81wlR5Kb1x56joFggO5Fa3G2s70=",
         "owner": "z3prover",
         "repo": "z3",
-        "rev": "fa2c0e027894a8d55d2b841e27cbeecc99692a3f",
+        "rev": "3c0d786e6e86b6a10cbc14703c3f863c568b85dd",
         "type": "github"
       },
       "original": {
         "owner": "z3prover",
-        "ref": "z3-4.12.6",
+        "ref": "z3-4.14.1",
         "repo": "z3",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "emacs-overlay": "emacs-overlay",
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "opam-nix",
@@ -221,25 +290,9 @@
         ],
         "opam-nix": "opam-nix",
         "prover_cvc4_1_8": "prover_cvc4_1_8",
-        "prover_cvc5_1_0_9": "prover_cvc5_1_0_9",
-        "prover_z3_4_12_6": "prover_z3_4_12_6",
-        "stable": "stable"
-      }
-    },
-    "stable": {
-      "locked": {
-        "lastModified": 1717179513,
-        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "24.05",
-        "repo": "nixpkgs",
-        "type": "github"
+        "prover_cvc5_1_3_0": "prover_cvc5_1_3_0",
+        "prover_z3_4_14_1": "prover_z3_4_14_1",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
@@ -269,6 +322,39 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,35 +1,60 @@
 {
+  nixConfig = {
+    extra-substituters = [
+      "https://easycrypt.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "easycrypt.cachix.org-1:d0hAur+ZAUIM7rAi1TlG2ZCra6AXS50CggshQcT6f7g="
+    ];
+  };
   inputs = {
     opam-nix.url = "github:tweag/opam-nix";
 
     flake-utils.url = "github:numtide/flake-utils";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
 
-    nixpkgs.url = "github:nixos/nixpkgs/24.05";
-    stable.url = "github:nixos/nixpkgs/24.05";
     nixpkgs.follows = "opam-nix/nixpkgs";
+    emacs-overlay.url = "github:nix-community/emacs-overlay";
 
     prover_cvc4_1_8 = {
       url = "github:CVC4/CVC4-archived/1.8";
       flake = false;
     };
 
-    prover_cvc5_1_0_9 = {
-      url = "github:cvc5/cvc5/cvc5-1.0.9";
+    prover_cvc5_1_3_0 = {
+      url = "github:cvc5/cvc5/cvc5-1.3.0";
       flake = false;
     };
 
-    prover_z3_4_12_6 = {
-      url = "github:z3prover/z3/z3-4.12.6";
+    prover_z3_4_14_1 = {
+      url = "github:z3prover/z3/z3-4.14.1";
       flake = false;
     };
   };
 
-  outputs = { self, flake-utils, opam-nix, nixpkgs, ... }@inputs:
-    let package = "easycrypt"; in
+  outputs = {
+    flake-utils,
+    opam-nix,
+    nixpkgs,
+    emacs-overlay,
+    treefmt-nix,
+    ...
+  } @ inputs: let
+    package = "easycrypt";
+  in
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        overlays = [(import emacs-overlay)];
+        pkgs = import nixpkgs {inherit system overlays;};
+        treefmtEval = treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
 
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
+          # Enable formatters
+          programs.alejandra.enable = true;
+          # programs.ocamlformat.enable = true; # TODO: Enable when we have a repo .ocamlformat
+
+          # Add any extra formatters here (for MD, docs, whatever)
+        };
 
         on = opam-nix.lib.${system};
 
@@ -39,36 +64,64 @@
           ocamlformat = "*";
         };
 
-        query = devPackagesQuery // {
-          ocaml-base-compiler = "4.14.2";
+        query =
+          devPackagesQuery
+          // {
+            ocaml-base-compiler = "5.3.0";
+          };
+
+        opamSource = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            type
+            == "directory"
+            || pkgs.lib.strings.hasSuffix ".opam" path
+            || builtins.baseNameOf path == "dune-project"
+            || builtins.baseNameOf path == "dune";
         };
 
-        scope = on.buildOpamProject' { } ./. query;
+        scope = on.buildOpamProject' {} opamSource query;
 
-        overlay = final: prev: {
+        overlay = _final: prev: {
           ${package} = prev.${package}.overrideAttrs (oa: {
-            nativeBuildInputs = oa.nativeBuildInputs
-              ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.sigtool ];
+            src = pkgs.lib.cleanSource ./.;
+            nativeBuildInputs =
+              oa.nativeBuildInputs ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [pkgs.darwin.sigtool];
             postInstall = ''
               ln -s "$out/lib/ocaml/$opam__ocaml__version/site-lib/easycrypt" $out/lib/
             '';
             doNixSupport = false;
           });
-          conf-pkg-config = prev.conf-pkg-config.overrideAttrs (oa: {
-            nativeBuildInputs = oa.nativeBuildInputs ++ [pkgs.pkg-config];
-          });
+          conf-zlib = prev.conf-zlib.overrideAttrs (
+            _finalAttrs: prevAttrs: {
+              nativeBuildInputs = prevAttrs.nativeBuildInputs ++ (with pkgs; [pkg-config]);
+            }
+          );
+          conf-git = prev.conf-git.overrideAttrs (
+            _finalAttrs: prevAttrs: {
+              nativeBuildInputs = prevAttrs.nativeBuildInputs ++ (with pkgs; [git]);
+              buildInputs = prevAttrs.buildInputs ++ (with pkgs; [git]);
+            }
+          );
+          alt-ergo = prev.alt-ergo.overrideAttrs (
+            _finalAttrs: prevAttrs: {
+              nativeBuildInputs = prevAttrs.nativeBuildInputs ++ (with pkgs; [darwin.sigtool]);
+            }
+          );
         };
 
         scope' = scope.overrideScope overlay;
 
         # Packages from devPackagesQuery
-        devPackages = builtins.attrValues
-          (pkgs.lib.getAttrs (builtins.attrNames devPackagesQuery) scope');
+        devPackages = builtins.attrValues (pkgs.lib.getAttrs (builtins.attrNames devPackagesQuery) scope');
 
         # The main package containing the executable
         main = pkgs.symlinkJoin {
           name = "main";
-          paths = [ scope'.${package} scope'.why3 ];
+          paths = [
+            scope'.${package}
+            scope'.why3
+          ];
         };
 
         # Create provers packages
@@ -78,36 +131,85 @@
             src = inputs."${"prover_" + pkg + "_" + builtins.replaceStrings ["."] ["_"] version}";
           });
 
-        mkAltErgo = version:
-          ((on.queryToScope { } (query // { alt-ergo = version; })).overrideScope overlay).alt-ergo;
+        mkAltErgo = version: (on.queryToScope {} (query // {alt-ergo = version;})).alt-ergo;
+
+        devTools = with pkgs;
+          [
+            (emacsWithPackagesFromUsePackage {
+              config = ''(setq easycrypt-prog-name "ec.native")'';
+              defaultInitFile = true;
+              alwaysEnsure = true;
+              package = pkgs.emacs;
+              extraEmacsPackages = epkgs: [epkgs.proof-general];
+            })
+            bashInteractive
+            git
+            difftastic
+          ]
+          ++ lib.optionals (!stdenv.isDarwin) [perf-tools];
+
+        ecShell = "${pkgs.bashInteractive + "/bin/bash"}";
+        ecShellHook = ''
+          export SHELL=${ecShell}
+          export PATH=$PATH:`realpath .`
+        '';
       in rec {
         legacyPackages = scope';
 
         packages = rec {
-          z3 = mkProverPackage "z3" "4.12.6";
+          z3 = mkProverPackage "z3" "4.14.1";
           cvc4 = mkProverPackage "cvc4" "1.8";
-          cvc5 = mkProverPackage "cvc5" "1.0.9";
-          altErgo = mkAltErgo "2.4.3";
+          cvc5 = mkProverPackage "cvc5" "1.3.0";
+          altErgo = mkAltErgo "2.4.2";
 
           provers = pkgs.symlinkJoin {
             name = "provers";
-            paths = [ altErgo z3 cvc4 cvc5 ];
+            paths =
+              [
+                altErgo
+                z3
+                cvc5
+              ]
+              ++ (pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [cvc4]); # Cvc4 build is broken in MacOS
           };
 
           with_provers = pkgs.symlinkJoin {
             name = "with-provers";
-            paths = [ main provers ];
+            paths = [
+              main
+              provers
+            ];
           };
 
           default = main;
         };
 
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [ scope'.easycrypt ];
-          buildInputs =
-              devPackages
-           ++ [ pkgs.git scope'.why3 packages.provers ]
-           ++ (with pkgs.python3Packages; [ pyyaml ]);
+        devShells.barebones = pkgs.mkShell {
+          inputsFrom = [scope'.easycrypt];
+          buildInputs = devPackages ++ [scope'.why3] ++ (with pkgs.python3Packages; [pyyaml]);
         };
-      });
+
+        devShells.noProvers = pkgs.mkShell {
+          inputsFrom = [
+            scope'.easycrypt
+            devShells.barebones
+          ];
+          buildInputs = devTools;
+          SHELL = ecShell;
+          shellHook = ecShellHook;
+        };
+
+        devShells.withDevTools = pkgs.mkShell {
+          inputsFrom = [
+            scope'.easycrypt
+            devShells.noProvers
+          ];
+          buildInputs = [packages.provers];
+          SHELL = ecShell;
+          shellHook = ecShellHook;
+        };
+
+        formatter = treefmtEval.config.build.wrapper;
+      }
+    );
 }


### PR DESCRIPTION
This PR updates the prover versions and adds support for automatically setting up emacs with proof general targeting the compiled EC binary in a devshell.

It also makes the OCaml dependency solver engine not dependent on the source so that we don't need to re-solve for deps every time the code is changed, leading to faster uptimes.

It also adds binary caching to the flake, reducing build time for easycrypt and provers.