### PR TITLE
Fix spurious line breaks in pretty-printing of qualified module paths

### DIFF
--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -510,7 +510,7 @@ let rec pp_msymbol (fmt : Format.formatter) (mx : msymbol) =
     Format.fprintf fmt "@[<hov 2>%s(@,%a)@]" x (pp_list ",@ " pp_msymbol) args
 
   | mx1 :: mx ->
-    Format.fprintf fmt "%a.@,%a" pp_msymbol [mx1] pp_msymbol mx
+    Format.fprintf fmt "%a.%a" pp_msymbol [mx1] pp_msymbol mx
 
 (* -------------------------------------------------------------------- *)
 let pp_topmod ppe fmt p =


### PR DESCRIPTION
## Summary

- Remove the `@,` (break hint) from the format string in `pp_msymbol` when printing multi-component module paths
- The break hint allowed OCaml's `Format` module to insert line breaks between namespace components (e.g., between `G.` and `RO`), producing incorrect output

**Before:**
```
proc sample(x : G.in_t) : unit = {
    G.
    RO.get(x);
}

module Alias = G.
RO.
```

**After:**
```
proc sample(x : G.in_t) : unit = {
    G.RO.get(x);
}

module Alias = G.RO.
```

## Test plan

- [x] Reproduced the bug using the exact example from #696
- [x] Verified fix resolves both manifestations (procedure call and module alias)
- [x] All 40 unit tests pass
- [x] Builds cleanly

Fixes #696.