### PR TITLE
ci: enforce single-commit PRs

### DIFF
--- a/.github/workflows/enforce-single-commit.yml
+++ b/.github/workflows/enforce-single-commit.yml
@@ -1,0 +1,21 @@
+name: Enforce single-commit PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+
+jobs:
+  check-commit-count:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR has exactly one commit
+        env:
+          COMMITS: ${{ github.event.pull_request.commits }}
+        run: |
+          echo "PR contains $COMMITS commit(s)."
+          if [ "$COMMITS" -ne 1 ]; then
+            echo "::error::This PR has $COMMITS commits. Please squash to a single commit."
+            exit 1
+          fi
+          echo "OK: PR has exactly 1 commit."


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that fails any PR whose commit count is not exactly 1.
- Uses `github.event.pull_request.commits` from the PR event payload, so no checkout or git history fetch is required.
- Triggers on `opened`, `synchronize`, and `reopened` — the only PR events that can change the commit count.

The repository is configured so that the `check-commit-count` job is a required status check, making this enforcement binding.