### PR TITLE
[chore] stabilise SMT and bump provers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,12 @@
 # --------------------------------------------------------------------
 DUNE      ?= dune
 ECARGS    ?=
-ECTOUT    ?= 10
 ECJOBS    ?= 0
 ECEXTRA   ?= --report=report.log
 CHECKPY   ?=
 CHECK     := $(CHECKPY) scripts/testing/runtest
 CHECK     += --bin=./ec.native
 CHECK     += --jobs="$(ECJOBS)"
-CHECK     += --bin-args=-timeout --bin-args="$(ECTOUT)"
 CHECK     += $(foreach arg,$(ECARGS),--bin-args="$(arg)")
 CHECK     += $(ECEXTRA) config/tests.config
 NIX       ?= nix --extra-experimental-features "nix-command flakes"

--- a/easycrypt.project
+++ b/easycrypt.project
@@ -1,3 +1,5 @@
 [general]
-provers = CVC5@1.0
-provers = Z3@4.12
+provers = CVC5@1.1
+provers = Z3@4.16
+
+timeout = 3

--- a/examples/MEE-CBC/RCPA_CMA.ec
+++ b/examples/MEE-CBC/RCPA_CMA.ec
@@ -23,7 +23,7 @@ theory MtE.
     type leaks                <- leaks,
     op   leak (pt:ptxt * tag) <- leak pt.`1,
     op   dC                   <- dC
-  proof * by smt.
+  proof * by exact: dC_ll.
 
   clone MACs as MACa with
     type mK   <- mK,
@@ -38,7 +38,7 @@ theory MtE.
     type leaks <- leaks,
     op   leak  <- leak,
     op   dC    <- dC
-  proof * by smt.
+  proof * by exact: dC_ll.
 
   (** The black-box construction is as follows **)
   module MacThenEncrypt(E:SKEa.Enc_Scheme, M:MACa.MAC_Scheme): Enc_Scheme = {
@@ -256,7 +256,7 @@ theory MtE.
           proc; inline *.
           wp=> /=; call (_: true).
           wp=> /=; call (_: true).
-          by auto; smt.
+          by auto=> |> &1 &2 _ + _ p1; rewrite !in_fsetU1=> ->.
           (* lossless after win *)
           by move=> &2 win; proc; wp; call (MtE_enc_ll E M E_enc_ll M_tag_ll).
           (* lossless and preservation of win *)
@@ -281,7 +281,7 @@ theory MtE.
           if=> //=.
             auto; call (_: true); auto=> /> &1 &2 _ /> eq_qs _ /> _.
             by case: (pt{2})=> //= -[p t] r; case: r=> //= _; rewrite eq_qs.
-          by auto; smt.
+          by auto=> |>.
         (* lossless after win *)
         by move=> &2 bad; proc; wp; call (MtE_dec_ll E M E_dec_ll M_verify_ll).
         (* lossless and preservation of win *)
@@ -289,13 +289,13 @@ theory MtE.
           by inline *; wp; call (_: true); auto.
           by inline *; wp; call E_dec_ll; auto.
           if=> /=.
-            by inline *; auto; call M_verify_ll; auto; smt.
+            by inline *; auto; call M_verify_ll; auto=> |>.
           done.
         (* back to the experiment *)
         swap{2} 4 -3.
         wp; call (_: true).
         wp; call (_: true).
-        by auto; smt.
+        by auto=> |> /#.
       qed.
     end section PTXT.
   end RCPA_WUF_PTXT.
@@ -321,7 +321,7 @@ theory EtM.
     type leaks <- leaks,
     op   leak  <- leak,
     op   dC    <- dC
-  proof * by smt.
+  proof * by exact: dC_ll.
 
   clone MACs as MACa with
     type mK   <- mK,
@@ -606,18 +606,21 @@ theory EtM.
             call{1} (_:     (glob E) = ge /\ k = _k /\ c = _c
                         ==> (glob E) = ge /\ res = dec _k _c).
               by conseq (E_dec_ll) (dec_sem ge _k _c).
-            by skip; smt.
-          by auto; smt.
+            by auto=> |> /#.
+          by auto=> |> /#.
         (* lossless after win *)
         by move=> &2 bad; proc; wp; call (EtM_dec_ll E M E_dec_ll M_verify_ll).
         (* lossless and preservation of win *)
         move=> &1; proc; seq  2: true 1%r 1%r 0%r _ (MACa.SUF_CMA.SUF_Wrap.win) => //=.
-          by inline *; wp; call (_: true); auto; smt.
+          by inline *; wp; call (_: true); auto=> |> /#.
           by inline *; wp; call M_verify_ll; auto.
         (* back to the experiment *)
         swap{2} 4 -3.
         wp; call (_: true).
-        by wp; call (_: true); skip; smt.
+        wp; call (_: true); auto=> |>.
+        move=> rR; split=> [|_].
+        + by move=> c t; rewrite in_fset0.
+        by move=> + + + + + + + + + [].
       qed.
     end section CTXT.
   end RCPA_SUF_CTXT.

--- a/examples/MEE-CBC/RCPA_pad.eca
+++ b/examples/MEE-CBC/RCPA_pad.eca
@@ -85,7 +85,7 @@ section RCPA.
   proof.
     byequiv=> //=; proc.
     call (_: true).
-      by proc; inline *; auto; smt.
+    + by proc; inline *; auto=> |>; smt(leak_pad).
     by call (_: true).
   qed.
 
@@ -99,7 +99,7 @@ section RCPA.
     byequiv=> //=; proc; inline *.
     call (_:    ={glob S}
              /\ ={k}(RCPA_Wrap,CoreDefs.RCPA.RCPA_Wrap)).
-      by proc; inline *; wp; call (_: true); auto; smt.
+      by proc; inline *; wp; call (_: true); auto.
     by call (_: true).
   qed.
 end section RCPA.

--- a/examples/UC/dh_enc.ec
+++ b/examples/UC/dh_enc.ec
@@ -30,7 +30,6 @@ type 'a stlkg = [
    | Ch_Available of 'a
 ].
 
-
 theory FChan.
 
 type msg.
@@ -1523,8 +1522,8 @@ proof.
       progress; smt ().
 
     + proc => /=; inline *; wp; skip => /> &1 &2; rewrite /party_output /kstp /= /#.
-    + proc; match; 1,2 : smt().
-      + move=> m1 m2.
+    + proc; match = => |>.
+      + move=> m1.
         inline OTP(DHKE.FKE.FKEAuth.FKEAuth).step OTP_AUX(RO, DHKE.FKE.FKEAuth.FKEAuth).step.
         sp 1 1; if => //; conseq />; last by sim.
         inline *.
@@ -1543,16 +1542,15 @@ proof.
         case : (FKE.st{1}.`kst) => />; rewrite //=.
         rewrite /= dmap_ll //=.
         by apply  dt_ll.
-      move => m1 m2.
+      move => m1.
       inline DHKE.FKE.FKEAuth.FKEAuth.step.
       sp 1 1; match; 1,2: smt().
       + by move=> *; inline *; auto => /#.
       move=> tt1 tt2; inline *; auto => /> &1 &2 heq ??.
       by rewrite /unblock /kstp heq; case: (FKE.st{2}.`kst) => />.
-    + proc.
-      match; 1,2 : smt().
-      + by move=> m1 m2; inline *; sim; auto.
-      by move=> m1 m2; inline *; auto => /> /#.
+    + proc; match = => |>.
+      + by move=> m1; inline *; sim; auto.
+      by move=> m1; inline *; auto => /> /#.
     inline *; auto => />; rewrite /is_lossless weight_dmap dt_ll /= => *.
     by rewrite get_setE /init /= mem_empty /= mem_set.
   have -> : Pr[D(RO).distinguish() @ &m : res] = Pr[D(LRO).distinguish() @ &m : res].
@@ -1731,8 +1729,8 @@ call (_: invotp OTP.Initiator.p{1}
                 FKE.st{1}.`kst <> KE_Available (snd OTP.Initiator.p{1},
                                                 rcv OTP.Initiator.p{1},()) /\
                 (oget (getr (oget lke{2}))) = KE_Wait (snd OTP.Initiator.p{1},
-                                                        rcv OTP.Initiator.p{1},())));
-            first by wp;skip;rewrite /invotp /#.
+                                                        rcv OTP.Initiator.p{1},()))).
+          + by auto=> /#.
           case (_K{1} = None).
           + rcondf {1} 1; first by auto => /#.
             by match {2}; auto => /#.
@@ -1792,8 +1790,8 @@ sp 0 1; match; first 2 by smt().
 + by move => m1 b1; inline *; wp;skip;rewrite /invotp; smt().
 
 (* Backdooring the hybrid functionalities *)
-move => m2 b2; inline *.
-by sp 1 0; match; 1,2: (by smt()); auto => />; rewrite /invotp /#.
+move => m2 b2; inline *; sp 1 0.
+by match = => |>; auto=> |> &1 &2 /#.
 qed.
 
 (* Main theorem for secure channel based on OTP using ideal functionalities
@@ -1875,9 +1873,10 @@ byequiv => //.
 proc;inline *.  
   wp;call(_: ={ DHKE.DHKE_SIM._X, DHKE.DHKE_SIM._Y, glob DHKE.SimAuth.FAuthLR.FAuth, glob DHKE.SimAuth.FAuthRL.FAuth, glob OTP, glob DHKE.FKE.FKEAuth.FChan.FAuth.FAuth, glob FKE});
      first 2 by sim.
-  + proc; match; [1,2: by smt()]; move => *;inline *; auto => /> /#.  
-  + proc; match; [1,2: by smt()]; move=>  m1 m2;inline *;auto => />.
-    move => &2;case m2 => x; smt(). 
+  + proc; match = => |>; auto; inline *; auto=> |> &2.
+    by case: m2=> |> [] //=; case: (leak FKE.st{2})=> |> [].
+  + proc; match = => |>; auto; inline *; auto => |> &2.
+    by case: m2=> |> [] //= [] //=; case: (leak FKE.st{2})=> |> [].
     
  by  auto => />.
 qed.

--- a/examples/cramer-shoup/cramer_shoup.ec
+++ b/examples/cramer-shoup/cramer_shoup.ec
@@ -868,8 +868,10 @@ section Security_Aux.
     (forall (x : 'a), mu1 dt x <= r) => mu dt (mem l) <= n%r * r.
   proof.
     move=> Hsize Hmu1;apply (ler_trans ((size l)%r * r)).
-    + by apply mu_mem_le_mu1.
-    apply ler_wpmul2r; 1: smt (mu_bounded).
+    + by apply: mu_mem_le_mu1.
+    apply: ler_wpmul2r.
+    + apply: (ler_trans (mu1 dt witness)); 1:exact: ge0_mu.
+      exact: Hmu1.
     by apply le_fromint.
   qed.
 

--- a/examples/ehoare/adversary.ec
+++ b/examples/ehoare/adversary.ec
@@ -14,7 +14,11 @@ axiom dr_mu_test : 0%r < p.
 op eps : real.
 axiom dr_mu1 : forall (x:r), mu1 dr x <= eps.
 
-lemma eps_ge0: 0%r <= eps. by smt(dr_mu1 mu_bounded). qed.
+lemma eps_ge0: 0%r <= eps.
+apply: (ler_trans (mu1 dr witness)).
++ exact: ge0_mu.
+exact: dr_mu1.
+qed.
 
 module type Oracle = { 
   proc o () : unit 
@@ -91,7 +95,10 @@ proof.
   + auto => &hr /=.
     case: (O.c{hr} = Q) => [ -> /= | *].
     + rewrite Ep_mu (:(fun (a : r) => a \in O.log{hr}) = mem O.log{hr}); 1: by auto.
-      rewrite -of_realM /=; smt(mu_mem_le_mu1 size_ge0 eps_ge0 dr_mu1).
+      rewrite -of_realM /= 1:le_fromint 1:size_ge0 1:eps_ge0.
+      rewrite /(%pos) (: 0%r <= _) /=.
+      + by apply: mulr_ge0; [exact/le_fromint/size_ge0 | exact: eps_ge0].
+      exact/mu_mem_le_mu1/dr_mu1.
     case: (Q < O.c{hr}); by smt().
   auto => &hr /=; apply xle_cxr => *; split; 1:smt().
   have -> /=: (Q < O.c{hr} + 1) = (Q <= O.c{hr}) by smt().

--- a/examples/ehoare/random_boolean_matrix.ec
+++ b/examples/ehoare/random_boolean_matrix.ec
@@ -44,8 +44,10 @@ lemma row_eq_upto_increase (i m : int) (a1 a2 : bool array):
    <=> row_eq_upto (i + 1) m a1 a2).
 proof.
 move=> ? @/row_eq_upto @/cell_eq_upto; split.
-- move=> ? i' j' ??.
-  by case: (i' < i) => /#.
+- move=> [] H_lti H_i i' j' [] ge0_i' /ltzS /lez_eqVlt + H_j.
+  case=> [->>|lti_i'].
+  + by rewrite H_i.
+  + by rewrite H_lti.
 - move=> h; split.
   - move => i' j' ??.
     have ?: 0 <= i' < i + 1 by smt().

--- a/theories/algebra/Bigalg.ec
+++ b/theories/algebra/Bigalg.ec
@@ -324,7 +324,7 @@ elim: s => // x s IHs F_ge0; rewrite BMul.big_cons.
 have {IHs} IHs := IHs _; first by smt().
 case: (P x) => [Px F_big_gt0 a a_x_s Pa| nPx /IHs]; 2:smt().
 rewrite pmulr_gt0 in F_big_gt0; 1, 3:smt().
-apply: prodr_ge0_seq; smt().
+by apply: prodr_ge0_seq; smt().
 qed.
 
 lemma ler_prod_seq (P : 'a -> bool) (F1 F2 : 'a -> t) s:

--- a/theories/algebra/DynMatrix.eca
+++ b/theories/algebra/DynMatrix.eca
@@ -1939,7 +1939,11 @@ qed.
 lemma supp_dmatrix_full m d r c : 
   0 <= r => 0 <= c =>
   is_full d => m \in dmatrix d r c <=> size m = (r,c).
-proof. smt(supp_dmatrix). qed.
+proof.
+move=> ge0_r ge0_c d_fu.
+rewrite supp_dmatrix //; split=> //.
+by move=> -> /= i j _; rewrite d_fu.
+qed.
 
 lemma dvector_rnd_funi (d : R distr) (v1 v2 : vector) l :
   is_funiform d => size v1 = size v2 => 

--- a/theories/crypto/SplitRO.ec
+++ b/theories/crypto/SplitRO.ec
@@ -185,9 +185,17 @@ section PROOFS.
       have hn := o_pair_none <: from, to1, to2>.
       by rewrite /pair_map merge_empty // map_empty /= => ?; rewrite !mem_empty. 
     + by conseq RO_get.
-    + by proc; inline *; auto => />;
-       smt (get_setE map_set set_pair_map mem_map mem_pair_map mem_set mapE mergeE topairK).
-    + by proc; inline *; auto; smt (map_rem rem_merge mem_map mem_pair_map mem_rem).
+    + proc; inline *; auto => |> &2 ih; split.
+      + apply: fmap_eqP=> z; rewrite mapE /= mergeE // !get_setE; case: (z = x{2}).
+        + by case _: (topair y{2})=> y1 y2 |> @/o_pair /= <-; rewrite topairK.
+        by rewrite mapE /= mergeE.
+      move=> z; rewrite !domE !get_setE; case: (z = x{2})=> // _.
+      by rewrite -!domE; exact: ih.
+    + proc; inline *; auto=> |> &2 ih; split.
+      + apply: fmap_eqP=> z; rewrite mapE /= mergeE // !remE; case: (z = x{2})=> //.
+        by move=> _; rewrite mapE /= mergeE.
+      move=> z; rewrite !domE !remE; case: (z = x{2})=> // _.
+      by rewrite -!domE; exact: ih.
     + proc *.
       inline {1} 1.
       outline {2} 1 by { RO_Pair(I1.RO, I2.RO).get(x); }.

--- a/theories/crypto/assumptions/DHIES.ec
+++ b/theories/crypto/assumptions/DHIES.ec
@@ -985,8 +985,8 @@ last by wp; skip; rewrite /inv /= => />; smt (fdom0 emptyE).
     case _: (Adv2_Procs.kindex.[(pk, ctxt.`1)]{2}).
     + by move: H10; rewrite -mem_fdom H -H2 mem_fdom domE.
     smt ().
-   wp; skip; rewrite /inv /= /#.
-  wp; skip; rewrite /inv /#.
+   by auto=> |> &1 &2 @/inv |> _ + _ _ _ _ _ _ _ _ _ _ /#.
+  by auto=> |> &1 &2 @/inv |> _ _ + _ _ _ _ _ _ _ /#.
 + by auto => />.
 + by auto => />.
 qed.

--- a/theories/datatypes/List.ec
+++ b/theories/datatypes/List.ec
@@ -446,7 +446,15 @@ proof. by move/onth_some => [? <-]; apply/mem_nth. qed.
 
 lemma nthP (x0 : 'a) (s : 'a list) (x : 'a) :
   (x \in s) <=> (exists (i : int), 0 <= i < size s /\ nth x0 s i = x) .
-proof. elim: s; smt(size_ge0). qed.
+proof.
+elim: s=> [/#|y ys] /= ih; case: (x = y)=> [<<-|x_neq_y] /=.
++ by exists 0=> |>; smt(size_ge0).
+rewrite ih; split=> - [] i [#].
++ by move=> ge0_i i_lt_szys ith_ys_is_x; exists (i + 1)=> /#.
+move=> /lez_eqVlt; rewrite (eq_sym 0 i).
+case: (i = 0)=> [|>|/=] i_neq_0 gt0_i i_lt_Sszys ith_ys_x.
+by exists (i - 1)=> /#.
+qed.
 
 lemma nthPn (x0 : 'a) (s : 'a list) (x : 'a) :
   ! (x \in s) <=> (forall (i : int), 0 <= i < size s => nth x0 s i <> x).
@@ -873,10 +881,8 @@ proof. by rewrite /= lezNgt; case: (0 < n). qed.
 lemma size_drop n (s : 'a list):
   0 <= n => size (drop n s) = max 0 (size s - n).
 proof.
-elim: s n=> //= n; first by smt(lez_maxl).
-move=> l ih n0 ?; case (n0 = 0).
-+ by move=> -> /=; smt(size_ge0).
-+ by smt().
+elim: s n => //= [/#|x xs ih n ge0_n].
+smt(size_ge0).
 qed.
 
 lemma drop_cat n (s1 s2 : 'a list):

--- a/theories/datatypes/Xreal.ec
+++ b/theories/datatypes/Xreal.ec
@@ -195,7 +195,12 @@ lemma of_realM x y : 0.0 <= x => 0.0 <= y =>
 proof. smt (of_realdK to_realP). qed.
 
 lemma of_realI (x:real) : (inv x)%rp = inv x%rp.
-proof. smt (of_realdK to_realP  of_real_neg divr0). qed.
+proof.
+case: (0%r <= x)=> [ge0_x|/ltrNge lt0_x].
++ rewrite -{1}(of_realdK x) 1:#smt:(divr0).
+  by rewrite -to_realI to_realKd.
+by rewrite (of_real_neg x) // of_real_neg // invr_lt0.
+qed.
 hint simplify of_realI.
 
 op (%pos) (x:real) = if 0.0 <= x then x else 0.0.

--- a/theories/distributions/DInterval.ec
+++ b/theories/distributions/DInterval.ec
@@ -75,12 +75,18 @@ have uniq_s: uniq s; first apply: uniq_flatten_map.
 have mem_s: forall x, (x \in s) <=> (x \in range 0 p).
 - move=> x; rewrite mem_range; split.
   - case/flatten_mapP=> j [/= /mem_range rgj] /=.
-    case/mapP => [k [/mem_range rgk]] ->; split; [smt()|smt(@IntDiv)].
+    case/mapP => [k [/mem_range rgk]] ->; split=> [/#|_].
+    rewrite (divz_eq p q) dvd_qp /=.
+    apply: (ltr_le_trans ((p %/ q - 1) * q + q)); last first.
+    + by rewrite -(mulzDl _ 1).
+    by apply: ler_lt_add=> [|/#]; apply: ler_pmul=> //#.
   - case=> ge0x lex; apply/flatten_mapP => /=.
     exists (x %/ q); rewrite mem_range.
-    rewrite divz_ge0 // ge0x /=; split; 1: smt(@IntDiv).
+    rewrite divz_ge0 // ge0x /=; split.
+    + rewrite -(ltr_pmul2r q gt0_q) (divzK q p dvd_qp).
+      by apply/(ler_lt_trans x _ _ _ lex)/lez_floor=> /#.
     apply/mapP; exists (x %% q); rewrite mem_range.
-    rewrite modz_ge0 1:gtr_eqF //= ltz_pmod //= &(divz_eq).
+    by rewrite modz_ge0 1:gtr_eqF //= ltz_pmod //= &(divz_eq).
 have eqs: perm_eq s (range 0 p).
 - by apply: uniq_perm_eq => //; apply/range_uniq.
 rewrite dmap1E duniformE /= undup_id ?range_uniq /pred1 /(\o).

--- a/theories/distributions/Distr.ec
+++ b/theories/distributions/Distr.ec
@@ -650,7 +650,8 @@ qed.
 
 lemma distr_0Vmem (d : 'a distr) : d = dnull \/ exists x, x \in d.
 proof.
-have := pred_0Vmem (support d); smt(support_eq0 supportP).
+have:= pred_0Vmem (support d); case: (exists x, x \in d)=> //=.
+by rewrite negb_exists=> /support_eq0.
 qed.
 
 lemma pmax_dnull ['a] : p_max dnull<:'a> = 0%r.

--- a/theories/distributions/SDist.ec
+++ b/theories/distributions/SDist.ec
@@ -119,7 +119,9 @@ have <- : `| Sp - Sn | = `|weight d1 - weight d2|.
   rewrite /Sp /Sn -sumB /=; try exact/summable_cond/summable_sdist.
   rewrite !weightE -sumB /= ?summable_mu1. 
   by congr; apply eq_sum => x /= /#.
-suff : flub F = Sp by rewrite /sdist -/F; smt(ler_def).
+suff : flub F = Sp.
++ rewrite /sdist -/F. print ler_def.
+  by move: ler_Sn_Sp=> /ler_def -> /#.
 apply ler_anti; split => [|_]; last first. 
 - apply (ler_trans (F pos)); last first.
   + by apply (flub_upper_bound); exists 1%r; rewrite /is_fub; smt(mu_bounded).

--- a/theories/encryption/Hybrid.ec
+++ b/theories/encryption/Hybrid.ec
@@ -428,7 +428,8 @@ section.
     by rewrite range_uniq=> /= x; rewrite mem_range supp_dinter=> /#.
   have Huni : forall (x : int), x \in [0..max 0 (q - 1)] => mu1 [0..max 0 (q - 1)] x = 1%r / q%r.
   + move=> x hx; rewrite dinter1E /=.
-    by rewrite -supp_dinter hx /= /#.
+    rewrite -supp_dinter hx /= /max subz_gt0.
+    by case: (1 < q)=> |> /lezNgt /lez_eqVlt=> - [] /#.
   pose ev :=
     fun (_j:int) (g:glob HybGameFixed(L(Ob))) (r:outputA),
       let (ga,ge,l,l0) = g in p ga ge l r /\ l <= q.


### PR DESCRIPTION
@EasyCrypt/developers I need quick eyes on this, and for you to tell me how much of a pain in the arse it is to bump z3 to 4.16 and cvc5 to 1.1.x as a requirement for easycrypt dev.

I use arch (btw), so my own setup can follow SMT solvers relatively closely, but I recognise that not everybody likes to spend their weekend fixing their bootloader...

As a side note, most of the proof breakage is in places where the solver would need to recall that `witness` exists in all types, and to instantiate a universal quantification with it for the sake of a proof. I assume that both z3 and cvc5 have made a move towards more "constructive-compatible" heuristics in places, as they work to better integrate with ITPs.