### PR TITLE
Add framing to proc change

### DIFF
--- a/src/ecCoreFol.mli
+++ b/src/ecCoreFol.mli
@@ -75,6 +75,7 @@ val f_node  : form -> f_node
 (* -------------------------------------------------------------------- *)
 (* not recursive *)
 val f_map  : (EcTypes.ty -> EcTypes.ty) -> (form -> form) -> form -> form
+val f_filter_map : (EcTypes.ty -> EcTypes.ty option) -> (form -> form option) -> form -> form option
 val f_iter : (form -> unit) -> form -> unit
 val form_exists: (form -> bool) -> form -> bool
 val form_forall: (form -> bool) -> form -> bool

--- a/src/phl/ecPhlConseq.mli
+++ b/src/phl/ecPhlConseq.mli
@@ -53,3 +53,6 @@ val process_conseq_opt :
 val t_conseqauto : ?delta:bool -> ?tsolve:FApi.backward -> FApi.backward
 
 val process_concave : pformula option tuple2 gppterm * pformula -> FApi.backward
+
+val cond_hoareS_notmod : ?mk_other:bool -> tcenv1 -> ss_inv -> form * memory list * (memory * ss_inv) list
+

--- a/tests/procchange.ec
+++ b/tests/procchange.ec
@@ -1,4 +1,4 @@
-require import AllCore Distr.
+require import AllCore Int Distr.
 
 (* -------------------------------------------------------------------- *)
 theory ProcChangeAssignEquiv.
@@ -229,3 +229,50 @@ theory ProcChangeInWhileHoare.
   abort.
 end ProcChangeInWhileHoare.
 
+theory ProcChangeHoareFrame.
+  module M = {
+    proc foo(uc: int) = {
+      var foo;
+      foo <- 1;
+      foo <- foo + uc;
+      return uc;
+    }
+  }.
+
+  lemma minimalexamplelemma (a: int):
+     hoare [M.foo: arg = a ==> res = a].
+  proof.
+    proc.
+    proc change [1..2] : { foo <- 1 + a; }. auto. auto.
+  qed.
+end ProcChangeHoareFrame.
+
+theory ProcChangeEquivFrame.
+  module M = {
+    proc foo1(uc: int) = {
+      var foo;
+      foo <- 1;
+      foo <- foo + uc;
+      return uc;
+    }
+
+    proc foo2(uc: int) = {
+      var foo;
+      uc <- uc + 1;
+      foo <- 0;
+      foo <- foo + uc;
+      uc <- uc - 1;
+      return uc;
+    }
+  }.
+
+  lemma minimalexamplelemma (a: int):
+     equiv [M.foo1 ~ M.foo2 : ={arg} /\ arg{1} = a ==> ={res} /\ res{1} = a].
+  proof.
+    proc.
+    proc change {1} [1..2] : { foo <- 1 + a; }. auto. 
+    conseq (_: ={uc} /\ uc{1} = a /\ uc{2} = a ==> ); 1:auto.
+    proc change {2} [1..1] : { uc <- a + 1; }. auto.
+    fail proc change {2} [2..3] : { foo <- a + 1; }; smt(). 
+  abort.
+end ProcChangeEquivFrame.


### PR DESCRIPTION
This PR adds framing to the proc change tactic, allowing untouched parts of the precondition to be used when proving equivalence of replacement code.