### PR TITLE
Fix `search` to resolve abbreviations by expanding their body

### DIFF
--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -2684,11 +2684,11 @@ end
                     let es = e_subst tip in
                     let xs  = List.map (snd_map (ty_subst tip)) nt.ont_args in
                     let bd  = EcFol.form_of_expr (es nt.ont_body) in
-                    let fp  = EcFol.f_lambda (List.map (snd_map EcFol.gtty) xs) bd in
+                    List.iter (fun (id, ty) -> ps := Mid.add id ty !ps) xs;
 
-                    match fp.f_node with
+                    match bd.f_node with
                     | Fop (pf, _) -> (pf :: paths, pts)
-                    | _ -> (paths, (ps, ue, fp) ::pts)
+                    | _ -> (paths, (ps, ue, bd) ::pts)
                   end
 
                   | _ -> (p :: paths, pts) in


### PR DESCRIPTION
## Summary

- Fix `search` command to correctly handle bare abbreviation names (e.g. `search mu1`)
- Previously, the abbreviation body was wrapped in a lambda over its arguments, producing an unmatchable pattern — the search always returned no results
- Now, abbreviation arguments are registered as pattern variables and the body is used directly as the search pattern

## Test plan

- [x] `search mu1` returns results (67 lemmas from `Distr`)
- [x] `search (mu1 _ _)` returns the same results (applied form, already worked)
- [x] `search mu` still works (plain operator, unchanged path)
- [x] Zero-argument abbreviations still use the fast `ByPath` lookup
- [x] Repeated-variable abbreviations (`bar x = foo x x`) correctly match/exclude