### PR TITLE
[ci] make the documentation build immune to the git-maintenance race

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,12 +41,21 @@ jobs:
         run: |
           make -C doc sphinx-deps
 
+      # Since git 2.46, fetch/clone spawn a detached `git maintenance` job
+      # that races with opam scanning the freshly cloned repository
+      # (ocaml/opam#7031); disable it and fetch the repository as a tarball.
+      - name: Disable git background maintenance
+        run: |
+          git config --global maintenance.auto false
+          git config --global gc.auto 0
+
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.4
           opam-disable-sandboxing: true
-          dune-cache: true
+          opam-repositories: |
+            default: https://opam.ocaml.org
 
       - name: Install EasyCrypt dependencies
         run: |


### PR DESCRIPTION
`opam init` intermittently failed in the documentation workflow with

    Could not update repository "default": lstat failed on
    .git/objects/maintenance.lock: No such file or directory

Since git 2.46, fetch and clone spawn a detached

    git maintenance run --auto

job that races with opam scanning the repository it has just
cloned (ocaml/opam#7031). The opam-side fix (ocaml/opam#7073) only ships
in 2.6.0, still a release candidate, and does not cover the path pin on
the checkout.

Disable git background maintenance on the runner, and fetch the opam
repository over HTTP instead of git, which removes the clone the
maintenance job operates on. Also drop the deprecated `dune-cache`
input, superseded by `cache`.