### PR TITLE
Check that `Distr` is in scope when tagging distributions, fixing #211

### DIFF
--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -1431,8 +1431,8 @@ module Op = struct
     let add_distr_tag
         (pred : path) (bases : string list) (tag : string) (suffix : string) scope
     =
-      if not (EcAlgTactic.is_module_loaded (env scope)) then
-        hierror "for tag %s, load Distr first" tag;
+      if EcEnv.Op.by_path_opt pred (env scope) = None then
+         hierror "for tag %s, load Distr first" tag;
 
       let oppath   = EcPath.pqname (path scope) (unloc op.po_name) in
       let nparams  = List.map EcIdent.fresh tyop.op_tparams in

--- a/tests/rnd_ll.ec
+++ b/tests/rnd_ll.ec
@@ -1,0 +1,19 @@
+require import AllCore.
+
+fail op[lossless] dC : bool distr.
+
+require import Distr.
+
+op[lossless] dC : bool distr.
+
+module M = { 
+  proc p1() = {
+    var e1;
+    e1 <$ dC;
+  }
+}.
+
+equiv foo : M.p1 ~ M.p1 : true ==> true.
+proc. 
+rnd.
+abort.

--- a/theories/crypto/DigitalSignatures.eca
+++ b/theories/crypto/DigitalSignatures.eca
@@ -12,7 +12,7 @@
 
 (* --- Require/Import Theories --- *)
 (* -- Built-in (i.e, standard library) -- *)
-require import AllCore List.
+require import AllCore List Distr.
 
 
 


### PR DESCRIPTION
Check that `Distr` is in scope when tagging distributions. The original implementation required parts of `AllCore` instead, of which `Distr` is not a part.

This breaks code that tags distributions without requiring `Distr`.

Edit: note to self; #416 and #756 are similar, but different.