### PR TITLE
[ci] do not rebuild base or base-build in PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,40 @@ jobs:
   docker:
     name: Build Docker images
     runs-on: ubuntu-24.04
+    permissions:
+      packages: read
     steps:
     - uses: actions/checkout@v4
     - name: Build base image
+      if: github.event_name == 'push'
       run: make -C scripts/docker build VARIANT=base TAG=$IMAGE_TAG
+    - name: Build base-build image
+      if: github.event_name == 'push'
+      run: make -C scripts/docker build VARIANT=base-build TAG=$IMAGE_TAG
+    - uses: docker/login-action@v3
+      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Retrieve base-build image
+      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      run: |
+        docker pull ghcr.io/easycrypt/ec-base-build-box:main
+        docker tag ghcr.io/easycrypt/ec-base-build-box:main ghcr.io/easycrypt/ec-base-build-box:$IMAGE_TAG
     - name: Build build image
-      run: make -C scripts/docker build VARIANT=build TAG=$IMAGE_TAG
+      run: make -C scripts/docker build VARIANT=build TAG=$IMAGE_TAG BARGS='--build-arg BASE_BUILD_LAYER=ghcr.io/easycrypt/ec-base-build-box:${IMAGE_TAG}'
     - name: Save images for downstream jobs
       run: |
         docker save "ghcr.io/easycrypt/ec-base-box:$IMAGE_TAG" | gzip > base-image.tar.gz
+        docker save "ghcr.io/easycrypt/ec-base-build-box:$IMAGE_TAG" | gzip > base-build-image.tar.gz
         docker save "ghcr.io/easycrypt/ec-build-box:$IMAGE_TAG" | gzip > build-image.tar.gz
     - uses: actions/upload-artifact@v4
       with:
         name: docker-images
         path: |
           base-image.tar.gz
+          base-build-image.tar.gz
           build-image.tar.gz
         retention-days: 1
 
@@ -228,12 +247,7 @@ jobs:
   publish:
     name: Publish Docker images
     if: |
-      github.event_name == 'push' && (
-        github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/release' ||
-        github.ref == 'refs/heads/latest' ||
-        startsWith(github.ref, 'refs/tags/r')
-      )
+      github.event_name == 'push'
     needs: [compile-opam, compile-nix, check, external, external-status, docker]
     runs-on: ubuntu-24.04
     permissions:
@@ -255,6 +269,12 @@ jobs:
         docker tag "ghcr.io/easycrypt/ec-base-box:$IMAGE_TAG" \
           "ghcr.io/easycrypt/ec-base-box:${{ github.ref_name }}"
         docker push "ghcr.io/easycrypt/ec-base-box:${{ github.ref_name }}"
+    - name: Push base-build image
+      if: github.ref_name == 'main'
+      run: |
+        docker tag "ghcr.io/easycrypt/ec-base-build-box:$IMAGE_TAG" \
+          "ghcr.io/easycrypt/ec-base-build-box:${{ github.ref_name }}"
+        docker push "ghcr.io/easycrypt/ec-base-build-box:${{ github.ref_name }}"
     - name: Push build image
       run: |
         docker tag "ghcr.io/easycrypt/ec-build-box:$IMAGE_TAG" \
@@ -266,8 +286,8 @@ jobs:
         github.ref == 'refs/heads/latest' ||
         github.ref_type == 'tag'
       run: |
-        make -C scripts/docker build VARIANT=test TAG=${{ github.ref_name }}
-        make -C scripts/docker publish VARIANT=test TAG=${{ github.ref_name }}
+        make -C scripts/docker build publish VARIANT=test TAG=${{ github.ref_name }} \
+          BARGS='--build-arg BUILD_LAYER=ghcr.io/easycrypt/ec-build-box:${{ github.ref_name }}'
 
   # ── Notification ──
 


### PR DESCRIPTION
Streamline the docker builds slightly
  - Use the last base box from `main` for PR and merge queue runs. Rebuild
    only on pushes to `main` and releases.
  - Reuses the already-built build box when building the test box.

Merge after #1007 .