### PR TITLE
fix(phl): `swap` with a code path must rebuild the enclosing program

### DIFF
--- a/doc/tactics/swap.rst
+++ b/doc/tactics/swap.rst
@@ -37,7 +37,18 @@ Here:
   right program in relational goals. If omitted, the tactic applies to the
   single program under consideration.
 
-- `{codepos1}` denotes a *top-level code position*.
+- `{codepos1}` denotes a code position in the program.
+
+- Any `{codepos1}` or block `[{codepos1}..{codepos1}]` may be prefixed with a
+  *code path*, selecting a nested block in which the swap takes place. Each
+  step of the path is a code position followed by a branch selector: `.`
+  for the then-branch of a conditional or the body of a loop, `?` for the
+  else-branch of a conditional, and `#C.` for the arm of a `match` labelled
+  by the constructor `C`. A single position directly follows the path,
+  while a block is separated from it by `:`. For instance, `2#Some.1`
+  designates the first command of the `Some` arm of the `match` at position
+  `2`, and `1.:[1..2]` the block formed by the first two commands of the
+  then-branch (or loop body) of the command at position `1`.
 
 - A `{codeoffset1}` is either:
 
@@ -63,6 +74,11 @@ The meaning of these forms is as follows:
 
 In all cases, the swap is only valid when the exchanged fragments are
 independent, so that the transformation preserves the program semantics.
+
+When a code path is given, positions and offsets are interpreted relative
+to the selected block, the destination must lie inside that block, and the
+enclosing command (conditional, loop or `match`) and its other branches are
+left unchanged.
 
 ------------------------------------------------------------------------
 Example (single statement)
@@ -134,6 +150,41 @@ commands with a later, independent command.
     swap [2..3] 1.
 
     (* The goal is the same, but with the program rewritten. *)
+    admit.
+  qed.
+
+------------------------------------------------------------------------
+Example (swapping inside a branch)
+------------------------------------------------------------------------
+
+The following example uses a code path to swap two commands located in the
+then-branch of a conditional. The conditional itself and its else-branch are
+preserved.
+
+.. ecproof::
+
+  require import AllCore.
+
+  module M = {
+    var x : bool
+    var y : int
+
+    proc branch(b : bool) : unit = {
+      if (b) { x <- true; y <- 2; } else { x <- false; y <- 6; }
+    }
+  }.
+
+  lemma branch_correct : hoare [ M.branch : !b ==> !M.x ].
+  proof.
+    proc.
+
+    (*$*)
+    (* Swap the first command of the then-branch of command 1 with the
+       following command of that branch. The program becomes
+       `if (b) { y <- 2; x <- true; } else { x <- false; y <- 6; }`. *)
+    swap 1.:[1..1] 1.
+
+    (* The conditional is still there. *)
     admit.
   qed.
 

--- a/src/ecMatching.ml
+++ b/src/ecMatching.ml
@@ -642,8 +642,7 @@ module Zipper = struct
    *) 
   let zipper_and_split_of_cgap_range (env: env) (path, (start, fin) : codegap_range) (s: stmt) : zipper * _ * nm_codegap_range =
     let (zpr, ((cpath, _), s)) = zipper_of_cgap_r env (path, start) s in
-    let start = normalize_cgap1 env start s in
-    let fin = normalize_cgap1 env fin s in
+    let (start, fin) = normalize_cgap1_range env (start, fin) s in
     let ss = split_by_nmcgap_range (start, fin) s in
     (zpr, ss, (cpath, (start, fin)))
 

--- a/src/phl/ecPhlOutline.ml
+++ b/src/phl/ecPhlOutline.ml
@@ -73,6 +73,8 @@ let process_outline info tc =
       let mode = if alias then `Alias else `Exact in
       t_outline side range (OV_Proc (mode, f)) tc
   with
+  | EcMatching.Position.InvalidCPos ->
+     tc_error !!tc "Outline: invalid code position"
   | UnificationError (UE_UnificationFailArg x) ->
      tc_error !!tc "Outline: unable to unify arg `%s`." x
   | UnificationError (UE_UnificationFailPv x) ->

--- a/src/phl/ecPhlRewrite.ml
+++ b/src/phl/ecPhlRewrite.ml
@@ -312,7 +312,11 @@ let t_change_stmt
   let mt = odfl metc mt in
 
   let zpr, (_,stmt, epilog), _nmr =
-    EcMatching.Zipper.zipper_and_split_of_cgap_range env pos stmt in
+    try
+      EcMatching.Zipper.zipper_and_split_of_cgap_range env pos stmt
+    with EcMatching.Position.InvalidCPos ->
+      tc_error !!tc "invalid code position"
+  in
 
   (* Collect the variables that may be modified by the surrounding context,
      excluding the fragment being replaced. *)

--- a/src/phl/ecPhlSwap.ml
+++ b/src/phl/ecPhlSwap.ml
@@ -69,15 +69,17 @@ module LowInternal = struct
     (info : swap_kind  )
     (s    : stmt       )
   =
-    let (env, s), (_, (start, fin)) = try 
-      let (cpath, (start, fin)) = info.interval in
-      normalize_cgap_range env (cpath, (start, fin)) s 
+    let zpr, _, (_, (start, fin)) = try
+      EcMatching.Zipper.zipper_and_split_of_cgap_range env info.interval s
     with InvalidCPos ->
       tc_error_lazy pf (fun fmt ->
         let ppe = EcPrinting.PPEnv.ofenv env in
         Format.fprintf fmt "invalid range: %a" (EcPrinting.pp_codegap_range ppe) info.interval
       )
     in
+
+    let env = odfl env zpr.z_env in
+    let s = stmt (List.rev_append zpr.z_head zpr.z_tail) in
 
     let target = try
       resolve_gap_offset env (start, fin) info.offset s
@@ -92,7 +94,8 @@ module LowInternal = struct
       ) s
     with 
     | [hd; s1; s2; tl] -> check_swap pf env (stmt s1) (stmt s2);
-      stmt (List.flatten [hd; s2; s1; tl])
+      EcMatching.Zipper.zip
+        { zpr with z_head = []; z_tail = List.flatten [hd; s2; s1; tl] }
     | _ -> assert false
 end
 

--- a/tests/swap-codepath-context.ec
+++ b/tests/swap-codepath-context.ec
@@ -1,0 +1,63 @@
+(* `swap` with a code path (`1.:[1 .. 1]`: then-branch of instruction 1,
+   `1?:[1 .. 1]`: else-branch, `2.:[1 .. 1]`: body of the loop at 2) must
+   keep the enclosing `if`/`while` and the sibling branch. It used to
+   replace the whole program by the addressed block, so the false goals
+   below (e.g. `M.f(false)` sets `M.x` to 5) were closed by `auto`/`sim`. *)
+require import AllCore.
+
+module M = {
+  var x, y : int
+  proc f(b : bool) : unit = {
+    if (b) { x <- 1; y <- 2; } else { x <- 5; y <- 6; }
+  }
+  proc w() : unit = {
+    x <- 0;
+    while (false) { x <- 1; y <- 2; }
+  }
+  proc g() : unit = { y <- 2; x <- 1; }
+}.
+
+lemma then_branch : hoare [M.f : true ==> M.x = 1].
+proof.
+proc.
+fail (swap 1.:[1 .. 1] 1; auto; done).
+abort.
+
+lemma else_branch : hoare [M.f : true ==> M.x = 5].
+proof.
+proc.
+fail (swap 1?:[1 .. 1] 1; auto; done).
+abort.
+
+lemma while_body : hoare [M.w : true ==> M.x = 1].
+proof.
+proc.
+fail (swap 2.:[1 .. 1] 1; auto; done).
+abort.
+
+lemma equiv_side : equiv [M.f ~ M.g : true ==> ={M.x, M.y}].
+proof.
+proc.
+fail (swap{1} 1.:[1 .. 1] 1; by sim).
+abort.
+
+(* a reversed range is rejected, with or without a path (it used to be
+   accepted as a no-op) *)
+lemma reversed_range : hoare [M.f : true ==> true].
+proof.
+proc.
+fail (swap 1.:[3 .. 1] 1).
+fail (swap 1?:[3 .. 1] -1).
+abort.
+
+(* sanity: a top-level swap still works *)
+lemma toplevel : hoare [M.g : true ==> M.x = 1 /\ M.y = 2].
+proof. proc. fail (swap [3 .. 1] 1). fail (swap [3 .. 1] -1). swap 1 1. auto. qed.
+
+(* the destination must stay inside the addressed block *)
+lemma escape : hoare [M.f : true ==> true].
+proof.
+proc.
+fail (swap 1.:[1 .. 1] 2).
+fail (swap 1?:[2 .. 2] -2).
+abort.

--- a/tests/swap-codepath.ec
+++ b/tests/swap-codepath.ec
@@ -1,0 +1,69 @@
+(* `swap` with a code path swaps inside the addressed block only; the
+   enclosing `if`/`while` and the sibling branch stay in the goal, so the
+   untouched branch is what makes the postconditions below hold. *)
+require import AllCore.
+
+module M = {
+  var x, y : int
+  proc f(b : bool) : unit = {
+    if (b) { x <- 1; y <- 2; } else { x <- 5; y <- 6; }
+  }
+  proc w(b : bool) : unit = {
+    x <- 0; y <- 0;
+    while (b) { x <- 1; y <- 2; }
+  }
+}.
+
+module N = {
+  proc f(b : bool) : unit = {
+    if (b) { M.y <- 2; M.x <- 1; } else { M.y <- 6; M.x <- 5; }
+  }
+  proc w(b : bool) : unit = {
+    M.x <- 0; M.y <- 0;
+    while (b) { M.y <- 2; M.x <- 1; }
+  }
+}.
+
+lemma then_branch : hoare [M.f : !b ==> M.x = 5 /\ M.y = 6].
+proof. proc. swap 1.:[1 .. 1] 1. auto. qed.
+
+lemma else_branch : hoare [M.f : b ==> M.x = 1 /\ M.y = 2].
+proof. proc. swap 1?:[1 .. 1] 1. auto. qed.
+
+lemma while_body : hoare [M.w : !b ==> M.x = 0 /\ M.y = 0].
+proof. proc. swap 3.:[1 .. 1] 1. rcondf 3; auto. qed.
+
+lemma then_branch_ph : phoare [M.f : !b ==> M.x = 5 /\ M.y = 6] = 1%r.
+proof. proc. swap 1.:[1 .. 1] 1. auto. qed.
+
+lemma equiv_if : equiv [M.f ~ N.f : ={b} ==> ={M.x, M.y}].
+proof. proc. swap{1} 1.:[1 .. 1] 1. swap{1} 1?:[1 .. 1] 1. sim. qed.
+
+lemma equiv_while : equiv [M.w ~ N.w : ={b} ==> ={M.x, M.y}].
+proof. proc. swap{1} 3.:[1 .. 1] 1. sim. qed.
+
+(* match arm: the path binds the arm's locals *)
+module P = {
+  proc m(o : int option) : unit = {
+    match o with
+    | None   => { M.x <- 5; M.y <- 6; }
+    | Some v => { M.x <- v; M.y <- 2; }
+    end;
+  }
+}.
+
+module Q = {
+  proc m(o : int option) : unit = {
+    match o with
+    | None   => { M.x <- 5; M.y <- 6; }
+    | Some v => { M.y <- 2; M.x <- v; }
+    end;
+  }
+}.
+
+lemma match_arm : equiv [P.m ~ Q.m : ={o} ==> ={M.x, M.y}].
+proof. proc. swap{1} 1#Some.:[1 .. 1] 1. sim. qed.
+
+(* a single position under a path is written without `:` *)
+lemma bare_position : equiv [M.f ~ N.f : ={b} ==> ={M.x, M.y}].
+proof. proc. swap{1} 1.1 1. swap{1} 1?1 1. sim. qed.


### PR DESCRIPTION
## Summary

Since f0827a138, `swap` accepts a range prefixed by a code path (`1.:[1 .. 1]`: then-branch of instruction 1; `1?:`: else-branch; loop bodies). After swapping inside the addressed block it installed that inner block as the whole program of the goal: the enclosing `if`/`while` and every sibling branch disappeared, so false `hoare`/`phoare`/`equiv` judgments became provable (`auto`, `by sim`), including `lemma bad : false` via `byphoare`. This PR makes the path work as intended: the swap is performed inside the addressed block and the enclosing program is rebuilt.

Fixes #1122.

## Root cause

`src/phl/ecPhlSwap.ml`, `LowInternal.swap_stmt`. f0827a138 ("Extend code-position handling with gap/range semantics") changed `swap_kind.interval` to a `codegap_range`, which carries a path, and made `swap_stmt` follow it with `normalize_cgap_range`. That function returns the sub-statement reached by the path; the swap was performed on it and `stmt (hd @ s2 @ s1 @ tl)` of that sub-statement was returned, which `t_swap_r` installed with `hl_set_stmt` as the full program. The normalised path was discarded and nothing zipped the context back, whereas `proc change`/`proc rewrite` (`src/phl/ecPhlRewrite.ml`) open a zipper with `EcMatching.Zipper.zipper_and_split_of_cgap_range` and rebuild the program with `Zipper.zip`, and `outline` goes through `Zipper.map_range` (routing that dates from 3808ca8bd / 8debf2729).

## Fix

`swap_stmt` now opens a zipper at the addressed block with `EcMatching.Zipper.zipper_and_split_of_cgap_range` (as `proc change` and `proc rewrite` do), resolves the offset and performs the swap on the block rebuilt from `z_head`/`z_tail`, and returns `EcMatching.Zipper.zip` of the zipper with the swapped block as its tail. `check_swap` (raise / read-write independence) still runs on the two swapped fragments of the inner block. For a top-level range (empty path) the zipper is `ZTop`, so the behaviour there is unchanged.

`zipper_and_split_of_cgap_range` normalised `start` and `fin` separately and never checked `start <= fin`; a reversed range such as `[3 .. 1]` then split into an empty middle fragment and was silently accepted (`proc change [3 .. 1] : { }` and `proc rewrite [3 .. 1] /=` were no-ops on main, and `swap` would have inherited that). It now goes through `Position.normalize_cgap1_range`, which raises `InvalidCPos` on a reversed range, exactly as the old `normalize_cgap_range` path of `swap` did. `proc change` (`t_change_stmt`) and `outline` did not catch `InvalidCPos` from the primitive (an out-of-range position was already reported as an `anomaly` on main); they now report "invalid code position" / "Outline: invalid code position".

`doc/tactics/swap.rst` now says that a code position may carry a code path (branch, loop body, match arm).

## Impact

- `swap`, `swap{i}` with a path now yield the original program with the two fragments exchanged inside the addressed branch/loop body/match arm, in all program logics.
- Top-level `swap` and `interleave` (which builds an empty path) are unaffected.
- No change to the independence checks; they were already run on the inner fragments.
- A reversed range is rejected again by `swap` ("invalid range"), and is now also rejected by `proc change`, `proc rewrite`, `outline` and module updates (`M with { proc f [[3 .. 1] ~ ...] }`) with "invalid code position" (all callers of `zipper_and_split_of_cgap_range`); on main they silently did nothing to the program. An empty range (`[2 .. 1]`, i.e. the gap before 2 = the gap after 1) is still accepted, as before.
- `proc change`/`outline` with an out-of-range position now give "invalid code position" instead of an `anomaly: InvalidCPos`.
- A `swap` path into an instruction that is not an `if`/`while`/`match` (e.g. `swap 1.:[1 .. 1] 1` on an assignment) now gives "invalid range" instead of an `anomaly` (`Assertion failed src/ecMatching.ml:374`) on main.

## Test

- `tests/swap-codepath-context.ec` (regression test, `fail (...)`/`abort` idiom): after `swap 1.:[1 .. 1] 1`, `1?:`, a while-body path and `swap{1}` in an `equiv`, the bogus goals can no longer be closed by `auto`/`by sim`; reversed ranges `[3 .. 1]` are rejected at top level and behind a `1.:`/`1?:` path. Fails on unpatched main at the first `fail` ("this command is expected to fail"), passes with the fix.
- `tests/swap-codepath.ec` (positive): legitimate swaps of two independent assignments inside a then-branch, an else-branch, a while body, in a `phoare` goal and with `swap{1}` in `equiv` goals; the resulting goal is the whole program (closed by `auto` with a pre/post that only the untouched branch satisfies, and by `sim` against the pre-swapped program). Fails on unpatched main, passes with the fix.
- Issue MRE (`lemma fake`, `lemma bad : false`, and the else/while/equiv variants) is rejected with the fix.
- `tests/procchange.ec`, `tests/procrewrite.ec`, `tests/procrewrite-block.ec`, `tests/procrewrite-simpl.ec`, `tests/outline.ec` pass individually on the patched binary (none uses a reversed range).
- `dune build --profile=ci` clean; `make unit` 107/107. `make stdlib` and `make examples` were run: the only failures are `theories/crypto/assumptions/DHIES.ec:987` (prover timeout under load; passes standalone on both the patched and the unpatched binary) and `examples/ChaChaPoly/chacha_poly.ec:2525` (identical on unpatched main).
