### PR TITLE
replay: redirect datatype constructors in match bodies too

### DIFF
--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -27,6 +27,7 @@ exception InconsistentSubst
 type subst = {
   sb_module   : EcPath.mpath Mid.t;
   sb_path     : EcPath.path Mp.t;
+  sb_ctor     : EcPath.path Mp.t;
   sb_tyvar    : ty Mid.t;
   sb_elocal   : expr Mid.t;
   sb_flocal   : EcCoreFol.form Mid.t;
@@ -40,6 +41,7 @@ type subst = {
 let empty : subst = {
   sb_module   = Mid.empty;
   sb_path     = Mp.empty;
+  sb_ctor     = Mp.empty;
   sb_tyvar    = Mid.empty;
   sb_elocal   = Mid.empty;
   sb_flocal   = Mid.empty;
@@ -52,6 +54,7 @@ let empty : subst = {
 let is_empty s =
   Mid.is_empty s.sb_module
   && Mp.is_empty s.sb_path
+  && Mp.is_empty s.sb_ctor
   && Mid.is_empty s.sb_tyvar
   && Mid.is_empty s.sb_elocal
   && Mid.is_empty s.sb_flocal
@@ -271,6 +274,10 @@ let subst_memtype (s : subst) ((m, mt) : EcMemory.memenv) =
 let add_path (s : subst) ~src ~dst =
   assert (Mp.find_opt src s.sb_path = None);
   { s with sb_path = Mp.add src dst s.sb_path }
+
+(* -------------------------------------------------------------------- *)
+let add_ctor (s : subst) ~src ~dst =
+  { s with sb_ctor = Mp.add src dst s.sb_ctor }
 
 let add_tydef (s : subst) p (ids, ty) =
   assert (Mp.find_opt p s.sb_tydef = None);
@@ -932,7 +939,15 @@ and subst_branches (s : subst) = function
   | OPB_Branch bs ->
       let for1 b =
         let (ctorp, ctori) = b.opb_ctor in
-          { opb_ctor = (subst_path s ctorp, ctori);
+        (* A branch constructor is stored as a bare path. When the datatype's
+           type has been overridden while cloning, it is redirected to the
+           target datatype's constructor, which is recorded separately from
+           the path substitution: the latter also rewrites the paths that its
+           entries qualify, which a constructor must not do. *)
+        let ctorp =
+          Option.value (Mp.find_opt ctorp s.sb_ctor)
+            ~default:(subst_path s ctorp) in
+          { opb_ctor = (ctorp, ctori);
             opb_sub  = subst_branches s b.opb_sub; }
       in
         OPB_Branch (Parray.map for1 bs)

--- a/src/ecSubst.mli
+++ b/src/ecSubst.mli
@@ -25,6 +25,7 @@ val is_empty : subst -> bool
 (* -------------------------------------------------------------------- *)
 val add_module   : subst -> EcIdent.t -> mpath -> subst
 val add_path     : subst -> src:path -> dst:path -> subst
+val add_ctor     : subst -> src:path -> dst:path -> subst
 val add_tydef    : subst -> path -> (EcIdent.t list * ty) -> subst
 val add_opdef    : subst -> path -> (EcIdent.t list * expr) -> subst
 val add_pddef    : subst -> path -> (EcIdent.t list * form) -> subst

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -574,9 +574,15 @@ let rec replay_tyd (ove : _ ovrenv) (subst, ops, proofs, scope) (import, x, otyd
                   List.map
                     (CS.Tvar.subst tysubst -| EcSubst.subst_ty subst)
                     tyargs in
-                EcSubst.add_opdef subst
-                  (xpath ove name)
-                  (newtparams, e_op np newtparams_ty (toarrow newtyargs newdtype))
+                let subst =
+                  EcSubst.add_opdef subst
+                    (xpath ove name)
+                    (newtparams, e_op np newtparams_ty (toarrow newtyargs newdtype)) in
+                (* The definition above rewrites the constructor where it
+                   occurs as an operator expression. The branches of a match
+                   body store it as a bare path, which is redirected through
+                   its own substitution. *)
+                EcSubst.add_ctor subst ~src:(xpath ove name) ~dst:np
                 ) subst octors
             | _ -> subst
           end

--- a/tests/clone-datatype-match.ec
+++ b/tests/clone-datatype-match.ec
@@ -1,0 +1,67 @@
+(* Regression test for issue #1046.
+
+   When a datatype's type is overridden during cloning, an operator whose
+   body pattern-matches on the datatype's constructors (i.e. compiles to
+   `OP_Fix`) used to crash with `anomaly: EcTheoryReplay.CoreIncompatible`.
+   The replay machinery redirects the source datatype's constructors to the
+   target datatype's constructors only through operator definitions
+   (`Fop`/`Eop` expression nodes), so the constructor *paths* stored in
+   `OP_Fix` match branches were left pointing at the source datatype and the
+   operator-compatibility check saw unequal constructor paths.
+
+   Both override modes must accept these clones. *)
+
+require import Int.
+
+theory Thy.
+  type ATy = [ CA | CB of int ].
+
+  op getit (x : ATy) =
+    with x = CA   => 0
+    with x = CB n => n.
+
+  op mk = CB 3.
+end Thy.
+
+clone Thy as Thy1.
+
+(* plain alias override *)
+clone Thy as Thy2 with
+  type ATy = Thy1.ATy,
+  op getit <= Thy1.getit,
+  op mk    <= Thy1.mk.
+
+(* inline override *)
+clone Thy as Thy3 with
+  type ATy <- Thy1.ATy,
+  op getit <= Thy1.getit,
+  op mk    <= Thy1.mk.
+
+(* No operator override: the replayed match operator must have its branch
+   constructors redirected to the target datatype, so it reduces on the
+   target's constructor applications. *)
+clone Thy as Thy4 with
+  type ATy = Thy1.ATy.
+
+lemma getit4 : Thy4.getit (Thy1.CB 5) = 5.
+proof. done. qed.
+
+(* Recursive match operator: exercises the recursive occurrence
+   (opf_recp) together with the constructor redirect. Only the inline
+   override is checked here: aliasing the type of a *recursive* datatype
+   is rejected by the type-compatibility check for an unrelated reason
+   (the constructor argument that mentions the datatype itself is not
+   redirected), independently of this fix. *)
+theory RThy.
+  type RTy = [ RNil | RCons of int & RTy ].
+
+  op total (x : RTy) =
+    with x = RNil       => 0
+    with x = RCons n xs => n + total xs.
+end RThy.
+
+clone RThy as RThy1.
+
+clone RThy as RThy2 with
+  type RTy <- RThy1.RTy,
+  op total <= RThy1.total.


### PR DESCRIPTION
## Problem

Cloning a theory while overriding a datatype's type crashes when an operator in that theory
pattern-matches on the datatype's constructors:

```
theory Thy.
  type ATy = [ CB of int ].
  op getit (x : ATy) = with x = CB n => n.
end Thy.

clone Thy as Thy1.

clone Thy as Thy2 with
  type ATy = Thy1.ATy,
  op getit <= Thy1.getit.
```

```
anomaly: EcLib.EcTheoryReplay.CoreIncompatible
```

Both override modes (`type ATy = ...` and `type ATy <- ...`) are affected.  Fixes #1046.

## Cause

When a datatype's type is overridden, the source datatype's constructors are not re-created in the
clone, so references to them have to be redirected to the target datatype's constructors.  #1045
does that with `EcSubst.add_opdef`, which populates the definition map.

That map is consulted only where a constructor occurs as an operator *expression*: `subst_expr`
checks `has_opdef` at `src/ecSubst.ml:335,342` and `subst_form` at `:517,524`.  A match body
(`OP_Fix`) does not store its branch constructors as expressions.  It stores each one as a bare
path in `opb_ctor`, which is rewritten through the *path* map instead
(`src/ecSubst.ml:934-935`, via `subst_path` at `:74`).

So for a match operator the branch constructors were left pointing at the source datatype, and
`Compatible.for_opfix`, which compares them with `EcPath.p_equal`
(`src/ecTheoryReplay.ml:213`), raised `CoreIncompatible`.  `Compatible.for_operator` catches only
`Failure _`, so the exception escaped as an anomaly rather than as a clone error.

## Fix

Add a dedicated constructor map to `EcSubst`, `sb_ctor`, consulted at exactly one place: where a
match branch's `opb_ctor` path is substituted.  `replay_tyd` records the redirect there alongside
the existing `add_opdef` entry, in the same fold.  On a miss the branch falls through to the
previous `subst_path` behaviour unchanged, so nothing outside an overridden datatype's match
branches is affected.

A separate map rather than a `sb_path` entry, because `_subst_path` recurses into qualifiers
(`src/ecSubst.ml:65-72`): an entry keyed on `Thy.CA` would also rewrite every path that `Thy.CA`
qualifies.  Constructor names share a namespace with sub-theories, types and modules, so a sibling
that happens to be named after a constructor would be silently re-rooted into the target datatype's
prefix, changing what replayed definitions denote while their already-proved axioms are re-admitted
unchanged.  `sb_ctor` is keyed exactly and read only for `opb_ctor`, so it cannot reach any other
position.

## Testing

New `tests/clone-datatype-match.ec`, covering: a match operator overridden through both override
modes;  a clone that overrides only the type, with a lemma checking that the replayed match operator
still reduces on the target's constructors;  and a recursive match operator, which exercises the
recursive occurrence alongside the constructor redirect.

* Before the change the new test fails with the anomaly, after it passes.
* `tests/clone-datatype-alias.ec` (the #1045 / #989 regression test) still passes.
* Full unit scenario green: 94/94, including the new test.
* Soundness probes for the namespace-collision case above (a sub-theory, a type, a module and an
  operator named after a constructor of the overridden datatype, plus a `rename` clause matching a
  constructor name) all behave exactly as on `main`.

## Out of scope, noted for the record

Aliasing the type of a *recursive* datatype (`type RTy = R1.RTy` where a constructor takes an
`RTy` argument) is rejected by the type-compatibility check with

```
type `RTy` incompatible type declaration
```

This behaves identically with and without this patch, including when no operator is overridden at
all, so it is pre-existing and independent.  The cause looks different in kind: it is the
constructor *argument* that mentions the datatype itself that is not redirected in alias mode,
whereas inline mode rewrites it through `add_tydef`.  I left it alone rather than widen the scope
here, but I am happy to look at it separately if that is useful.

Relatedly, `Compatible.for_operator` has no `CoreIncompatible` handler, unlike `for_tydecl`
(`src/ecTheoryReplay.ml:208`).  That is why this bug presented as an anomaly instead of a clone
error, and any other operator-body mismatch reaching `check` would do the same.  Adding
`| CoreIncompatible -> raise (Incompatible OpBody)` would route it through `CE_OpIncompatible`.  I
have not included it here since it changes unrelated error paths, but say the word and I will add
it to this PR or a follow-up.

<sub>Drafted with AI assistance;  the diagnosis, the code, and every claim above were reviewed and
tested by me against a local build.</sub>
