### PR TITLE
Fixed `priority_of_binop` to handle PLUSn, MINUSn and STARn

### DIFF
--- a/src/ecPrinting.ml
+++ b/src/ecPrinting.ml
@@ -799,10 +799,13 @@ let priority_of_binop name =
   | Some EP.LOP1 _    -> Some e_bin_prio_lop1
   | Some EP.ROP1 _    -> Some e_bin_prio_rop1
   | Some EP.LOP2 _    -> Some e_bin_prio_lop2
+  | Some EP.PLUSn _   -> Some e_bin_prio_lop2
+  | Some EP.MINUSn _  -> Some e_bin_prio_lop2
   | Some EP.ROP2 _    -> Some e_bin_prio_rop2
   | Some EP.PLUS      -> Some e_bin_prio_lop2
   | Some EP.MINUS     -> Some e_bin_prio_lop2
   | Some EP.LOP3 _    -> Some e_bin_prio_lop3
+  | Some EP.STARn _   -> Some e_bin_prio_lop3
   | Some EP.ROP3 _    -> Some e_bin_prio_rop3
   | Some EP.STAR      -> Some e_bin_prio_lop3
   | Some EP.SLASH     -> Some e_bin_prio_lop3
@@ -2506,7 +2509,7 @@ let pp_codeoffset1 (ppe : PPEnv.t) (fmt : Format.formatter) (offset : CP.codeoff
   | `Absolute p -> Format.fprintf fmt "%a" (pp_codepos1 ppe) p
   | `Relative o -> Format.fprintf fmt "%d" o
 
-let pp_codepos_brsel (fmt: Format.formatter) (br: CP.codepos_brsel) = 
+let pp_codepos_brsel (fmt: Format.formatter) (br: CP.codepos_brsel) =
   Format.fprintf fmt "%s"
   (match br with
   | `Cond true -> "."
@@ -2514,7 +2517,7 @@ let pp_codepos_brsel (fmt: Format.formatter) (br: CP.codepos_brsel) =
   | `Match cp -> Format.sprintf "#%s." cp
   | `MatchByPos ix -> Format.sprintf "#%i" ix)
 
-let pp_codepos_step (ppe: PPEnv.t) (fmt: Format.formatter) ((cp, br): CP.codepos_step) = 
+let pp_codepos_step (ppe: PPEnv.t) (fmt: Format.formatter) ((cp, br): CP.codepos_step) =
   Format.fprintf fmt "%a%a" (pp_codepos1 ppe) cp pp_codepos_brsel br
 
 let pp_codepos_path ppe =
@@ -2533,16 +2536,16 @@ let pp_codegap1 (ppe : PPEnv.t) (fmt : Format.formatter) (g : CP.codegap1) =
 let pp_codegap (ppe : PPEnv.t) (fmt : Format.formatter) ((cpath, g1) : CP.codegap) =
   Format.fprintf fmt "%a%a" (pp_codepos_path ppe) cpath (pp_codegap1 ppe) g1
 
-let symbol_and_codepos1_of_codegap1_range_edge (cg: CP.codegap1) : symbol * CP.codepos1 = 
+let symbol_and_codepos1_of_codegap1_range_edge (cg: CP.codegap1) : symbol * CP.codepos1 =
   match cg with
   | GapBefore cp -> "[", cp
   | GapAfter cp  -> "]", cp
 
 (* -------------------------------------------------------------------- *)
 let pp_codegap1_range (ppe: PPEnv.t) (fmt: Format.formatter) ((start, fin) : CP.codegap1_range) =
-  let s, cps = symbol_and_codepos1_of_codegap1_range_edge start in 
-  let e, cpe = symbol_and_codepos1_of_codegap1_range_edge fin in 
-  Format.fprintf fmt "%s%a;%a%s" s (pp_codepos1 ppe) cps (pp_codepos1 ppe) cpe e 
+  let s, cps = symbol_and_codepos1_of_codegap1_range_edge start in
+  let e, cpe = symbol_and_codepos1_of_codegap1_range_edge fin in
+  Format.fprintf fmt "%s%a;%a%s" s (pp_codepos1 ppe) cps (pp_codepos1 ppe) cpe e
 
 (* FIXME: change when we can change the syntax *)
 let pp_codegap_range (ppe: PPEnv.t) (fmt: Format.formatter) ((cpath, cp1r) : CP.codegap_range) =


### PR DESCRIPTION
Fixed `priority_of_binop` to handle PLUSn, MINUSn and STARn,
as otherwise infix operators like ++, -- and ** do not pretty print properly.