### PR TITLE
fix(equiv): equivF_abs must check the glob-A oracle footprint on both oracles

### DIFF
--- a/src/phl/ecPhlFun.ml
+++ b/src/phl/ecPhlFun.ml
@@ -205,8 +205,7 @@ module FunAbsLow = struct
       let use =
         try
           check_oracle_use pf env topl o_l;
-          if   EcPath.x_equal o_l o_r
-          then check_oracle_use pf env topl o_r;
+          check_oracle_use pf env topr o_r;
           false
         with _ -> true
       in
@@ -330,8 +329,7 @@ module UpToLow = struct
 
     let ospec o_l o_r =
       check_oracle_use pf env topl o_l;
-      if   EcPath.x_equal o_l o_r
-      then check_oracle_use pf env topl o_r;
+      check_oracle_use pf env topr o_r;
 
       let fo_l = EcEnv.Fun.by_xpath o_l env in
       let fo_r = EcEnv.Fun.by_xpath o_r env in

--- a/tests/equivf-abs-oracle-glob.ec
+++ b/tests/equivf-abs-oracle-glob.ec
@@ -1,0 +1,31 @@
+(* Regression for the equivF_abs oracle-footprint asymmetry.
+
+   `equiv ... proc` for an abstract adversary must require that BOTH oracles
+   leave `glob A` unchanged, not only the left one. Here the right oracle O2
+   writes the concrete global Shared.g (which an unrestricted `A` may touch, so
+   Shared.g in glob A) while the left oracle O1 does not, so the `={glob A}`
+   invariant is not preserved by the oracle pair and this equiv is not provable.
+
+   Before the fix `check_oracle_use` was run on the right oracle only when
+   o_l = o_r, so the distinct-oracle case silently dropped the obligation and
+   the proof below closed (and could be turned into a proof of `false`). With
+   the fix the O2 `={glob A}` obligation remains, so the closing `by` must
+   fail. *)
+require import AllCore.
+
+module Shared = { var g : int }.
+
+module type O = { proc f() : unit }.
+module type Adv (M : O) = { proc main() : int }.
+
+module O1 : O = { proc f() : unit = { } }.
+module O2 : O = { proc f() : unit = { Shared.g <- Shared.g + 1; } }.
+
+section.
+declare module A <: Adv.
+
+lemma bad : equiv[ A(O1).main ~ A(O2).main : ={glob A} ==> ={res} ].
+proof.
+fail (by proc (true) => //; proc; auto).
+abort.
+end section.

--- a/theories/query_counting/Counter.eca
+++ b/theories/query_counting/Counter.eca
@@ -35,7 +35,7 @@ module Counter(S : System) = {
 
 section.
   declare module S <: System { -Counter }.
-  declare module D <: Distinguisher { -S }.
+  declare module D <: Distinguisher { -S, -Counter }.
 
 
   lemma ind_counting (E : (glob S) -> bool) &m:


### PR DESCRIPTION
## Summary
The abstract-function relational rule (`equivF_abs`) checks the oracle's `glob A` footprint
on the **left** oracle only. With two *distinct* oracle modules `O1 <> O2`, a write to
`glob A` by the right oracle `O2` is never checked, so the `={glob A}` obligation is dropped
while still asserted in the conclusion. EC then accepts a false
`equiv[ A(O1).main ~ A(O2).main : ={glob A} ==> ={res} ]`, and `byequiv` turns it into
`1 = 0`.

## Root cause
In `FunAbsLow.equivF_abs_spec`, the `use` flag (whether to include the `eqglob` obligation)
runs `check_oracle_use` on the right oracle `o_r` only inside the `o_l = o_r` branch:

```ocaml
check_oracle_use pf env topl o_l;
if   EcPath.x_equal o_l o_r
then check_oracle_use pf env topl o_r;
```

For `o_l <> o_r` the right oracle is never checked. `equivF_abs_upto` (`UpToLow`) has the
identical asymmetric guard.

## Fix (`src/phl/ecPhlFun.ml`)
Check **both** oracles unconditionally, each against its own abstract top:

```ocaml
check_oracle_use pf env topl o_l;
check_oracle_use pf env topr o_r;
```

Applied to both `equivF_abs_spec` and `equivF_abs_upto`. When either oracle touches
`glob A`, the `eqglob` obligation is now correctly required (and the false equiv above no
longer type-checks).

## Impact: an existing stdlib lemma is unsound
This is not only synthetic. `theories/query_counting/Counter.eca` proves

```
lemma ind_counting (E : (glob S) -> bool) &m:
  Pr[D(S).distinguish() @ &m: E (glob S)] = Pr[D(Counter(S)).distinguish() @ &m: E (glob S)]
```

with `declare module D <: Distinguisher { -S }` — `D` is restricted from `S` but **not** from
`Counter`, so `Counter.c ∈ glob D`. The right oracle `Counter(S).oracle` writes `Counter.c`
(= writes `glob D`), and the dropped right-oracle check is exactly what let this proof through.
The lemma is false: a distinguisher that records `c0 := Counter.c` and re-queries iff
`Counter.c = c0` queries twice against bare `S` but once against `Counter(S)`, so `glob S`
differs — giving `1 = 0`.

This PR therefore also fixes the theory: `declare module D <: Distinguisher { -S, -Counter }`
(the sound restriction; the file's second section already uses `D{-Counter}`). With the tactic
fix in place the theory compiles, and a `Counter.c`-reading distinguisher is correctly no longer
a valid instantiation.

## Test
Must-fail regression `tests/ko/equivf-abs-oracle-glob.ec`: the distinct-oracle equiv where only
the right oracle writes `glob A` is now rejected (the writer-on-left case was already rejected,
confirming the asymmetry). The updated `Counter.eca` exercises the fixed theory.
