### PR TITLE
Fix anomaly when alias-cloning a datatype type

### DIFF
--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -476,36 +476,39 @@ let rec replay_tyd (ove : _ ovrenv) (subst, ops, proofs, scope) (import, x, otyd
             rename ove subst (`Type, x)
 
         | `Inline _ ->
-          let subst =
-            EcSubst.add_tydef
-              subst (xpath ove x) (newtyd.tyd_params, body) in
+            let subst =
+              EcSubst.add_tydef
+                subst (xpath ove x) (newtyd.tyd_params, body) in
+            (subst, x) in
 
-          let subst =
-            (* FIXME: HACK *)
-            match otyd.tyd_type, body.ty_node with
-            | Datatype { tydt_ctors = octors }, Tconstr (np, _) -> begin
-                match (EcEnv.Ty.by_path np env).tyd_type with
-                | Datatype { tydt_ctors = _ } ->
-                  let newtparams = newtyd.tyd_params in
-                  let newtparams_ty = List.map tvar newtparams in
-                  let newdtype = tconstr np newtparams_ty in
-                  let tysubst = CS.Tvar.init otyd.tyd_params newtparams_ty in
+      let subst =
+        (* FIXME: HACK -- when a datatype is overridden by another datatype,
+           the source constructors are not re-created, so redirect them to the
+           target's constructors. This is needed for every override mode (alias
+           or inline); skipping it leaves references to the source constructors
+           (e.g. in operator bodies) pointing at non-existent paths. *)
+        match otyd.tyd_type, body.ty_node with
+        | Datatype { tydt_ctors = octors }, Tconstr (np, _) -> begin
+            match (EcEnv.Ty.by_path np env).tyd_type with
+            | Datatype { tydt_ctors = _ } ->
+              let newtparams = newtyd.tyd_params in
+              let newtparams_ty = List.map tvar newtparams in
+              let newdtype = tconstr np newtparams_ty in
+              let tysubst = CS.Tvar.init otyd.tyd_params newtparams_ty in
 
-                  List.fold_left (fun subst (name, tyargs) ->
-                    let np = EcPath.pqoname (EcPath.prefix np) name in
-                    let newtyargs =
-                      List.map
-                        (CS.Tvar.subst tysubst -| EcSubst.subst_ty subst)
-                        tyargs in
-                    EcSubst.add_opdef subst
-                      (xpath ove name)
-                      (newtparams, e_op np newtparams_ty (toarrow newtyargs newdtype))
-                    ) subst octors
-                | _ -> subst
-              end
-            | _, _ -> subst
-
-          in (subst, x) in
+              List.fold_left (fun subst (name, tyargs) ->
+                let np = EcPath.pqoname (EcPath.prefix np) name in
+                let newtyargs =
+                  List.map
+                    (CS.Tvar.subst tysubst -| EcSubst.subst_ty subst)
+                    tyargs in
+                EcSubst.add_opdef subst
+                  (xpath ove name)
+                  (newtparams, e_op np newtparams_ty (toarrow newtyargs newdtype))
+                ) subst octors
+            | _ -> subst
+          end
+        | _, _ -> subst in
 
       let refotyd = EcSubst.subst_tydecl subst otyd in
 

--- a/tests/clone-datatype-alias.ec
+++ b/tests/clone-datatype-alias.ec
@@ -1,0 +1,30 @@
+(* Regression test for issue #989.
+
+   Overriding a datatype's type with another datatype (`type ATy = ...`)
+   used to crash with `anomaly: ... Assertion failed` when an operator body
+   referenced one of the source datatype's constructors. The replay machinery
+   only redirected the source constructors to the target's constructors for
+   inline overrides (`<-`/`<=`), so for a plain alias (`=`) the constructor
+   references were renamed to non-existent paths and tripped an `oget None`.
+
+   Both override modes must accept this clone. *)
+
+theory Thy.
+  type ATy = [ CA | CB of int & bool ].
+  op mk = CB 3 true.
+  op base = CA.
+end Thy.
+
+clone Thy as Thy1.
+
+(* plain alias override (the form that used to crash) *)
+clone Thy as Thy2 with
+  type ATy = Thy1.ATy,
+  op mk   <= Thy1.mk,
+  op base <= Thy1.base.
+
+(* inline override (already worked; kept as a companion check) *)
+clone Thy as Thy3 with
+  type ATy <- Thy1.ATy,
+  op mk   <= Thy1.mk,
+  op base <= Thy1.base.


### PR DESCRIPTION
Closes #989.

## Problem

Overriding a datatype's type with another datatype via a plain alias (`type ATy = ...`) crashed during cloning:

```
theory Thy.
  type ATy = [constr].
  op useconstr = constr.
end Thy.

clone Thy as Thy1.

clone Thy as Thy2 with
  type ATy = Thy1.ATy,
  op useconstr <= Thy1.useconstr.
```
→ `anomaly: File "src/ecUtils.ml", line 239 ... Assertion failed` (an `oget None`).

## Cause

When a datatype's type is overridden during cloning, the source datatype's constructors are not re-created in the clone (the new type isn't a `Datatype`). References to those constructors — e.g. in operator bodies — must therefore be redirected to the *target* datatype's constructors.

`EcTheoryReplay.replay_tyd` did exactly that, but only inside the `Inline _` branch (`<-` / `<=`). For a plain alias override (`=` → `Alias`), the source constructor paths were instead renamed to non-existent paths (`Thy2.constr`); force-reducing them in the operator-compatibility check tripped the `oget None`.

## Fix

Lift the constructor-remapping out of the inline-only branch so it runs after the mode match, for every override mode. The substitution in scope at that point is already correct for both modes (rename for alias, `add_tydef` for inline).

Regression test added: `tests/clone-datatype-alias.ec`.

## Notes / out of scope

This is a surgical fix; it will be subsumed by the planned refactor that introduces an explicit elaborator for derived objects (constructors, projectors, `_ind`/`_case`). Two related issues are left untouched as pre-existing and orthogonal (they reproduce on `main`, in both override modes):

- Operator bodies that *match* on constructors (`OP_Fix`) still fail with `CoreIncompatible` under a datatype-type override — the remap only covers `OP_Constr`, not match bodies.
- Polymorphic op overrides (`op mk <= Thy1.mk` with a type variable) fail with "operator body contains 0 type parameter instead of 1".