### PR TITLE
use conversion in t_ehoare_call_core

### DIFF
--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -1686,6 +1686,12 @@ let check_conv ?ri hyps f1 f2 =
   if is_conv ?ri hyps f1 f2 then ()
   else raise (IncompatibleForm ((LDecl.toenv hyps), (f1, f2)))
 
+let ss_inv_is_conv ?(ri = full_red) hyps (inv1 : ss_inv) (inv2 : ss_inv) =
+  let subst = Fsubst.f_bind_mem Fsubst.f_subst_id inv1.m inv2.m in
+  let f1 = Fsubst.f_subst subst inv1.inv in
+  let f2 = inv2.inv in
+  is_conv ~ri hyps f1 f2
+
 (* -------------------------------------------------------------------- *)
 let h_red ri hyps f =
   try

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -119,3 +119,5 @@ val xconv : xconv -> LDecl.hyps -> form -> form -> bool
 val ss_inv_alpha_eq : LDecl.hyps -> ss_inv -> ss_inv -> bool
 val ts_inv_alpha_eq : LDecl.hyps -> ts_inv -> ts_inv -> bool
 val hs_inv_alpha_eq : LDecl.hyps -> hs_inv -> hs_inv -> bool
+
+val ss_inv_is_conv :  ?ri:reduction_info -> LDecl.hyps -> ss_inv -> ss_inv -> bool

--- a/src/phl/ecPhlCall.ml
+++ b/src/phl/ecPhlCall.ml
@@ -111,7 +111,7 @@ let compute_equiv_call_post
   let fpost =
     let s =
       PVM.of_list env
-        [((pv_res, mr), fresr.inv); ((pv_res, ml), fresl.inv)] in    
+        [((pv_res, mr), fresr.inv); ((pv_res, ml), fresl.inv)] in
     PVM.subst env s fpost in
 
   let post =
@@ -247,13 +247,13 @@ let t_ehoare_call_core fpre fpost tc =
   let hyps, env, hs, s, f, wppre, wppost = ehoare_call_pre_post fpre fpost tc in
   if not (List.is_empty s.s_node) then
     tc_error !!tc  "ehoare call core rule: only single call statements are accepted";
-  if not (EcReduction.ss_inv_alpha_eq hyps (ehs_po hs) wppost) then
+  if not (EcReduction.ss_inv_is_conv hyps (ehs_po hs) wppost) then
     (let env = EcEnv.Memory.push_active_ss hs.ehs_m env in
      let ppe  = EcPrinting.PPEnv.ofenv env in
      tc_error !!tc "ehoare call core rule: wrong post-condition %a instead %a"
        (EcPrinting.pp_form ppe) (ehs_po hs).inv (EcPrinting.pp_form ppe) wppost.inv);
 
-  if not (EcReduction.ss_inv_alpha_eq hyps (ehs_pr hs) wppre) then
+  if not (EcReduction.ss_inv_is_conv hyps (ehs_pr hs) wppre) then
     (let env = EcEnv.Memory.push_active_ss hs.ehs_m env in
      let ppe  = EcPrinting.PPEnv.ofenv env in
      tc_error !!tc "ehoare call core rule: wrong pre-condition %a instead %a"


### PR DESCRIPTION
before the commit 23cf44, conversion was used in tactic t_ehoare_call_core (and not alpha conversion), this restore conversion.
The previous change was breaking some existing proofs.