### PR TITLE
Check equality of expressions up to convertibility

### DIFF
--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -185,7 +185,7 @@ module EqMod_base(Fe : sig
   val for_expr : env -> norm:bool -> (ident * ty) Mid.t -> expr -> expr -> bool
 end) = struct
   open EqTest_base
-  open Fe
+  include Fe
 
   (* ------------------------------------------------------------------ *)
   let rec for_stmt env alpha ~norm s1 s2 =
@@ -1866,8 +1866,9 @@ module EqTest = struct
 
   include EqMod_base(struct
     let for_expr env ~norm:_ alpha e1 e2 =
+      let dummy_mem = EcIdent.create "&dummy" in
       let convert e =
-        let f = (ss_inv_of_expr (EcIdent.create "&dummy") e).inv in
+        let f = (ss_inv_of_expr dummy_mem e).inv in
 
         if Mid.is_empty alpha then f else
 

--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -1864,26 +1864,28 @@ let hs_inv_alpha_eq hyps (inv1 : hs_inv) (inv2 : hs_inv) =
 module EqTest = struct
   include EqTest_base
 
+  let for_expr env ~norm:_ alpha e1 e2 =
+    let convert e =
+      let f = (ss_inv_of_expr (EcIdent.create "&dummy") e).inv in
+
+      if Mid.is_empty alpha then f else
+
+      let subst =
+        Mid.fold
+          (fun x (y, ty) subst ->
+            Fsubst.f_bind_local subst x (f_local y ty))
+        alpha Fsubst.f_subst_id
+
+      in Fsubst.f_subst subst f in
+
+    let f1 = convert e1 in
+    let f2 = convert e2 in
+
+    is_conv (LDecl.init env []) f1 f2
+
   include EqMod_base(struct
-    let for_expr env ~norm:_ alpha e1 e2 =
-      let convert e =
-        let f = (ss_inv_of_expr (EcIdent.create "&dummy") e).inv in
-
-        if Mid.is_empty alpha then f else
-
-        let subst =
-          Mid.fold
-            (fun x (y, ty) subst ->
-              Fsubst.f_bind_local subst x (f_local y ty))
-          alpha Fsubst.f_subst_id
-
-        in Fsubst.f_subst subst f in
-
-      let f1 = convert e1 in
-      let f2 = convert e2 in
-
-      is_conv (LDecl.init env []) f1 f2
-   end)
+    let for_expr = for_expr
+  end)
 
   let for_pv    = fun env ?(norm = true) -> for_pv    env ~norm
   let for_lv    = fun env ?(norm = true) -> for_lv    env ~norm


### PR DESCRIPTION
This was already being done when checking equality of instructions and statements, but not expressions.

It seems like this was an accident. The `EqTest` module exposes the `for_expr` definition used by the internal `EqTest_base` while defining its own that ends up being used by `for_instr` and `for_stmt`. The relevant line number is 1896.

It's likely that this will break something, but I don't have an example. I found this while trying to fix #990, but AFAICT this change won't break any uses of `sim` by itself. See also #997.