### PR TITLE
Fix printing of hypothesis about abstract statements

### DIFF
--- a/src/ecCorePrinting.ml
+++ b/src/ecCorePrinting.ml
@@ -40,7 +40,7 @@ module type PrinterAPI = sig
 
   val pp_paren : 'a pp -> 'a pp
 
-  val pp_list : ('a, 'b, 'c, 'd, 'd, 'a) format6 -> 'a pp -> 'a list pp
+  val pp_list : ?on_empty:unit pp -> ('a, 'b, 'c, 'd, 'd, 'a) format6 -> 'a pp -> 'a list pp
 
   (* ------------------------------------------------------------------ *)
   val pp_pv      : PPEnv.t -> prog_var pp


### PR DESCRIPTION
This PR fixes the printing of hypothesis about abstract statements to include information about what they read write and call.
Closes #901.