### PR TITLE
typing: precise diagnostics for failed operator applications

### DIFF
--- a/src/ec.ml
+++ b/src/ec.ml
@@ -826,6 +826,17 @@ let main () =
                          end;
                          raise (EcScope.toperror_of_exn ~gloc:loc e)
                        end;
+                       p.EP.gl_expect |> oiter (fun expected ->
+                         let actual =
+                           Format.asprintf "%a" EcPException.exn_printer e in
+                         if String.trim actual <> String.trim (EcLocation.unloc expected) then
+                           EcScope.hierror ~loc:(EcLocation.loc expected)
+                             "expect fail: error message mismatch@\n\
+                              --- expected ---@\n\
+                              %s@\n\
+                              --- actual ---@\n\
+                              %s"
+                             (EcLocation.unloc expected) actual);
                        if T.interactive terminal then begin
                         let error =
                           Format.asprintf

--- a/src/ecParser.mly
+++ b/src/ecParser.mly
@@ -3999,11 +3999,17 @@ stop:
 | DROP DOT { }
 
 global:
-| db=debug_global? fail=boption(FAIL) g=global_action ep=FINAL
+| db=debug_global? f=failmode g=global_action ep=FINAL
   { let lc = EcLocation.make $startpos ep in
     { gl_action = EcLocation.mk_loc lc g;
-      gl_fail   = fail;
+      gl_fail   = fst f;
+      gl_expect = snd f;
       gl_debug  = db; } }
+
+%inline failmode:
+| (* empty *)               { (false, None  ) }
+| FAIL                      { (true , None  ) }
+| EXPECT FAIL s=loc(STRING) { (true , Some s) }
 
 debug_global:
 | TIME  { `Timed }

--- a/src/ecParsetree.ml
+++ b/src/ecParsetree.ml
@@ -1388,6 +1388,7 @@ type global_action =
 type global = {
   gl_action : global_action located;
   gl_fail   : bool;
+  gl_expect : string located option;   (* [expect fail "…"]: expected error *)
   gl_debug  : [`Timed | `Break] option;
 }
 

--- a/src/ecTyping.ml
+++ b/src/ecTyping.ml
@@ -122,8 +122,15 @@ type filter_error =
 | FE_InvalidIndex of int
 | FE_NoMatch
 
-type goal_shape_error = 
+type goal_shape_error =
 | GSE_ExpectedTwoSided
+
+(* A failed application candidate, tagged by the kind of entity. *)
+type appcand = [
+  | `Op of EcPath.path * EcUnify.op_instance * ty
+  | `Pv of EcTypes.prog_var * ty
+  | `Lc of EcIdent.t * ty
+]
 
 type tyerror =
 | UniVarNotAllowed
@@ -159,6 +166,8 @@ type tyerror =
 | NotAnInductive
 | AbbrevLowArgs
 | UnknownVarOrOp         of qsymbol * ty list
+| UnappliedOp            of qsymbol * ty list * ty option
+                           * (appcand * EcUnify.op_failure) list
 | MultipleOpMatch        of qsymbol * ty list * (opmatch * EcUnify.unienv) list
 | UnknownModName         of qsymbol
 | UnknownTyModName       of qsymbol
@@ -315,22 +324,22 @@ let select_local env (qs,s) =
   else None
 
 (* -------------------------------------------------------------------- *)
-let select_pv env side name ue tvi (psig, retty) =
+(* The program variable [name] if it applies to [psig]/[retty], else the
+   reason it does not. *)
+let select_pv env side name ue tvi (psig, retty)
+    : (_ * ty * EcUnify.unienv) list * (appcand * EcUnify.op_failure) list =
   if   tvi <> None
-  then []
+  then ([], [])
   else
     try
-      let pvs = EcEnv.Var.lookup_progvar ?side name env in
-      let select (pv,ty) =
-        let subue = UE.copy ue in
-        let texpected = EcUnify.tfun_expected subue ?retty psig in
-          try
-            EcUnify.unify env subue ty texpected;
-            [(pv, ty, subue)]
-          with EcUnify.UnificationFailure _ -> []
-      in
-        select pvs
-    with EcEnv.LookupFailure _ -> []
+      let (pv, ty) = EcEnv.Var.lookup_progvar ?side name env in
+      let subue = UE.copy ue in
+      match EcUnify.classify_application env subue ty psig retty with
+      | None   -> ([(pv, ty, subue)], [])
+      | Some f ->
+          let pv0 = match pv with `Var p -> p | `Proj (p, _) -> p in
+          ([], [(`Pv (pv0, ty), f)])
+    with EcEnv.LookupFailure _ -> ([], [])
 
 (* -------------------------------------------------------------------- *)
 module OpSelect = struct
@@ -350,6 +359,8 @@ module OpSelect = struct
 
   type gopsel =
     opsel * EcTypes.ty * EcUnify.unienv * opmatch
+
+  type opfailure = appcand * EcUnify.op_failure
 end
 
 let gen_select_op
@@ -363,8 +374,10 @@ let gen_select_op
     (ue       : EcUnify.unienv)
     (psig     : EcTypes.dom * EcTypes.ty option)
 
-    : OpSelect.gopsel list
+    : OpSelect.gopsel list * OpSelect.opfailure list
 =
+
+  let opfailures = ref [] in
 
   let fpv me (pv, ty, ue) : OpSelect.gopsel =
     (`Pv (me, pv), ty, ue, (pv :> opmatch))
@@ -405,18 +418,30 @@ let gen_select_op
     else [] in
 
   let ops () : OpSelect.gopsel list =
-    let ops = EcUnify.select_op ~filter:ue_filter tvi env name ue psig in
+    let outcomes =
+      EcUnify.select_op_outcomes ~filter:ue_filter tvi env name ue psig in
+    let ops =
+      List.filter_map
+        (function EcUnify.OK r -> Some r | EcUnify.KO _ -> None) outcomes in
+    opfailures := !opfailures @
+      List.filter_map
+        (function
+          | EcUnify.KO (p, inst, ty, f) -> Some (`Op (p, inst, ty), f)
+          | EcUnify.OK _ -> None)
+        outcomes;
     let ops = opsc |> ofold (fun opsc -> List.mbfilter (by_scope opsc)) ops in
     let ops = match List.mbfilter by_current ops with [] -> ops | ops -> ops in
     let ops = match List.mbfilter by_tc ops with [] -> ops | ops -> ops in
     (List.map fop ops)
 
   and pvs () : OpSelect.gopsel list =
-    let me, pvs =
+    let me, (pvs, pvfailures) =
       match EcEnv.Memory.get_active_ss env, actonly with
-      | None, true -> (None, [])
+      | None, true -> (None, ([], []))
       | me  , _    -> (  me, select_pv env me name ue tvi psig)
-    in List.map (fpv me) pvs
+    in
+    opfailures := !opfailures @ pvfailures;
+    List.map (fpv me) pvs
   in
 
   let select (filters : (unit -> OpSelect.gopsel list) list) : OpSelect.gopsel list =
@@ -425,14 +450,17 @@ let gen_select_op
       filters
     |> odfl [] in
 
-  match mode with
-  | `Expr `InOp   -> select [locals; ops]
-  | `Form
-  | `Expr `InProc ->
-      if forcepv then
-        select [pvs; locals; ops]
-      else
-        select [locals; pvs; ops]
+  let selected =
+    match mode with
+    | `Expr `InOp   -> select [locals; ops]
+    | `Form
+    | `Expr `InProc ->
+        if forcepv then
+          select [pvs; locals; ops]
+        else
+          select [locals; pvs; ops]
+  in
+  (selected, !opfailures)
 
 (* -------------------------------------------------------------------- *)
 let select_exp_op env mode opsc name ue tvi psig =
@@ -443,6 +471,14 @@ let select_exp_op env mode opsc name ue tvi psig =
 let select_form_op env mode ~forcepv opsc name ue tvi psig =
   gen_select_op ~actonly:true ~mode ~forcepv
     opsc tvi env name ue psig
+
+(* -------------------------------------------------------------------- *)
+(* [UnappliedOp] when candidates of that name exist but fail, else
+   [UnknownVarOrOp]. *)
+let tyerror_noop env loc name esig retty (opfailures : OpSelect.opfailure list) =
+  match opfailures with
+  | [] -> tyerror loc env (UnknownVarOrOp (name, esig))
+  | _  -> tyerror loc env (UnappliedOp (name, esig, retty, opfailures))
 
 (* -------------------------------------------------------------------- *)
 let select_proj env opsc name ue tvi recty =
@@ -1668,6 +1704,24 @@ let form_of_opselect
   EcUnify.UniEnv.restore ~src:subue ~dst:ue;
 
   let esig  = List.map (lmap f_ty) args in
+
+  (* Locals are selected without an applicability check (they shadow
+     operators unconditionally), so diagnose a failing application here. *)
+  begin match sel with
+  | `Lc id ->
+      let resolve t = ty_subst (Tuni.subst (EcUnify.UniEnv.assubst ue)) t in
+      let psig = List.map (fun t -> resolve (unloc t)) esig in
+      let ue'  = EcUnify.UniEnv.copy ue in
+      begin match EcUnify.classify_application env ue' ty psig None with
+      | None   -> ()
+      | Some f ->
+          tyerror loc env
+            (UnappliedOp (([], EcIdent.name id), psig, None,
+                          [(`Lc (id, resolve ty), f)]))
+      end
+  | _ -> ()
+  end;
+
   let args  = List.map unloc args in
   let codom = ty_fun_app loc env ue ty esig in
 
@@ -2884,13 +2938,13 @@ and translvalue ue (env : EcEnv.env) lvalue =
 
       let name = ([], EcCoreLib.s_set) in
       let esig = [xty; ety; codom] in
-      let ops = select_exp_op env `InProc None name ue tvi (esig, None) in
+      let ops, opfailures = select_exp_op env `InProc None name ue tvi (esig, None) in
 
       match ops with
       | [] ->
          let uidmap = UE.assubst ue in
          let esig = Tuni.subst_dom uidmap esig in
-          tyerror x.pl_loc env (UnknownVarOrOp (name, esig))
+          tyerror_noop env x.pl_loc name esig None opfailures
 
       | [`Op (p, tys), opty, subue, _] ->
           EcUnify.UniEnv.restore ~src:subue ~dst:ue;
@@ -2903,7 +2957,7 @@ and translvalue ue (env : EcEnv.env) lvalue =
       | [_] ->
           let uidmap = UE.assubst ue in
           let esig = Tuni.subst_dom uidmap esig in
-          tyerror x.pl_loc env (UnknownVarOrOp (name, esig))
+          tyerror_noop env x.pl_loc name esig None opfailures
 
       | _ ->
           let uidmap = UE.assubst ue in
@@ -3195,13 +3249,13 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
 
     | PFident ({ pl_desc = name; pl_loc = loc }, tvi) ->
         let tvi = tvi |> omap (transtvi env ue) in
-        let ops =
+        let ops, opfailures =
           select_form_op
             ~forcepv:(PFS.isforced state)
             env mode opsc name ue tvi ([], tt) in
         begin match ops with
         | [] ->
-            tyerror loc env (UnknownVarOrOp (name, []))
+            tyerror_noop env loc name [] tt opfailures
 
         | [sel] -> begin
             let op = form_of_opselect (env, ue) loc sel [] in
@@ -3357,7 +3411,7 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           select_form_op ~forcepv:(PFS.isforced state)
             env mode opsc name ue tvi (esig, tt)
         with
-        | [sel] -> Some (sel, (es, esig, tvi))
+        | [sel], _ -> Some (sel, (es, esig, tvi))
         | _ ->
             Option.iter (fun ps -> ps := !(Option.get ps')) ps;
             EcUnify.UniEnv.restore ~dst:ue ~src:ue';
@@ -3367,7 +3421,7 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
         let tvi  = tvi |> omap (transtvi env ue) in
         let es   = List.map (transf env) pes in
         let esig = List.map EcFol.f_ty es in
-        let ops  =
+        let ops, opfailures  =
           select_form_op ~forcepv:(PFS.isforced state)
             env mode opsc name ue tvi (esig, tt) in
 
@@ -3375,7 +3429,7 @@ and trans_form_or_pattern env mode ?mv ?ps ue pf tt =
           | [] ->
              let uidmap = UE.assubst ue in
              let esig = Tuni.subst_dom uidmap esig in
-             tyerror loc env (UnknownVarOrOp (name, esig))
+             tyerror_noop env loc name esig tt opfailures
 
           | [sel] ->
               let es = List.map2 (fun e l -> mk_loc l.pl_loc e) es pes in

--- a/src/ecTyping.mli
+++ b/src/ecTyping.mli
@@ -20,6 +20,13 @@ type opmatch = [
   | `Proj of EcTypes.prog_var * EcMemory.proj_arg
 ]
 
+(* A failed application candidate, tagged by the kind of entity. *)
+type appcand = [
+  | `Op of EcPath.path * EcUnify.op_instance * EcTypes.ty
+  | `Pv of EcTypes.prog_var * EcTypes.ty
+  | `Lc of EcIdent.t * EcTypes.ty
+]
+
 type 'a mismatch_sets = [`Eq of 'a * 'a | `Sub of 'a ]
 
 
@@ -152,6 +159,8 @@ type tyerror =
 | NotAnInductive
 | AbbrevLowArgs
 | UnknownVarOrOp         of qsymbol * ty list
+| UnappliedOp            of qsymbol * ty list * ty option
+                           * (appcand * EcUnify.op_failure) list
 | MultipleOpMatch        of qsymbol * ty list * (opmatch * EcUnify.unienv) list
 | UnknownModName         of qsymbol
 | UnknownTyModName       of qsymbol

--- a/src/ecUnify.ml
+++ b/src/ecUnify.ml
@@ -331,7 +331,73 @@ type sbody = ((EcIdent.t * ty) list * expr) Lazy.t
 type select_result = (EcPath.path * ty list) * ty * unienv * sbody option
 
 (* -------------------------------------------------------------------- *)
-let select_op
+type op_failure =
+  | OF_argument of int * ty * ty   (* 1-based index, expected (param), provided (arg) *)
+  | OF_result   of ty * ty         (* operator result type, expected result type *)
+  | OF_arity    of int * int       (* expected arity (at most), provided *)
+
+(* -------------------------------------------------------------------- *)
+(* Constrained type parameters of an operator (those bound while applying it). *)
+type op_instance = (EcIdent.t * ty) list
+
+type select_outcome =
+  | OK of select_result
+  | KO of EcPath.path * op_instance * ty * op_failure
+    (* operator path, partial instantiation, declared operator type, reason *)
+
+(* -------------------------------------------------------------------- *)
+(* [None] if [top] applies to [psig] (and [retty]), updating [ue]; otherwise
+   [Some] of the first argument/result/arity failure. *)
+let classify_application
+   (env  : EcEnv.env)
+   (ue   : unienv)
+   (top  : ty)
+   (psig : ty list)
+   (retty : ty option)
+  : op_failure option
+=
+  let exception Failure_with of op_failure in
+
+  let resolve ty = ty_subst (Tuni.subst (UniEnv.assubst ue)) ty in
+  let whnf ty = EcEnv.ty_hnorm (resolve ty) env in
+
+  let rec peel i cur args =
+    match args with
+    | [] -> begin
+        match retty with
+        | None -> None
+        | Some r ->
+            try  unify env ue cur r; None
+            with UnificationFailure _ ->
+              Some (OF_result (resolve cur, resolve r))
+      end
+
+    | a :: args ->
+        match (whnf cur).ty_node with
+        | Tfun (d, c) ->
+            (try  unify env ue d a
+             with UnificationFailure _ ->
+               raise_notrace (Failure_with (OF_argument (i, resolve d, resolve a))));
+            peel (i+1) c args
+
+        | Tunivar _ ->
+            let d = UniEnv.fresh ue in
+            let c = UniEnv.fresh ue in
+            (try  unify env ue cur (tfun d c)
+             with UnificationFailure _ ->
+               raise_notrace (Failure_with (OF_arity (List.length psig, i-1))));
+            (try  unify env ue d a
+             with UnificationFailure _ ->
+               raise_notrace (Failure_with (OF_argument (i, resolve d, resolve a))));
+            peel (i+1) c args
+
+        | _ ->
+            Some (OF_arity (List.length psig, i-1))
+  in
+    try peel 1 top psig with Failure_with f -> Some f
+
+(* -------------------------------------------------------------------- *)
+let select_op_outcomes
   ?(hidden : bool = false)
   ?(filter : EcPath.path -> operator -> bool = fun _ _ -> true)
    (tvi    : tvar_inst option)
@@ -339,7 +405,7 @@ let select_op
    (name   : qsymbol)
    (ue     : unienv)
    (sig_   : ty list * ty option)
-  : select_result list
+  : select_outcome list
 =
   ignore hidden;                (* FIXME *)
 
@@ -369,33 +435,50 @@ let select_op
   in
 
   let select (path, op) =
-    let module E = struct exception Failure end in
-
     let subue = UniEnv.copy ue in
 
-    try
-      let (tip, tvs) = UniEnv.openty_r subue op.D.op_tparams tvi in
-      let top = ty_subst tip op.D.op_ty in
-      let texpected = tfun_expected subue ?retty psig in
+    let (tip, tvs) = UniEnv.openty_r subue op.D.op_tparams tvi in
+    let top = ty_subst tip op.D.op_ty in
 
-      (try  unify env subue top texpected
-       with UnificationFailure _ -> raise E.Failure);
+    let resolve ty = ty_subst (Tuni.subst (UniEnv.assubst subue)) ty in
 
-      let bd =
-        match op.D.op_kind with
-        | OB_nott nt ->
-           let substnt () =
-             let xs = List.map (snd_map (ty_subst tip)) nt.D.ont_args in
-             let es = e_subst tip in
-             let bd = es nt.D.ont_body in
-             (xs, bd)
-           in Some (Lazy.from_fun substnt)
+    let failure = classify_application env subue top psig retty in
 
-        | _ -> None
+    match failure with
+    | Some f ->
+        let instance =
+          List.combine op.D.op_tparams tvs
+          |> List.filter_map (fun (tp, tv) ->
+               match (resolve tv).ty_node with
+               | Tunivar _ -> None
+               | _         -> Some (tp, resolve tv))
+        in
+        KO (path, instance, op.D.op_ty, f)
+    | None ->
+        let bd =
+          match op.D.op_kind with
+          | OB_nott nt ->
+             let substnt () =
+               let xs = List.map (snd_map (ty_subst tip)) nt.D.ont_args in
+               let es = e_subst tip in
+               let bd = es nt.D.ont_body in
+               (xs, bd)
+             in Some (Lazy.from_fun substnt)
 
-      in Some ((path, tvs), top, subue, bd)
+          | _ -> None
 
-    with E.Failure -> None
+        in OK ((path, tvs), top, subue, bd)
 
   in
-    List.pmap select (EcEnv.Op.all ~check:filter ~name env)
+    List.map select (EcEnv.Op.all ~check:filter ~name env)
+
+(* -------------------------------------------------------------------- *)
+let select_op
+  ?hidden ?filter (tvi : tvar_inst option)
+  (env : EcEnv.env) (name : qsymbol) (ue : unienv)
+  (sig_ : ty list * ty option)
+  : select_result list
+=
+  List.filter_map
+    (function OK r -> Some r | KO _ -> None)
+    (select_op_outcomes ?hidden ?filter tvi env name ue sig_)

--- a/src/ecUnify.mli
+++ b/src/ecUnify.mli
@@ -42,6 +42,24 @@ type sbody = ((EcIdent.t * ty) list * expr) Lazy.t
 
 type select_result = (EcPath.path * ty list) * ty * unienv * sbody option
 
+type op_failure =
+  | OF_argument of int * ty * ty   (* 1-based index, expected (param), provided (arg) *)
+  | OF_result   of ty * ty         (* operator result type, expected result type *)
+  | OF_arity    of int * int       (* expected arity (at most), provided *)
+
+(* Constrained type parameters of an operator (those bound while applying it). *)
+type op_instance = (EcIdent.t * ty) list
+
+type select_outcome =
+  | OK of select_result
+  | KO of EcPath.path * op_instance * ty * op_failure
+    (* operator path, partial instantiation, declared operator type, reason *)
+
+(* [None] if [top] applies to [psig] (and [retty]), updating [ue]; otherwise
+   [Some] of the first argument/result/arity failure. *)
+val classify_application :
+  EcEnv.env -> unienv -> ty -> ty list -> ty option -> op_failure option
+
 val select_op :
      ?hidden:bool
   -> ?filter:(path -> operator -> bool)
@@ -51,3 +69,13 @@ val select_op :
   -> unienv
   -> dom * ty option
   -> select_result list
+
+val select_op_outcomes :
+     ?hidden:bool
+  -> ?filter:(path -> operator -> bool)
+  -> tvi
+  -> EcEnv.env
+  -> qsymbol
+  -> unienv
+  -> dom * ty option
+  -> select_outcome list

--- a/src/ecUserMessages.ml
+++ b/src/ecUserMessages.ml
@@ -389,6 +389,75 @@ end = struct
         msg "for the following parameters' type:@\n";
         List.iteri (fun i ty -> msg "  [%d]: @[%a@]@\n" (i+1) pp_type ty) tys
 
+    | UnappliedOp (name, esig, _retty, failures) ->
+        let pp_reason fmt = function
+          | EcUnify.OF_result (got, expected) ->
+              Format.fprintf fmt
+                "it returns a value of type@\n  @[%a@]@\nbut a value of type@\n  @[%a@]@\nwas expected"
+                pp_type got pp_type expected
+          | EcUnify.OF_argument (i, expected, got) ->
+              Format.fprintf fmt
+                "its #%d argument is expected to have type@\n  @[%a@]@\nbut is applied to a value of type@\n  @[%a@]"
+                i pp_type expected pp_type got
+          | EcUnify.OF_arity (provided, atmost) ->
+              Format.fprintf fmt
+                "it is applied to %d argument(s) but takes at most %d"
+                provided atmost
+        in
+        let pp_instance fmt instance =
+          if not (List.is_empty instance) then begin
+            Format.fprintf fmt "where the type parameters were inferred as:@\n";
+            List.iter
+              (fun (tp, ty) ->
+                Format.fprintf fmt "  @[%a = %a@]@\n"
+                  pp_type (tvar tp) pp_type ty)
+              instance
+          end
+        in
+        let pp_kind fmt = function
+          | `Op (p, _, _) ->
+              Format.fprintf fmt "operator `%a'" EcPrinting.pp_path p
+          | `Pv (pv, _) ->
+              Format.fprintf fmt "program variable `%a'" (EcPrinting.pp_pv env) pv
+          | `Lc (id, _) ->
+              Format.fprintf fmt "local variable `%a'" (EcPrinting.pp_local env) id
+        in
+        let pp_details fmt (cand, fail) =
+          begin match cand with
+          | `Op (_, instance, declty) ->
+              if not (List.is_empty instance) then
+                Format.fprintf fmt "its type is@\n  @[%a@]@\n%a"
+                  pp_type declty pp_instance instance
+          | `Pv (_, ty) | `Lc (_, ty) ->
+              Format.fprintf fmt "it has type@\n  @[%a@]@\n" pp_type ty
+          end;
+          pp_reason fmt fail
+        in
+        let pp_args () =
+          if List.is_empty esig then
+            msg ":@\n"
+          else begin
+            msg " to arguments of type:@\n";
+            List.iteri
+              (fun i ty -> msg "  [%d]: @[%a@]@\n" (i+1) pp_type ty) esig
+          end
+        in
+        begin match failures with
+        | [(cand, fail)] ->
+            msg "%a cannot be applied" pp_kind cand;
+            pp_args ();
+            msg "@[<v>%a@]" pp_details (cand, fail)
+        | _ ->
+            msg "`%a' cannot be applied" pp_qsymbol name;
+            pp_args ();
+            msg "the candidates cannot be applied:@\n";
+            List.iter
+              (fun (cand, fail) ->
+                msg "  [%a]:@\n    @[<v>%a@]@\n"
+                  pp_kind cand pp_details (cand, fail))
+              failures
+        end
+
     | MultipleOpMatch (name, tys, matches) -> begin
         let uvars = List.map Tuni.univars tys in
         let uvars = List.fold_left Suid.union Suid.empty uvars in

--- a/tests/op-application-errors.ec
+++ b/tests/op-application-errors.ec
@@ -1,0 +1,290 @@
+(* Operator application failures must be diagnosed precisely. Each command
+   below is ill-typed; [expect fail "..."] asserts the exact error it
+   produces, so the messages are tested for regression. *)
+
+require import AllCore List FSet.
+
+(* --- result type mismatch ------------------------------------------ *)
+
+expect fail "operator `Top.List.filter' cannot be applied to arguments of type:
+  [1]: int -> bool
+  [2]: int list
+its type is
+  ('a -> bool) -> 'a list -> 'a list
+where the type parameters were inferred as:
+  'a = int
+it returns a value of type
+  int list
+but a value of type
+  int fset
+was expected"
+op choose (s : int fset) : int fset =
+  List.filter (fun (i : int) => i \in s) [1; 2; 3].
+
+op h : 'a -> 'a * 'a.
+
+expect fail "operator `Top.h' cannot be applied to arguments of type:
+  [1]: int
+its type is
+  'a -> 'a * 'a
+where the type parameters were inferred as:
+  'a = int
+it returns a value of type
+  int * int
+but a value of type
+  int
+was expected"
+op bad_result : int = h 0.
+
+(* --- argument mismatch --------------------------------------------- *)
+
+expect fail "operator `Top.List.filter' cannot be applied to arguments of type:
+  [1]: int -> int
+  [2]: int list
+its #1 argument is expected to have type
+  #a -> bool
+but is applied to a value of type
+  int -> int"
+op bad_arg (s : int list) : int list =
+  List.filter (fun (i : int) => i) s.
+
+expect fail "operator `Top.List.map' cannot be applied to arguments of type:
+  [1]: int -> int
+  [2]: bool list
+its type is
+  ('a -> 'b) -> 'a list -> 'b list
+where the type parameters were inferred as:
+  'b = int
+  'a = int
+its #2 argument is expected to have type
+  int list
+but is applied to a value of type
+  bool list"
+op bad_ho : bool list =
+  List.map (fun (x : int) => x + 1) [true].
+
+expect fail "operator `Top.List.foldr' cannot be applied to arguments of type:
+  [1]: int -> bool -> bool
+  [2]: int
+  [3]: int list
+its type is
+  ('a -> 'b -> 'b) -> 'b -> 'a list -> 'b
+where the type parameters were inferred as:
+  'b = bool
+  'a = int
+its #2 argument is expected to have type
+  bool
+but is applied to a value of type
+  int"
+op bad_fold : int =
+  List.foldr (fun (x : int) (acc : bool) => acc) 0 [1; 2; 3].
+
+(* --- arity mismatch / under-application ---------------------------- *)
+
+expect fail "operator `Top.List.size' cannot be applied to arguments of type:
+  [1]: int list
+  [2]: int list
+its type is
+  'a list -> int
+where the type parameters were inferred as:
+  'a = int
+it is applied to 2 argument(s) but takes at most 1"
+op bad_arity (s : int list) : int =
+  List.size s s.
+
+op k : int -> int -> int.
+
+expect fail "operator `Top.k' cannot be applied to arguments of type:
+  [1]: int
+it returns a value of type
+  int -> int
+but a value of type
+  int
+was expected"
+op bad_underapp : int = k 0.
+
+(* --- partial instantiation of type parameters --------------------- *)
+
+op poly : 'a -> 'a -> int.
+
+expect fail "operator `Top.poly' cannot be applied to arguments of type:
+  [1]: int
+  [2]: bool
+its type is
+  'a -> 'a -> int
+where the type parameters were inferred as:
+  'a = int
+its #2 argument is expected to have type
+  int
+but is applied to a value of type
+  bool"
+op bad_poly : int = poly 0 true + 2.
+
+expect fail "operator `Top.poly' cannot be applied to arguments of type:
+  [1]: #a * #b
+  [2]: int
+its type is
+  'a -> 'a -> int
+where the type parameters were inferred as:
+  'a = #a * #b
+its #2 argument is expected to have type
+  #a * #b
+but is applied to a value of type
+  int"
+op bad_partial : int = poly (witness, witness) 0.
+
+op poly2 : 'a -> 'b -> 'b.
+
+expect fail "operator `Top.poly2' cannot be applied to arguments of type:
+  [1]: int
+  [2]: bool
+its type is
+  'a -> 'b -> 'b
+where the type parameters were inferred as:
+  'b = bool
+  'a = int
+it returns a value of type
+  bool
+but a value of type
+  int
+was expected"
+op bad_poly2 : int = poly2 0 true.
+
+(* --- multiple candidates ------------------------------------------- *)
+
+expect fail "`+' cannot be applied to arguments of type:
+  [1]: bool
+  [2]: int
+the candidates cannot be applied:
+  [operator `Top.Xint.+']:
+    its #1 argument is expected to have type
+      xint
+    but is applied to a value of type
+      bool
+  [operator `Top.Real.+']:
+    its #1 argument is expected to have type
+      real
+    but is applied to a value of type
+      bool
+  [operator `Top.Int.+']:
+    its #1 argument is expected to have type
+      int
+    but is applied to a value of type
+      bool"
+op bad_overload : int = true + 1.
+
+expect fail "`+' cannot be applied to arguments of type:
+  [1]: int
+  [2]: bool
+the candidates cannot be applied:
+  [operator `Top.Xint.+']:
+    its #1 argument is expected to have type
+      xint
+    but is applied to a value of type
+      int
+  [operator `Top.Real.+']:
+    its #1 argument is expected to have type
+      real
+    but is applied to a value of type
+      int
+  [operator `Top.Int.+']:
+    its #2 argument is expected to have type
+      int
+    but is applied to a value of type
+      bool"
+lemma bad_form : List.size [true] = 0 + true.
+
+theory A. op cand (x : int)  : int  = x. end A.
+theory B. op cand (x : bool) : bool = x. end B.
+import A B.
+
+expect fail "`cand' cannot be applied to arguments of type:
+  [1]: bool
+the candidates cannot be applied:
+  [operator `Top.B.cand']:
+    it returns a value of type
+      bool
+    but a value of type
+      int
+    was expected
+  [operator `Top.A.cand']:
+    its #1 argument is expected to have type
+      int
+    but is applied to a value of type
+      bool"
+op bad_multi : int = cand true.
+
+(* --- local variables ----------------------------------------------- *)
+
+expect fail "local variable `x' cannot be applied to arguments of type:
+  [1]: int
+it has type
+  int
+it is applied to 1 argument(s) but takes at most 0"
+op bad_local : int = let x = 0 in x 1.
+
+expect fail "local variable `g' cannot be applied to arguments of type:
+  [1]: bool
+it has type
+  int -> int
+its #1 argument is expected to have type
+  int
+but is applied to a value of type
+  bool"
+op bad_local_fun : int =
+  let g = (fun (n : int) => n) in g true.
+
+(* --- program variables --------------------------------------------- *)
+
+module M = {
+  var xz : int
+  var gf : int -> int
+  proc f () : unit = {}
+}.
+
+expect fail "program variable `M.xz' cannot be applied to arguments of type:
+  [1]: int
+it has type
+  int
+it is applied to 1 argument(s) but takes at most 0"
+lemma bad_pv     : hoare[M.f : M.xz 0 = 0 ==> true].
+
+expect fail "program variable `M.gf' cannot be applied to arguments of type:
+  [1]: bool
+it has type
+  int -> int
+its #1 argument is expected to have type
+  int
+but is applied to a value of type
+  bool"
+lemma bad_pv_fun : hoare[M.f : M.gf true = 0 ==> true].
+
+(* --- mixed candidate kinds (program variable + operator) ----------- *)
+
+op mix : bool -> bool.
+
+module N = {
+  proc f (mix : bool) : unit = {}
+}.
+
+expect fail "`mix' cannot be applied to arguments of type:
+  [1]: int
+the candidates cannot be applied:
+  [program variable `arg']:
+    it has type
+      bool
+    it is applied to 1 argument(s) but takes at most 0
+  [operator `Top.mix']:
+    its #1 argument is expected to have type
+      bool
+    but is applied to a value of type
+      int"
+lemma bad_mix : hoare[N.f : mix 0 = 0 ==> true].
+
+(* --- genuinely unknown operator ------------------------------------ *)
+
+expect fail "no matching operator, named `List.frobnicate', for the following parameters' type:
+  [1]: int list"
+op unknown (s : int list) : int list =
+  List.frobnicate s.
+


### PR DESCRIPTION
Operator selection unified arguments and result type in one shot and
dropped every rejected candidate, so a failure was always reported as
"no matching operator for the parameters' type" — even when the
parameters matched and only the result type (or a single argument, or
the arity) was wrong.

Rework selection to classify failures:

- EcUnify.classify_application unifies a candidate against the expected
  arguments one at a time (head-normalising to see through type
  abbreviations), pinpointing the first argument / result / arity
  failure. select_op now returns OK / KO outcomes carrying the reason,
  the declared type and the inferred partial instantiation.

- The same classification is applied to program variables (select_pv)
  and to local variables (in form_of_opselect, where a local that
  shadows an operator fails to apply). The new UnappliedOp error and its
  printer describe each failing candidate (operator, program variable or
  local), the argument types, and for operators the declared polymorphic
  type with the inferred type-parameter instantiation. Genuinely unknown
  names keep the previous UnknownVarOrOp message.

Also add an "expect fail \"...\"" command that asserts a command fails
with a given error message, and use it in a new regression test covering
result/argument/arity mismatches, partial instantiation, multiple and
mixed-kind candidates, formula context and unknown names.

Closes #1048, #825.