### PR TITLE
`hint simplify` registers one rule per conjunct of a lemma

### DIFF
--- a/doc/tactics/hint-simplify.rst
+++ b/doc/tactics/hint-simplify.rst
@@ -20,18 +20,86 @@ Global declarations add lemmas to a simplification database.
 
 .. admonition:: Syntax
 
-   `hint simplify {lemma}+ .`
+   `hint simplify [{option}*]? {item} (, {item})* .`
 
 Add the listed lemmas to the default simplification database.
 
 .. admonition:: Syntax
 
-   `hint simplify in {db} : {lemma}+ .`
+   `hint simplify in {db} : [{option}*]? {item} (, {item})* .`
 
 Add the listed lemmas to the named database `{db}`.
 
+Each `{item}` is a lemma name, or a parenthesised list of lemma names,
+optionally followed by a priority:
+
+- `{lemma}`
+- `{lemma} @ {n}`
+- `( {lemma} (, {lemma})* ) @ {n}`
+
+Rules are tried in increasing priority order, `0` being the default, so
+`@ {n}` with a larger `{n}` places a rule after the rules declared without
+a priority. The priority of an item applies to every rule it produces.
+
+The optional bracketed `{option}` list applies to every item of the
+command:
+
+- `reduce` -- head-normalise the statement of the lemma, unfolding
+  transparent definitions, before compiling it into rules. This lets a
+  lemma stated through an abbreviation-like operator register a rule on
+  the operator the abbreviation unfolds to.
+- `eqtrue` -- accepted for compatibility. A boolean statement that is not
+  an equation is always compiled as a rewrite to `true` (see below), so
+  the option currently has no additional effect.
+
 These commands are theory-level declarations: once imported, the
 corresponding rules are available to simplification.
+
+------------------------------------------------------------------------
+Rule shape
+------------------------------------------------------------------------
+
+A lemma is compiled into one or more rewrite rules by decomposing its
+statement. The statement is first stripped of its leading universal
+quantifiers, then split as follows:
+
+- `{c} => {f}` -- a conditional rule: `{c}` is recorded as a side
+  condition of every rule produced from `{f}`. When a rule is applied,
+  each side condition is instantiated and must simplify to `true` for the
+  rule to fire.
+- `{f1} /\ {f2}` -- a conjunction contributes the rules of both
+  conjuncts. Side conditions and binders introduced above the conjunction
+  apply to both sides.
+- `forall {x}, {f}` -- a conjunct may carry its own binders, which are
+  added to those of the enclosing statement.
+- `{lhs} = {rhs}` and `{lhs} <=> {rhs}` -- a rewrite rule from `{lhs}` to
+  `{rhs}`.
+- any other boolean statement `{p}` -- a rewrite rule from `{p}` to
+  `true`.
+
+Hence a lemma such as
+
+.. code-block:: easycrypt
+
+   lemma gE : g 0 = 4 /\ g 1 = 6 /\ g 2 = 2.
+   hint simplify gE.
+
+registers three rules, one per equation, and
+
+.. code-block:: easycrypt
+
+   lemma hE (x : int) : (0 < x => h x = x + 1) /\ h 0 = 7.
+   hint simplify hE.
+
+registers a rule for `h x` guarded by `0 < x` and an unconditional rule
+for `h 0`.
+
+The left-hand side of each rule must be a first-order pattern: an
+application of an operator to patterns, a tuple, a projection, an
+integer literal, or a variable. Its head must not be a variable, and
+every bound variable of the rule must occur in it (a binder of the
+statement that a conjunct does not mention is simply dropped for that
+conjunct). Lemmas quantifying over memories or modules are rejected.
 
 ------------------------------------------------------------------------
 The `hint` clause
@@ -160,8 +228,13 @@ Example
    lemma wrap2E x : box (wrap2 x) = box (x + 2).
    proof. smt(). qed.
 
+   op g : int -> int.
+
+   axiom gE : g 0 = 4 /\ g 1 = 6 /\ g 2 = 2.
+
    hint simplify wrap1E.
    hint simplify in named : wrap2E.
+   hint simplify gE.
 
    lemma demo_default (x : int) :
      box (wrap1 x) = box (x + 1).
@@ -188,5 +261,12 @@ Example
      box (wrap1 x) = box (x + 1).
    proof.
      simplify hint +[wrap1].
+     trivial.
+   qed.
+
+   lemma demo_conjunction :
+     g 0 + g 1 + g 2 = 12.
+   proof.
+     (*$*) simplify.
      trivial.
    qed.

--- a/src/ecEnv.ml
+++ b/src/ecEnv.ml
@@ -1532,9 +1532,7 @@ module Reduction = struct
   (* The default-database name is owned by [EcSimplifyContext]. *)
   let dname : symbol = EcSimplifyContext.dname
 
-  let add_rule ((src, rule) : path * rule option) (db : mredinfo) =
-    match rule with None -> db | Some rule ->
-
+  let add_rule ((src, rule) : path * rule) (db : mredinfo) =
     let p : topsym =
       match rule.rl_ptn with
       | Rule (`Op p, _)   -> `Path (fst p)
@@ -1557,22 +1555,24 @@ module Reduction = struct
 
       Some { ri_priomap; ri_list }) p db
 
-  let add_rules (rules : (path * rule option) list) (db : mredinfo) =
+  let add_rules (rules : (path * rule) list) (db : mredinfo) =
     List.fold_left ((^~) add_rule) db rules
 
-  let updatedb ?(base : symbol option) (rules : (path * rule option) list) (db : mredinfo Msym.t) =
+  let updatedb ?(base : symbol option) (rules : (path * rule) list) (db : mredinfo Msym.t) =
     let nbase = odfl dname base in
     let base = Msym.find_def Mrd.empty nbase db in
     Msym.add nbase (add_rules rules base) db
 
   let add ?(import = true) ({ red_base; red_rules } : reduction_rule) (env : env) =
-    let rstrip = List.map (fun (x, _, y) -> (x, y)) red_rules in
+    let rstrip =
+      List.concat_map (fun (x, _, rules) ->
+        List.map (fun rule -> (x, rule)) rules) red_rules in
 
     { env with
         env_redbase = updatedb ?base:red_base rstrip env.env_redbase;
         env_item = mkitem ~import (Th_reduction { red_base; red_rules }) :: env.env_item; }
 
-  let add1 ?base (prule : path * rule_option * rule option) (env : env) =
+  let add1 ?base (prule : path * rule_option * rule list) (env : env) =
     add { red_base = base; red_rules = [prule] } env
 
   let get_entries ?base (p : topsym) (env : env) =
@@ -3592,7 +3592,9 @@ module Theory = struct
   let bind_rd_th =
     let for1 _path db = function
       | Th_reduction { red_base; red_rules } ->
-         let rules = List.map (fun (x, _, y) -> (x, y)) red_rules in
+         let rules =
+           List.concat_map (fun (x, _, rules) ->
+             List.map (fun rule -> (x, rule)) rules) red_rules in
          Some (Reduction.updatedb ?base:red_base rules db)
       | _ -> None
 

--- a/src/ecEnv.mli
+++ b/src/ecEnv.mli
@@ -448,7 +448,7 @@ module Reduction : sig
   (* Name of the default database (the empty name). *)
   val dname : symbol
   val all : env -> (base * (topsym * rule list) list) list
-  val add1 : ?base:symbol -> path * rule_option * rule option -> env -> env
+  val add1 : ?base:symbol -> path * rule_option * rule list -> env -> env
   val add  : ?import:bool -> reduction_rule -> env -> env
   val get  : ?base:symbol -> topsym -> env -> rule list
   val get_entries : ?base:symbol -> topsym -> env -> entry list

--- a/src/ecHiGoal.ml
+++ b/src/ecHiGoal.ml
@@ -112,8 +112,9 @@ let process_local_hint (hint : plocalhint) (tc : tcenv1) =
         let simpl =
           List.fold_left (fun simpl lemma ->
             let path = EcEnv.Ax.lookup_path (unloc lemma) env in
-            let rule = EcReduction.User.compile ~opts ~prio:0 env path in
-            EcEnv.SimplifyContext.add_rules [(path, rule)] simpl)
+            let rules = EcReduction.User.compile ~opts ~prio:0 env path in
+            EcEnv.SimplifyContext.add_rules
+              (List.map (fun rule -> (path, rule)) rules) simpl)
             simpl h.ph_lemmas
         in
 
@@ -198,8 +199,9 @@ let process_simplify_info ri (tc : tcenv1) =
     let opts = EcTheory.{ ur_delta = false; ur_eqtrue = false; } in
     List.fold_left (fun simpl lemma ->
       let path = EcEnv.Ax.lookup_path (unloc lemma) env in
-      let rule = EcReduction.User.compile ~opts ~prio:0 env path in
-      EcEnv.SimplifyContext.add_rules [(path, rule)] simpl
+      let rules = EcReduction.User.compile ~opts ~prio:0 env path in
+      EcEnv.SimplifyContext.add_rules
+        (List.map (fun rule -> (path, rule)) rules) simpl
     ) simpl hint.ph_lemmas
   in
 

--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -1794,7 +1794,16 @@ module User = struct
   let empty_cst : compile_st =
     { cst_ty_vs = Sid.empty; cst_f_vs = Sid.empty; }
 
-  let compile ~opts ~prio (env : EcEnv.env) p =
+  (* One rewrite rule to be compiled: a conjunct of the axiom body, with
+     the binders & conditions it inherits from its ancestors. *)
+  type leaf = {
+    lf_bds   : (EcIdent.t * ty) list;
+    lf_conds : form list;
+    lf_lhs   : form;
+    lf_rhs   : form;
+  }
+
+  let compile ~opts ~prio (env : EcEnv.env) p : rule list =
     let simp =
       if opts.EcTheory.ur_delta then
         let hyps = EcEnv.LDecl.init env [] in
@@ -1802,105 +1811,139 @@ module User = struct
       else fun f -> f in
 
     let ax = EcEnv.Ax.by_path p env in
-    let bds, rl = EcFol.decompose_forall (simp ax.ax_spec) in
 
-    let bds =
+    let tybds (bds : bindings) : (EcIdent.t * ty) list =
       let filter = function
         | (x, GTty ty) -> (x, ty)
         | _ -> raise (InvalidUserRule RuleDependsOnMemOrModule)
       in List.map filter bds in
 
-    let lhs, rhs, conds =
-      try
-        let rec doit conds f =
-          match sform_of_form (simp f) with
-          | SFimp (f1, f2) -> doit (f1 :: conds) f2
-          | SFiff (f1, f2)
-          | SFeq  (f1, f2) -> (f1, f2, List.rev conds)
-          | _ when ty_equal tbool (EcEnv.ty_hnorm f.f_ty env) ->
-            (f, f_true, List.rev conds)
-          | _ -> raise (InvalidUserRule NotAnEq)
-        in doit [] rl
+    let mkleaf bds conds lhs rhs : leaf =
+      (* A binder that the conjunct does not mention cannot be inferred by
+         matching, and needs not be: it is irrelevant to this rule. *)
+      let bds =
+        let occurs (x, _) =
+          List.exists
+            (fun f -> Mid.mem x (f_fv f))
+            (lhs :: rhs :: conds)
+        in List.filter occurs bds
 
-      with InvalidUserRule NotAnEq
-        when opts.EcTheory.ur_eqtrue &&
-             ty_equal tbool (EcEnv.ty_hnorm rl.f_ty env)
-        -> (rl, f_true, List.rev [])
+      in { lf_bds = bds; lf_conds = conds; lf_lhs = lhs; lf_rhs = rhs; } in
+
+    let bds, rl = EcFol.decompose_forall (simp ax.ax_spec) in
+    let bds = tybds bds in
+
+    let leaves =
+      let rec split bds conds (f : form) : leaf list =
+        let f = simp f in
+
+        match sform_of_form f with
+        | SFquant (Lforall, _, _) ->
+            let xs, f = EcFol.decompose_forall f in
+            split (bds @ tybds xs) conds f
+
+        | SFimp (c, f) ->
+            split bds (c :: conds) f
+
+        | SFand (_, (f1, f2)) ->
+            split bds conds f1 @ split bds conds f2
+
+        | SFiff (f1, f2)
+        | SFeq  (f1, f2) ->
+            [mkleaf bds (List.rev conds) f1 f2]
+
+        | _ when ty_equal tbool (EcEnv.ty_hnorm f.f_ty env) ->
+            [mkleaf bds (List.rev conds) f f_true]
+
+        | _ -> raise (InvalidUserRule NotAnEq)
+
+      in
+        try split bds [] rl
+        with InvalidUserRule NotAnEq
+          when opts.EcTheory.ur_eqtrue &&
+               ty_equal tbool (EcEnv.ty_hnorm rl.f_ty env)
+          -> [mkleaf bds [] rl f_true]
     in
 
-    let rule =
-      let rec rule (f : form) : EcTheory.rule_pattern =
-        match EcFol.destr_app f with
-        | { f_node = Fop (p, tys) }, args ->
-            R.Rule (`Op (p, tys), List.map rule args)
-        | { f_node = Ftuple args }, [] ->
-            R.Rule (`Tuple, List.map rule args)
-        | { f_node = Fproj (target, i) }, [] ->
-            R.Rule (`Proj i, [rule target])
-        | { f_node = Fint i }, [] ->
-            R.Int i
-        | { f_node = Flocal x }, [] ->
-            R.Var x
-        | _ -> raise (InvalidUserRule NotFirstOrder)
+    let compile1 (leaf : leaf) : rule =
+      let { lf_bds = bds; lf_conds = conds; lf_lhs = lhs; lf_rhs = rhs; } =
+        leaf in
 
-      in rule lhs in
+      let rule =
+        let rec rule (f : form) : EcTheory.rule_pattern =
+          match EcFol.destr_app f with
+          | { f_node = Fop (p, tys) }, args ->
+              R.Rule (`Op (p, tys), List.map rule args)
+          | { f_node = Ftuple args }, [] ->
+              R.Rule (`Tuple, List.map rule args)
+          | { f_node = Fproj (target, i) }, [] ->
+              R.Rule (`Proj i, [rule target])
+          | { f_node = Fint i }, [] ->
+              R.Int i
+          | { f_node = Flocal x }, [] ->
+              R.Var x
+          | _ -> raise (InvalidUserRule NotFirstOrder)
 
-    let cst =
-      let rec doit cst = function
-        | R.Var x ->
-          { cst with cst_f_vs = Sid.add x cst.cst_f_vs }
+        in rule lhs in
 
-        | R.Int _ -> cst
+      let cst =
+        let rec doit cst = function
+          | R.Var x ->
+            { cst with cst_f_vs = Sid.add x cst.cst_f_vs }
 
-        | R.Rule (op, args) ->
-            let ltyvars =
-              match op with
-              | `Op (_, tys) ->
-                List.fold_left (
-                    let rec doit ltyvars = function
-                      | { ty_node = Tvar a } -> Sid.add a ltyvars
-                      | _ as ty -> ty_fold doit ltyvars ty in doit)
-                  cst.cst_ty_vs tys
-              | `Tuple -> cst.cst_ty_vs
-              | `Proj _ -> cst.cst_ty_vs in
-            let cst = {cst with cst_ty_vs = ltyvars } in
-            List.fold_left doit cst args
+          | R.Int _ -> cst
 
-      in doit empty_cst rule in
+          | R.Rule (op, args) ->
+              let ltyvars =
+                match op with
+                | `Op (_, tys) ->
+                  List.fold_left (
+                      let rec doit ltyvars = function
+                        | { ty_node = Tvar a } -> Sid.add a ltyvars
+                        | _ as ty -> ty_fold doit ltyvars ty in doit)
+                    cst.cst_ty_vs tys
+                | `Tuple -> cst.cst_ty_vs
+                | `Proj _ -> cst.cst_ty_vs in
+              let cst = {cst with cst_ty_vs = ltyvars } in
+              List.fold_left doit cst args
 
-    let s_bds   = Sid.of_list (List.map fst bds)
-    and s_tybds = Sid.of_list ax.ax_tparams in
+        in doit empty_cst rule in
 
-    (* Variables appearing in types and formulas are always, respectively,
-     * type and formula variables.
-     *)
-    let lvars   = cst.cst_f_vs
-    and ltyvars = cst.cst_ty_vs in
+      let s_bds   = Sid.of_list (List.map fst bds)
+      and s_tybds = Sid.of_list ax.ax_tparams in
 
-    (* Sanity check *)
-    assert (Sid.disjoint lvars   ltyvars);
+      (* Variables appearing in types and formulas are always, respectively,
+       * type and formula variables.
+       *)
+      let lvars   = cst.cst_f_vs
+      and ltyvars = cst.cst_ty_vs in
 
-    (* We check that the binded variables all appear in the lhs.
-       This ensures that, when applying the rule, we can infer how to
-       instantiate the axiom by matching with the lhs. *)
-    let mvars   = Sid.diff s_bds lvars in
-    let mtyvars = Sid.diff s_tybds ltyvars in
+      (* Sanity check *)
+      assert (Sid.disjoint lvars   ltyvars);
 
-    if not (Sid.is_empty mvars) then
-      raise (InvalidUserRule (MissingVarInLhs (Sid.choose mvars)));
-    if not (Sid.is_empty mtyvars) then
-      raise (InvalidUserRule (MissingTyVarInLhs (Sid.choose mtyvars)));
+      (* We check that the binded variables all appear in the lhs.
+         This ensures that, when applying the rule, we can infer how to
+         instantiate the axiom by matching with the lhs. *)
+      let mvars   = Sid.diff s_bds lvars in
+      let mtyvars = Sid.diff s_tybds ltyvars in
 
-    begin match rule with
-    | R.Var _ -> raise (InvalidUserRule (HeadedByVar));
-    | _       -> () end;
+      if not (Sid.is_empty mvars) then
+        raise (InvalidUserRule (MissingVarInLhs (Sid.choose mvars)));
+      if not (Sid.is_empty mtyvars) then
+        raise (InvalidUserRule (MissingTyVarInLhs (Sid.choose mtyvars)));
 
-    R.{ rl_tyd   = ax.ax_tparams;
-        rl_vars  = bds;
-        rl_cond  = conds;
-        rl_ptn   = rule;
-        rl_tg    = rhs;
-        rl_prio  = prio; }
+      begin match rule with
+      | R.Var _ -> raise (InvalidUserRule (HeadedByVar));
+      | _       -> () end;
+
+      R.{ rl_tyd   = ax.ax_tparams;
+          rl_vars  = bds;
+          rl_cond  = conds;
+          rl_ptn   = rule;
+          rl_tg    = rhs;
+          rl_prio  = prio; }
+
+    in List.map compile1 leaves
 
 end
 

--- a/src/ecReduction.mli
+++ b/src/ecReduction.mli
@@ -53,7 +53,7 @@ module User : sig
 
   type rule = EcEnv.Reduction.rule
 
-  val compile : opts:options -> prio:int -> EcEnv.env -> EcPath.path -> rule
+  val compile : opts:options -> prio:int -> EcEnv.env -> EcPath.path -> rule list
 end
 
 (* -------------------------------------------------------------------- *)

--- a/src/ecScope.ml
+++ b/src/ecScope.ml
@@ -2106,7 +2106,7 @@ module Reduction = struct
 
         let red_info =
           EcReduction.User.compile ~opts ~prio:idx (env scope) ax_p in
-        (ax_p, opts, Some red_info) in
+        (ax_p, opts, red_info) in
 
       let rules = List.map (fun (xs, idx) -> List.map (for1 idx) xs) reds in
       List.flatten rules

--- a/src/ecSubst.ml
+++ b/src/ecSubst.ml
@@ -1268,7 +1268,7 @@ let rec subst_theory_item_r (s : subst) (item : theory_item_r) =
 
   | Th_reduction ({ red_rules } as red) ->
       let red_rules =
-        List.map (fun (p, opts, _) -> (subst_path s p, opts, None)) red_rules
+        List.map (fun (p, opts, _) -> (subst_path s p, opts, [])) red_rules
       in Th_reduction { red with red_rules }
 
   | Th_auto ({ axioms } as auto_rl) ->

--- a/src/ecTheory.ml
+++ b/src/ecTheory.ml
@@ -72,7 +72,7 @@ and rule_option = {
 
 and reduction_rule = {
   red_base : symbol option;
-  red_rules : (path * rule_option * rule option) list;
+  red_rules : (path * rule_option * rule list) list;
 }
 
 and auto_rule = {

--- a/src/ecTheory.mli
+++ b/src/ecTheory.mli
@@ -69,7 +69,7 @@ and rule_option = {
 
 and reduction_rule = {
   red_base : symbol option;
-  red_rules : (path * rule_option * rule option) list;
+  red_rules : (path * rule_option * rule list) list;
 }
 
 and auto_rule = {

--- a/src/ecTheoryReplay.ml
+++ b/src/ecTheoryReplay.ml
@@ -1072,22 +1072,24 @@ and replay_reduction
   (ove : _ ovrenv) (subst, ops, proofs, scope)
   (import, ({ red_rules } as red) : _ * EcTheory.reduction_rule)
 =
-  let for1 (p, opts, rule) =
+  let for1 (p, opts, rules) =
     let exception Removed in
 
     let p = EcSubst.subst_path subst p in
 
-    let rule =
-      obind (fun rule ->
+    let rules =
+      match rules with
+      | [] -> []
+      | rule :: _ ->
         let env = EcSection.env (ove.ovre_hooks.henv scope) in
 
         try
           if not (is_some (EcEnv.Ax.by_path_opt p env)) then
             raise Removed;
-          Some (EcReduction.User.compile ~opts ~prio:rule.rl_prio env p)
-        with EcReduction.User.InvalidUserRule _ | Removed -> None) rule
+          EcReduction.User.compile ~opts ~prio:rule.rl_prio env p
+        with EcReduction.User.InvalidUserRule _ | Removed -> []
 
-    in (p, opts, rule) in
+    in (p, opts, rules) in
 
   let red_rules = List.map for1 red_rules in
   let scope = ove.ovre_hooks.hadd_item scope ~import (Th_reduction { red with red_rules }) in

--- a/tests/hint_simplify_conj.ec
+++ b/tests/hint_simplify_conj.ec
@@ -1,0 +1,132 @@
+require import Int.
+
+(* Abstract operators (no body): a goal below closes only if [simplify]
+   actually fires the rule compiled from the corresponding hint. *)
+
+(* --- A conjunction registers one rule per conjunct ------------------- *)
+
+op g : int -> int.
+
+axiom gE :
+  g 0 = 4 /\ g 1 = 6 /\ g 2 = 2 /\ g 3 = 6 /\
+  g 4 = 4 /\ g 5 = 2 /\ g 6 = 4 /\ g 7 = 2.
+
+hint simplify gE.
+
+lemma g_head : g 0 = 4.
+proof. simplify. done. qed.
+
+lemma g_middle : g 3 = 6.
+proof. simplify. done. qed.
+
+lemma g_last : g 7 = 2.
+proof. simplify. done. qed.
+
+lemma g_all :
+  g 0 = 4 /\ g 1 = 6 /\ g 2 = 2 /\ g 3 = 6 /\
+  g 4 = 4 /\ g 5 = 2 /\ g 6 = 4 /\ g 7 = 2.
+proof. simplify. done. qed.
+
+(* --- Conditions distribute over the conjuncts below them ------------- *)
+
+op h : int -> int.
+
+axiom hE (x : int) : (0 < x => h x = x + 1) /\ h 0 = 7.
+
+hint simplify hE.
+
+lemma h_guarded : h 3 = 4.
+proof. simplify. done. qed.
+
+(* The guarded rule must not fire when its condition does not hold. *)
+lemma h_guard_blocks : h (-1) = 0.
+proof. fail (simplify; done). abort.
+
+(* The unguarded conjunct does not mention [x]; the binder is dropped. *)
+lemma h_ground : h 0 = 7.
+proof. simplify. done. qed.
+
+(* --- A conjunct may carry its own quantifier ------------------------- *)
+
+op p : int -> int.
+op q : int -> int.
+
+axiom pqE : (forall (x : int), p x = x + 1) /\ (forall (y : int), q y = y + 2).
+
+hint simplify pqE.
+
+lemma pq_both (n : int) : p n = n + 1 /\ q n = n + 2.
+proof. simplify. done. qed.
+
+(* --- A shared binder unused by one conjunct -------------------------- *)
+
+op r : int -> int.
+op s : int -> int.
+
+axiom rsE (x y : int) : r x = x + 3 /\ s y = y + 4.
+
+hint simplify rsE.
+
+lemma rs_both (n : int) : r n = n + 3 /\ s n = n + 4.
+proof. simplify. done. qed.
+
+(* --- The single-equation form is unaffected -------------------------- *)
+
+op u : int -> int.
+
+axiom uE (x : int) : u x = x + 5.
+
+hint simplify uE.
+
+lemma u_simplifies (n : int) : u n = n + 5.
+proof. simplify. done. qed.
+
+(* --- The [eqtrue] option still registers ----------------------------- *)
+
+op t : int -> bool.
+
+axiom tE (x : int) : t x.
+
+hint simplify [eqtrue] tE.
+
+lemma t_simplifies (n : int) : t n.
+proof. simplify. done. qed.
+
+(* --- An explicit priority applies to every conjunct ------------------ *)
+
+op v : int -> int.
+
+axiom vE : v 0 = 1 /\ v 1 = 2.
+
+hint simplify vE @10.
+
+lemma v_both : v 0 = 1 /\ v 1 = 2.
+proof. simplify. done. qed.
+
+(* --- Cloning replays the conjunction hint ---------------------------- *)
+
+abstract theory T.
+  op w : int -> int.
+
+  axiom wE : w 0 = 1 /\ w 1 = 2 /\ w 2 = 3.
+
+  hint simplify wE.
+end T.
+
+clone import T as T1.
+
+lemma clone_all : T1.w 0 = 1 /\ T1.w 1 = 2 /\ T1.w 2 = 3.
+proof. simplify. done. qed.
+
+(* --- Per-call addition of a conjunction lemma ------------------------ *)
+
+op z : int -> int.
+
+axiom zE : z 0 = 1 /\ z 1 = 2 /\ z 2 = 3.
+
+lemma z_local : z 0 = 1 /\ z 1 = 2 /\ z 2 = 3.
+proof.
+  fail (simplify; done).
+  simplify hint {zE}.
+  done.
+qed.


### PR DESCRIPTION
A lemma whose body is a conjunction of rewrite rules used to compile to
a single eq-true rule whose pattern was the whole conjunction, rooted at
`(/\)`. It registered without error and never fired: the only way to
feed the simplifier a family of equations was one lemma and one hint
line per equation.

`EcReduction.User.compile` now splits the body recursively and returns
a rule list. Implications distribute their condition over every rule
beneath them, conjunctions contribute both sides, and a conjunct may
carry its own `forall`. Each rule keeps only the binders occurring in
its conjunct, so a shared outer binder that one conjunct does not
mention no longer trips the missing-variable check. The `Th_reduction`
entry carries a rule list per lemma (empty meaning "not compiled"), so
printing and cloning replay keep working per lemma name.

