### PR TITLE
fix(clone): compare oracle-call restrictions when overriding a module type

### DIFF
--- a/src/ecReduction.ml
+++ b/src/ecReduction.ml
@@ -292,6 +292,16 @@ end) = struct
     List.for_all2 (for_module_sig_body_item env) b1 b2
 
   (* ------------------------------------------------------------------ *)
+  (* Allowed oracle calls are compared as sets, per procedure. *)
+  and for_oracle_infos env ~norm ois1 ois2 =
+    let allowed oi =
+      let calls = OI.allowed oi in
+      let calls = if norm then List.map (NormMp.norm_xfun env) calls else calls in
+      Sx.of_list calls in
+    EcSymbols.Msym.equal
+      (fun oi1 oi2 -> Sx.equal (allowed oi1) (allowed oi2)) ois1 ois2
+
+  (* ------------------------------------------------------------------ *)
   and for_module_sig env ~norm ms1 ms2 =
     let p1 = ms1.mis_params in
     let p2 = ms2.mis_params in
@@ -300,7 +310,10 @@ end) = struct
     let env, s = add_modules env p2 p1 in
     let body1 = ms1.mis_body in
     let body2 = EcSubst.subst_modsig_body s ms2.mis_body in
-    for_module_sig_body env body1 body2
+    for_module_sig_body env body1 body2 &&
+    let ois1 = ms1.mis_oinfos in
+    let ois2 = EcSubst.subst_oracle_infos s ms2.mis_oinfos in
+    for_oracle_infos env ~norm ois1 ois2
 
   (* ------------------------------------------------------------------ *)
   let for_variable env v1 v2 =

--- a/tests/clone-modtype-oinfos.ec
+++ b/tests/clone-modtype-oinfos.ec
@@ -1,0 +1,30 @@
+(* Regression for #1123: `clone ... with module type X <- Y` must compare the
+   oracle-call restrictions of X and Y, not only procedure names and types.
+   Lemmas proved for `A <: X` are replayed verbatim for `A <: Y`, so the
+   allowed-call sets must coincide exactly (as sets, order-insensitively). *)
+require import AllCore.
+
+theory T.
+  module type ORCL = { proc g() : unit  proc h() : unit  proc k() : unit }.
+  module type ADV (O : ORCL) = { proc f() : unit {O.g, O.h} }.
+  module type GAME (A : ADV) = { proc main() : bool }.
+end T.
+
+module type ADV_looser  (O : T.ORCL) = { proc f() : unit {O.g, O.h, O.k} }.
+module type ADV_tighter (O : T.ORCL) = { proc f() : unit {O.g} }.
+module type ADV_reorder (O : T.ORCL) = { proc f() : unit {O.h, O.g} }.
+
+fail clone T as U1 with module type ADV <- ADV_looser.
+fail clone T as U2 with module type ADV <- ADV_tighter.
+fail clone T as U3 with module type ADV =  ADV_looser.
+fail clone T as U4 with module type ADV <= ADV_tighter.
+
+clone T as U5 with module type ADV <- ADV_reorder.
+
+(* The oracle sets of functor parameters' signatures are compared too. *)
+module type GAME_looser  (A : ADV_looser)  = { proc main() : bool }.
+module type GAME_reorder (A : ADV_reorder) = { proc main() : bool }.
+
+fail clone T as U6 with module type GAME <- GAME_looser.
+
+clone T as U7 with module type GAME <- GAME_reorder.


### PR DESCRIPTION
## Summary

`clone ... with module type X <- Y` (likewise `=` and `<=`) accepted `Y` whenever its parameters and procedure names/types matched those of `X`; the allowed-oracle-call sets (`proc f() : t {O.g}`) were never compared. Lemmas proved for `A <: X` are replayed verbatim for `A <: Y`, so with a looser `Y` they can be instantiated with adversaries the original proof never accounted for, which yields `false` (see the MRE in the issue).

Fixes #1123

## Root cause

`src/ecTheoryReplay.ml`, `replay_modtype`, decides the override with `EcReduction.EqTest.for_msig`. Its implementation, `for_module_sig` in `src/ecReduction.ml`, compares `mis_params` and `mis_body` only and ignores `mis_oinfos`, in both `Alias` and `Inline` modes. The typing-side check `EcTyping.check_item_compatible` (mode `` `Eq ``) does compare the sets, but the clone path bypasses it.

## Fix

`for_module_sig` now additionally requires, per procedure, equality of the allowed-call sets: the parameter renaming already applied to the body is applied to the oracle infos, the paths are normalised with `NormMp.norm_xfun` when `~norm` is set, and the lists are compared as `Sx` sets, so the order in which the oracles are written is irrelevant.

Since `for_module_type` falls back to `for_module_sig` for parameters whose type names differ, the signatures of functor parameters are covered as well. `for_msig` has no other caller; `for_mexpr` (module overrides in `clone`) inherits the stricter comparison of its parameters, where it is equally required.

Exact equality is required in both directions, as in `check_item_compatible`. A looser `Y` is unsound as explained above. A tighter `Y` is unsound too: module-type binders also occur negatively, in lemma hypotheses `(forall (A <: X), ...) => ...`, and the replayed proofs (which are not re-checked) may instantiate an `X`-lemma or axiom at a module such as `Wrap(B)` that inhabits `X` but not `Y`.

## Impact

Only `clone` overrides of module types (and, through the parameter comparison, of modules) whose oracle-call sets differ are affected; they are now rejected with the existing `module type X is incompatible` error. No `clone` in `theories/` or `examples/` overrides a module type or a module at all (the only such override is in `tests/clone-module-stateless.ec`, with equal oracle sets), so no existing development relied on the lax check; `make unit` and `make stdlib` pass, and `make examples` shows only the pre-existing `ChaChaPoly/chacha_poly.ec` prover-timeout failure that occurs identically on unpatched `main`.

## Test

`tests/clone-modtype-oinfos.ec`: overrides that loosen or tighten the oracle set (via `<-`, `=` and `<=`) must fail, a mismatch inside a functor parameter's signature must fail, and the same set written in a different order must be accepted. The file fails on unpatched `main` (every `fail clone` is accepted there) and passes with this patch. The issue's MRE is now rejected at the `clone` line.
