### PR TITLE
fix(clone): `proof * [-tag]` should force (realize) untagged axioms

### DIFF
--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -351,15 +351,13 @@ let check_evtags ?(tags : evtags option) (src : symbol list) =
       let dfl =
         not (List.mem explicit src) &&
         not (List.exists (fun (mode, _) -> mode = `Include) tags) in
-      let stt =
-        List.map (fun src ->
-          let do1 status (mode, dst) =
-            match mode with
-            | `Exclude -> if sym_equal src dst then raise Reject; status
-            | `Include -> status || (sym_equal src dst)
-          in List.fold_left do1 dfl tags)
-          src
-      in List.mem true stt
+      let has_tag dst = List.exists (fun s -> sym_equal s dst) src in
+      let do1 status (mode, dst) =
+        match mode with
+        | `Exclude -> if has_tag dst then raise Reject; status
+        | `Include -> status || has_tag dst
+      in
+      List.fold_left do1 dfl tags
 
   with Reject -> false
 

--- a/tests/clone-proofstar-tagdrop.ec
+++ b/tests/clone-proofstar-tagdrop.ec
@@ -1,0 +1,19 @@
+(* Regression for `proof * [-tag]` failing to force untagged axioms.
+
+   An exclusion-only bracket list (`proof * [-foo]`) means "force every axiom
+   except those tagged `foo`", so the untagged axiom `A` must be FORCED into a
+   proof obligation. `A` is unprovable, so the discharging tactic fails and
+   the whole `clone` command must fail. Before the fix the untagged axiom was
+   silently kept as an assumed axiom in the clone, so this clone was accepted
+   (and `U.A` could be used to prove `false`). *)
+require import AllCore.
+
+theory T.
+  axiom A : false.
+end T.
+
+fail clone T as U proof * [-foo] by done.
+
+(* An include list (`proof * [foo]`) forces ONLY the axioms tagged `foo`:
+   the untagged `A` is intentionally not forced and stays an axiom. *)
+clone T as V proof * [foo] by done.


### PR DESCRIPTION
## Summary
`clone ... proof * [-tag].` leaves untagged axioms as they are. This lets a clone
instantiate a false instance of an untagged axiom (e.g. `FinType.enum_spec`) and derive
`false` (see the example below).

```
require import AllCore List FinType.


clone FinType as F with
  type t <- int,
  op enum <- [0]
  proof * [-dummy] by smt().

lemma bad : false.
proof.
have h := F.enum_spec 1.                               (* forall x, count (pred1 x) [0] = 1 *)
have : count (pred1 1) [0] = 1 by apply h.     (* count (pred1 1) [0] = 0, not 1    *)
by rewrite /count /pred1 /=.
qed.
```

## Root cause
`check_evtags` (`src/ecTheoryReplay.ml`) decides whether an axiom is forced by mapping the
directive's tag test over the *axiom's own* tag list `src`. For an untagged axiom `src = []`,
`List.mem true (List.map _ []) = false`, so it is never forced — and the correct default
(`dfl`) is never consulted.

## Fix (`src/ecTheoryReplay.ml`)
Rewrite the tag-matching so the directive is folded starting from the default `dfl`, testing
membership of each directive tag in the axiom's `src`. Untagged axioms now correctly fall
back to the default (forced), while explicit `[-tag]` exclusions still apply to tagged
axioms.

## Test
`tests/clone-proofstar-tagdrop.ec` (must-fail): a `proof * [-dummy]` clone that previously
dropped an untagged axiom is now rejected. Contrast: the no-bracket `proof *` form already
rejected, confirming this was a genuine drop rather than the by-design "clone assumes its
axioms" behaviour.
