### PR TITLE
In clone, allow applying renamings pre-emptively

### DIFF
--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3640,8 +3640,8 @@ clone_override:
 | MODULE TYPE x=uqident mode=loc(opclmode) y=uqident
    { (x, PTHO_ModTyp (y, unloc mode)) }
 
-| THEORY x=uqident mode=loc(opclmode) y=uqident
-   { (x, PTHO_Theory (y, unloc mode)) }
+| THEORY x=uqident mode=loc(opclmode) y=uqident renames=brace(clone_rename)?
+   { (x, PTHO_Theory (y, unloc mode, odfl [] renames)) }
 
 realize:
 | REALIZE x=qident

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1193,7 +1193,7 @@ and op_override = op_override_def genoverride * clmode
 and pr_override = pr_override_def genoverride * clmode
 and me_override = pqsymbol * clmode
 and mt_override = pqsymbol * clmode
-and th_override = pqsymbol * clmode
+and th_override = pqsymbol * clmode * theory_renaming list
 and ax_override = pqsymbol * clmode
 and nt_override = EcPath.path * clmode
 

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -367,23 +367,14 @@ let string_of_renaming_kind = function
   | `Theory  -> "theory"
 
 (* -------------------------------------------------------------------- *)
-let rename ?(fold = true) ove subst (kind, name) =
+let rename ove subst (kind, name) =
   try
     let newname =
-      match fold with
-      | false ->
-        List.find_map
-          (fun rnm -> EcThCloning.rename rnm (kind, name))
-          ove.ovre_rnms
-      | _ ->
-        let newname =
-          List.fold_left (* FIXME:parallel substitution *)
-            (fun name rnm ->
-              Option.value ~default:name (EcThCloning.rename rnm (kind, name)))
+      List.fold_left (* FIXME:parallel substitution *)
+        (fun name rnm ->
+            Option.value ~default:name (EcThCloning.rename rnm (kind, name)))
             name ove.ovre_rnms in
-        if newname = name then raise Not_found;
-        newname
-    in
+    if newname = name then raise Not_found;
 
     let nameok =
       match kind with


### PR DESCRIPTION
When cloning a theory and subtituting a sub-theory by some other one, it is now possible to apply renamings on the target sub-theory.

The syntax is:

```
clone T ... with theory T <- U { rename ... }
```

This allows to substitute one theory by some other one that got some of its components renamed by a
previous clone.

For example:

```
abstract theory Word.
  op foo_XX = ...
end Word.

clone Word as W16 rename "_XX" as "_16".

abstract theory UseWord.
  clone Word as W.
end UseWord.

clone UseWord as UseWord16 with
  theory W <- W16 { rename "_XX" as "_16" }.
```